### PR TITLE
build: add Makefile for Gradle tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+GRADLE := ./gradlew
+GRADLE_SHADOWJAR := shadowJar
+
+.PHONY: build
+
+build:
+	$(GRADLE) $(GRADLE_SHADOWJAR)
+
+clean:
+	$(GRADLE) clean
+
+test:
+	$(GRADLE) test


### PR DESCRIPTION
- Add Makefile to simplify running Gradle tasks
- Include targets for build, clean, and test
- Use shadowJar for building the project

Fixes N/A