### PR TITLE
fix: correct shadow jar Main-Class to MainKt

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,7 +63,7 @@ version = "1.0"
 
 tasks.jar {
   manifest {
-    attributes["Main-Class"] = "com.codymikol.Main"
+    attributes["Main-Class"] = "com.codymikol.MainKt"
     attributes["Class-Path"] = configurations
         .runtimeClasspath
         .get()


### PR DESCRIPTION
## Summary
- `Main.kt` contains a top-level `fun main`, so Kotlin compiles it to the class `com.codymikol.MainKt`, not `com.codymikol.Main`.
- The `tasks.jar` manifest in `build.gradle.kts` set `Main-Class` to `com.codymikol.Main`, which doesn't exist, causing `java -jar gitdown-1.0-all.jar` to fail with `Error: Could not find or load main class com.codymikol.Main`.
- Fixed the manifest to use `com.codymikol.MainKt`, matching the `mainClass` already correctly configured for the Compose desktop application block.

Closes #137

## Note for reviewer
This sandbox has no local JDK/network access to run `./gradlew build`, so the fix relies on CI (`actions/setup-java` + `./gradlew build`) for verification. The change is a one-line manifest fix consistent with the existing correct `mainClass = "com.codymikol.MainKt"` value used elsewhere in the same file.

## Test plan
- [ ] CI build passes (`./gradlew build`)
- [ ] `java -jar build/libs/gitdown-1.0-all.jar` launches without `ClassNotFoundException`