### PR TITLE
chore(cli): make the temoporary cli a little better

### DIFF
--- a/src/main/kotlin/com/codymikol/Main.kt
+++ b/src/main/kotlin/com/codymikol/Main.kt
@@ -11,9 +11,10 @@ class Main {
         @JvmStatic
         fun main(args: Array<String>) = application {
 
+            // todo(mikol): we should move this into a load directory service and make it more robust eventually...
             if(args.size == 1) {
-                println(args[0])
-                GitDownState.gitDirectory.value = args[0]
+                println("requested directory: " + args[0])
+                GitDownState.gitDirectory.value = args[0] + "/.git"
             }
 
             startKoin { modules(


### PR DESCRIPTION
now you can run the program, specify a directory, and if it is a directory it will automatically open gitdown in that directory.

`./git-down ./`

Fixes N/A