### PR TITLE
feat: insert newline on shift+enter in commit message

### DIFF
--- a/src/main/kotlin/com/codymikol/views/CommitView.kt
+++ b/src/main/kotlin/com/codymikol/views/CommitView.kt
@@ -16,8 +16,16 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.*
 import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isShiftPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.codymikol.components.SlimButton
@@ -110,15 +118,41 @@ fun DrawScope.drawCommitGuideline(xOffset: Float, lineHeight: Float, spaceHeight
 
 @Composable
 private fun CommitMessageInput() {
+    var textFieldValue by remember { mutableStateOf(TextFieldValue(commitMessage.value)) }
+
+    // commitMessage can be mutated externally (amend, post-commit clear); resync when it drifts.
+    if (textFieldValue.text != commitMessage.value) {
+        textFieldValue = TextFieldValue(commitMessage.value, TextRange(commitMessage.value.length))
+    }
+
     BasicTextField(
         cursorBrush = Brush.verticalGradient(0.00f to Color.White),
-        value = commitMessage.value,
+        value = textFieldValue,
         modifier = Modifier
             .fillMaxSize()
             .padding(top = 8.dp, start = 8.dp, bottom = 0.dp, end = 8.dp)
-            .background(Colors.DarkGrayBackground),
+            .background(Colors.DarkGrayBackground)
+            .onPreviewKeyEvent { event ->
+                val isShiftEnter = event.type == KeyEventType.KeyDown &&
+                    event.key == Key.Enter &&
+                    event.isShiftPressed
+
+                if (!isShiftEnter) return@onPreviewKeyEvent false
+
+                val selection = textFieldValue.selection
+                val newText = textFieldValue.text.replaceRange(selection.min, selection.max, "\n")
+                val newValue = TextFieldValue(newText, TextRange(selection.min + 1))
+
+                textFieldValue = newValue
+                commitMessage.value = newValue.text
+
+                true
+            },
         textStyle = TextStyle(color = Color.White, fontSize = 12.sp),
-        onValueChange = { commitMessage.value = it },
+        onValueChange = {
+            textFieldValue = it
+            commitMessage.value = it.text
+        },
         decorationBox = { innerTextField ->
             Row(modifier = Modifier
                 .fillMaxWidth()


### PR DESCRIPTION
## Summary
- The commit message `BasicTextField` in `CommitView.kt` had no explicit key-event handling, so shift+enter's newline behavior was left entirely to default text field handling.
- Adds an `onPreviewKeyEvent` handler on the commit message field that explicitly intercepts shift+enter, inserts `\n` at the current cursor/selection position, and consumes the event.
- Switches the field's local state from a plain `String` to `TextFieldValue` so the insertion happens at the cursor rather than always at the end of the text. The shared `commitMessage` state (read by `CommitBottomToolbar` for commit/amend and reset elsewhere) stays a `String` — the composable resyncs its local `TextFieldValue` whenever that external string changes (amend-fill, post-commit clear).

Closes #10

## Reviewer notes
- Plain Enter is untouched and continues to fall through to the text field's default handling.
- No local JDK/Gradle available in this sandbox to run `./gradlew build`; relying on CI (JDK 21 via `actions/setup-java`) to compile and run the test suite.