### PR TITLE
feat(commit): don't squish stage / unstage file

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ repositories {
 
 dependencies {
     ksp("io.insert-koin:koin-ksp-compiler:$koinKspVersion")
+    implementation("com.github.git24j:git24j:1.0.0")
     implementation("io.insert-koin:koin-core:$koinVersion")
     implementation("io.insert-koin:koin-annotations:$koinKspVersion")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.14.0")

--- a/src/main/kotlin/com/codymikol/beans/ObjectMapperBean.kt
+++ b/src/main/kotlin/com/codymikol/beans/ObjectMapperBean.kt
@@ -7,4 +7,5 @@ import org.koin.core.annotation.Single
 @Single
 class ObjectMapperBean {
     val value: ObjectMapper by lazy { ObjectMapper().registerKotlinModule() }
+
 }

--- a/src/main/kotlin/com/codymikol/components/commit/diff/file/header/FileHeader.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/diff/file/header/FileHeader.kt
@@ -22,7 +22,7 @@ fun FileHeader(fileDeltaNode: FileDeltaNode) = Row(
     Row(modifier = Modifier.fillMaxSize(), horizontalArrangement = Arrangement.SpaceBetween) {
 
         Row(
-            modifier = Modifier.fillMaxHeight().wrapContentWidth(),
+            modifier = Modifier.fillMaxHeight().weight(1f),
             verticalAlignment = Alignment.CenterVertically
         ) {
 
@@ -37,8 +37,9 @@ fun FileHeader(fileDeltaNode: FileDeltaNode) = Row(
         }
 
         Row(
-            modifier = Modifier.fillMaxHeight().wrapContentWidth(),
-            verticalAlignment = Alignment.CenterVertically
+            modifier = Modifier.fillMaxHeight().width(100.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center
         ) {
 
             FileHeaderActions(fileDeltaNode)

--- a/src/main/kotlin/com/codymikol/components/commit/diff/file/header/action/buttons/StageLinesButton.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/diff/file/header/action/buttons/StageLinesButton.kt
@@ -2,12 +2,10 @@ package com.codymikol.components.commit.diff.file.header.action.buttons
 
 import androidx.compose.runtime.Composable
 import com.codymikol.data.diff.FileDeltaNode
+import com.codymikol.extensions.stageLines
+import com.codymikol.state.GitDownState
 
 @Composable
 fun StageLinesButton(fileDeltaNode: FileDeltaNode) = FileHeaderButton("Stage Lines") {
-
-//    val lineDeets = fileDeltaNode.getSelectedLines
-
-    println("yeet")
-
+    GitDownState.git.value.stageLines(fileDeltaNode.getSelectedLines())
 }

--- a/src/main/kotlin/com/codymikol/components/commit/diff/file/header/icons/FileHeaderIcon.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/diff/file/header/icons/FileHeaderIcon.kt
@@ -7,10 +7,10 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.unit.dp
 import com.codymikol.components.commit.FileIcon
 import com.codymikol.data.diff.FileDeltaNode
-import com.codymikol.data.diff.FileDeltaNodeOld
 
 @Composable
 fun FileHeaderIcon(fileDeltaNode: FileDeltaNode) = FileIcon(
     modifier = Modifier.shadow(elevation = 3.dp, shape = RoundedCornerShape(14.dp)),
     fileDelta = fileDeltaNode.fileDelta
+
 )

--- a/src/main/kotlin/com/codymikol/components/commit/diff/file/header/text/FileHeaderText.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/diff/file/header/text/FileHeaderText.kt
@@ -2,15 +2,25 @@ package com.codymikol.components.commit.diff.file.header.text
 
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.sp
 import com.codymikol.data.diff.FileDeltaNode
 
 @Composable
-fun FileHeaderText(fileDeltaNode: FileDeltaNode) = Text(
-    fileDeltaNode.fileDelta.getPath(),
-    color = Color.White,
-    fontSize = 12.sp,
-    fontWeight = FontWeight.Medium
-)
+fun FileHeaderText(fileDeltaNode: FileDeltaNode) {
+
+    val text = mutableStateOf(fileDeltaNode.fileDelta.getPath())
+
+    Text(
+        text.value,
+        color = Color.White,
+        fontSize = 12.sp,
+        fontWeight = FontWeight.Medium,
+        softWrap = false,
+        overflow = TextOverflow.Ellipsis,
+    )
+
+}

--- a/src/main/kotlin/com/codymikol/data/diff/DiffTree.kt
+++ b/src/main/kotlin/com/codymikol/data/diff/DiffTree.kt
@@ -15,8 +15,11 @@ data class DiffTree(
             // todo(mikol): Is there a better way to define parent relationships without drilling back down through the tree?
             tree.fileDeltaNodes.forEach {fileDeltaNode ->
                fileDeltaNode.parent = tree
-               fileDeltaNode.hunks.forEach {hunkNode ->
+               fileDeltaNode.hunkNodes.forEach { hunkNode ->
                    hunkNode.parent = fileDeltaNode
+                   hunkNode.lineNodes.forEach {
+                       it.parent = hunkNode
+                   }
                }
             }
 

--- a/src/main/kotlin/com/codymikol/data/diff/FileDeltaNode.kt
+++ b/src/main/kotlin/com/codymikol/data/diff/FileDeltaNode.kt
@@ -4,12 +4,16 @@ import com.codymikol.data.file.FileDelta
 
 class FileDeltaNode(
     val fileDelta: FileDelta,
-    val hunks: List<HunkNode>
+    val hunkNodes: List<HunkNode>
 ) {
 
     lateinit var parent: DiffTree
     fun getPath() = fileDelta.getPath()
-    fun isSelectingLines(): Boolean = hunks.any { hunk -> hunk.isSelectingLines() }
+
+    fun isSelectingLines(): Boolean = hunkNodes.any { hunk -> hunk.isSelectingLines() }
+
+    fun getSelectedLines(): List<LineNode> = hunkNodes.flatMap { hunk
+        -> hunk.getSelectedLines() }
 
     companion object {
         fun make(fileDelta: FileDelta): FileDeltaNode {

--- a/src/main/kotlin/com/codymikol/data/diff/HunkNode.kt
+++ b/src/main/kotlin/com/codymikol/data/diff/HunkNode.kt
@@ -2,11 +2,13 @@ package com.codymikol.data.diff
 
 data class HunkNode(
     val hunk: Hunk,
-    val lines: List<LineNode>,
+    val lineNodes: List<LineNode>,
 ) {
 
     lateinit var parent: FileDeltaNode
-    fun isSelectingLines() = lines.any { it.line.selected.value }
+    fun isSelectingLines() = lineNodes.any { it.line.selected.value }
+
+    fun getSelectedLines() = lineNodes.filter { it.line.selected.value }
 
     companion object {
         fun make(hunk: Hunk): HunkNode = HunkNode(hunk, hunk.lines.map(LineNode.Companion::make))

--- a/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
+++ b/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
@@ -2,6 +2,7 @@ package com.codymikol.extensions
 
 import androidx.compose.runtime.MutableState
 import com.codymikol.data.diff.FileDeltaNode
+import com.codymikol.data.diff.LineNode
 import com.codymikol.data.file.WorkingDirectory
 import com.codymikol.state.GitDownState
 import kotlinx.coroutines.Dispatchers
@@ -48,25 +49,18 @@ suspend fun Git.discardFile(location: String): Git = command {
     TODO()
 }
 
-suspend fun Git.unstageLines(): Git = command {
-
-//    val repoState = repository.repositoryState
-//
-//    val dc = repository.lockDirCache()
-//
-//    try {
-//        val walk = TreeWalk(repository)
-//
-//        if(commitTree)
-//
-//    } finally {
-//        dc.unlock()
-//    }
-
+suspend fun Git.unstageLines(lines: List<LineNode>): Git = command {
+    print(lines.size)
 }
 
-suspend fun Git.stageLines(): Git = command {
-    TODO()
+suspend fun Git.stageLines(lineNodes: List<LineNode>): Git = command {
+
+    val hunkNodes = lineNodes.groupBy { it.parent }
+
+    hunkNodes.forEach { hunkNode ->
+        println("Hunk ${hunkNode.key.hashCode()}, Line: ${hunkNode.value.map { it.hashCode() }}")
+    }
+
 }
 
 suspend fun Git.discardAllWorkingDirectory(): Git = command {

--- a/src/main/kotlin/com/codymikol/views/CommitView.kt
+++ b/src/main/kotlin/com/codymikol/views/CommitView.kt
@@ -157,9 +157,9 @@ private fun Diff() {
     LazyColumn {
         GitDownState.diffTree.value.fileDeltaNodes.forEach { fileDeltaNode ->
             stickyHeader { FileHeader(fileDeltaNode) }
-            fileDeltaNode.hunks.forEach { hunkNode ->
+            fileDeltaNode.hunkNodes.forEach { hunkNode ->
                 item { HunkHeader(hunkNode.hunk) }
-                hunkNode.lines.forEach { lineNode -> item { DiffLine(lineNode, fileDeltaNode) } }
+                hunkNode.lineNodes.forEach { lineNode -> item { DiffLine(lineNode, fileDeltaNode) } }
             }
         }
     }
@@ -168,7 +168,7 @@ private fun Diff() {
 @Composable
 private fun DiffLine(lineNode: LineNode, parentFileNode: FileDeltaNode) {
 
-    val fileLines = parentFileNode.hunks.map { it.lines }.flatten()
+    val fileLines = parentFileNode.hunkNodes.map { it.lineNodes }.flatten()
 
     //todo(mikol): figure out drag selection :')
     //todo(mikol): limit click hitbox to around the gutter area

--- a/src/main/kotlin/com/codymikol/windows/GitDown.kt
+++ b/src/main/kotlin/com/codymikol/windows/GitDown.kt
@@ -42,8 +42,17 @@ import java.awt.event.WindowFocusListener
 @Composable
 fun GitDown() {
 
+    fun handleUpArrow() {
+        //todo(mikol): if a file is selected, see if we can
+    }
+
+    fun handleDownArrow() {
+
+    }
+
     Window(
         onKeyEvent = {
+
             Keys.isShiftPressed.value = it.isShiftPressed
             Keys.isCtrlPressed.value = it.isCtrlPressed
             false

--- a/src/test/kotlin/data/diff/DiffSpec.kt
+++ b/src/test/kotlin/data/diff/DiffSpec.kt
@@ -37,30 +37,30 @@ index 39d9a33..960dae4 100644
         val fileDeltaNode = FileDeltaNode.make(subject)
 
         it("should have the correct number of chunks based on the number of delimiters in the diff") {
-            fileDeltaNode.hunks.size shouldBe 2
+            fileDeltaNode.hunkNodes.size shouldBe 2
         }
 
         describe("Hunk") {
 
-            val hunk = fileDeltaNode.hunks.getOrNull(0)
+            val hunk = fileDeltaNode.hunkNodes.getOrNull(0)
 
             it("should have the proper delimiter for the first hunk") {
                 hunk?.delimiter shouldBe "@@ -16,8 +16,9 @@"
             }
 
             it("should have the proper number of lines in the hunk") {
-                hunk?.lines?.size shouldBe 10
+                hunk?.lineNodes?.size shouldBe 10
             }
 
         }
 
         describe("Line") {
 
-            val hunk = fileDeltaNode.hunks.getOrNull(0)
+            val hunk = fileDeltaNode.hunkNodes.getOrNull(0)
 
             describe("Added Line") {
 
-                val example = hunk?.lines?.getOrNull(6)
+                val example = hunk?.lineNodes?.getOrNull(6)
 
                 it("should be the line I expect to be testing") {
                     example?.value shouldBe "            val path = this.dir.toString() + \"/\" +  filename"
@@ -74,7 +74,7 @@ index 39d9a33..960dae4 100644
 
             describe("Deleted Line") {
 
-                val example = hunk?.lines?.getOrNull(5)
+                val example = hunk?.lineNodes?.getOrNull(5)
 
                 it("should be the line I expect to be testing") {
                     example?.value shouldBe "            val path = this.dir.toString() + \"/\" + filename"
@@ -88,7 +88,7 @@ index 39d9a33..960dae4 100644
 
             describe("Unmodified Line") {
 
-                val example = hunk?.lines?.getOrNull(7)
+                val example = hunk?.lineNodes?.getOrNull(7)
 
                 it("should be the line I expect to be testing") {
                     example?.value shouldBe "            File(path).also { file -> file.parentFile.mkdirs() }.writeText(\"Foo\")"


### PR DESCRIPTION
this prevents an issue where the stage / unstage file button would get clipped out of frame if the file path is too long. We still need to find a way to do a reverse ellipse, but I feel this is part of another issue.

Fixes #87