### PR TITLE
fix(commit): handle empty newly initialized repos

### DIFF
--- a/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
+++ b/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.ResetCommand
+import org.eclipse.jgit.api.errors.NoHeadException
 import org.slf4j.LoggerFactory
 
 class GitExtensions
@@ -24,6 +25,12 @@ private suspend fun Git.command(fn: () -> Unit) = withContext(Dispatchers.IO) {
     GitDownState.lastRequestedUpdateTimestamp.value = System.currentTimeMillis()
     scanForChanges()
 }.let { this }
+
+fun Git.getCurrentRefCommitCount() = try {
+    this.log().call().toSet().size
+} catch (e: NoHeadException) {
+    0
+}
 
 suspend fun Git.stageAll(): Git = command {
 

--- a/src/main/kotlin/com/codymikol/state/state.kt
+++ b/src/main/kotlin/com/codymikol/state/state.kt
@@ -5,6 +5,7 @@ import com.codymikol.data.diff.DiffTree
 import com.codymikol.data.file.FileDelta
 import com.codymikol.data.file.Index
 import com.codymikol.data.file.WorkingDirectory
+import com.codymikol.extensions.getCurrentRefCommitCount
 import com.codymikol.tabs.Tab
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder
@@ -44,7 +45,7 @@ object GitDownState {
     val branchName = derivedStateOf { repo.value.branch ?: "" }
 
     val commitCount = derivedStateOf {
-        git.value.log().call().toSet().size
+        git.value.getCurrentRefCommitCount()
     }
 
     val committingAsName = derivedStateOf { repo.value.config.getString("user", null, "name") ?: "" }


### PR DESCRIPTION
this fixes a bug where the commit count derived
state was encountering an exception. Now we will
explicitly handle this and return 0 commits.

Fixes #28