### PR TITLE
fix(nix): properly set LD_LIBRARY_PATH in nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
 
         shellHook = ''
           echo "Setting up OpenGL environment...";
-          export LD_LIBRARY_PATH="/run/opengl-driver/lib:/run/opengl-driver-32/lib";
+          LD_LIBRARY_PATH="${pkgs.libGL}/lib/:${pkgs.stdenv.cc.cc.lib}/lib/";
         '';
 
       };


### PR DESCRIPTION
this fixes an issue where we were loading in the wrong libGL file because we were not pointing to the directory of the nix pkg pulled in.

Fixes N/A