### PR TITLE
fix(recent): move selected project to the top of recents

### DIFF
--- a/src/main/kotlin/com/codymikol/repositories/RecentProjectRepository.kt
+++ b/src/main/kotlin/com/codymikol/repositories/RecentProjectRepository.kt
@@ -41,9 +41,9 @@ class RecentProjectRepository(
         }
     }
 
-    fun addRecentProject(newProject: RecentProject) : Unit {
+    fun addRecentProject(newProject: RecentProject) {
         val currentRecentProjects = getRecentProjects()
-        val newProjects = (currentRecentProjects.projects + newProject).distinctBy { it.location }
+        val newProjects = listOf(newProject) + (currentRecentProjects.projects.filterNot { it.location == newProject.location })
         val newRecentProjects = RecentProjects(newProjects)
         setRecentProjects(newRecentProjects)
     }


### PR DESCRIPTION
now when you select any recent project, we will move it to the top of the recently selected list.

Fixes #50