### PR TITLE
feat: add stash list view

### DIFF
--- a/src/main/kotlin/com/codymikol/components/stash/StashRow.kt
+++ b/src/main/kotlin/com/codymikol/components/stash/StashRow.kt
@@ -1,0 +1,49 @@
+package com.codymikol.components.stash
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.codymikol.data.Colors
+import com.codymikol.data.stash.StashListItem
+
+@Composable
+fun StashRow(stash: StashListItem, selected: Boolean, onClick: () -> Unit) {
+
+    val backgroundColor = when (selected) {
+        true -> Color(0, 89, 207)
+        false -> Color.Transparent
+    }
+
+    Column(
+        modifier = Modifier
+            .clickable(onClick = onClick)
+            .fillMaxWidth()
+            .background(backgroundColor)
+            .padding(horizontal = 12.dp, vertical = 6.dp)
+    ) {
+        Text(
+            stash.title,
+            color = Color.White,
+            fontSize = 12.sp,
+            softWrap = false,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Spacer(modifier = Modifier.height(2.dp))
+        Text(
+            stash.body,
+            color = Colors.LightGrayText,
+            fontSize = 11.sp,
+        )
+    }
+}

--- a/src/main/kotlin/com/codymikol/data/stash/StashListItem.kt
+++ b/src/main/kotlin/com/codymikol/data/stash/StashListItem.kt
@@ -1,0 +1,59 @@
+package com.codymikol.data.stash
+
+import org.eclipse.jgit.lib.Repository
+import org.eclipse.jgit.revwalk.RevCommit
+import org.eclipse.jgit.revwalk.RevWalk
+import java.text.SimpleDateFormat
+import java.util.Date
+
+private val WipStashMessage = Regex("^WIP on (.+?): .*$")
+private val CustomStashMessage = Regex("^On (.+?): (.*)$")
+
+data class StashListItem(
+    val sha: String,
+    val date: Date,
+    val description: String,
+    val branchOrSha: String,
+    val commitMessage: String,
+) {
+
+    val title: String
+        get() {
+            val datePart = SimpleDateFormat("MM/dd/yy").format(date)
+            val timePart = SimpleDateFormat("h:mm a").format(date)
+            return "${sha.take(7)}    $datePart, $timePart"
+        }
+
+    val body: String
+        get() = "$description on $branchOrSha: $commitMessage"
+
+    companion object {
+        fun make(repository: Repository, revCommit: RevCommit): StashListItem {
+            val fullMessage = revCommit.fullMessage.trim()
+
+            val (description, branchOrSha) = when {
+                WipStashMessage.matches(fullMessage) ->
+                    "WIP" to WipStashMessage.find(fullMessage)!!.groupValues[1]
+                CustomStashMessage.matches(fullMessage) ->
+                    CustomStashMessage.find(fullMessage)!!.groupValues[2] to CustomStashMessage.find(fullMessage)!!.groupValues[1]
+                else -> "WIP" to (repository.branch ?: revCommit.name.take(7))
+            }
+
+            val commitMessage = when (revCommit.parentCount > 0) {
+                true -> RevWalk(repository).use { walk ->
+                    val parsedParent = walk.parseCommit(revCommit.getParent(0))
+                    "${parsedParent.name.take(7)} ${parsedParent.shortMessage}"
+                }
+                false -> ""
+            }
+
+            return StashListItem(
+                sha = revCommit.name,
+                date = Date(revCommit.commitTime.toLong() * 1000),
+                description = description,
+                branchOrSha = branchOrSha,
+                commitMessage = commitMessage,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
+++ b/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
@@ -19,6 +19,7 @@ import org.eclipse.jgit.dircache.DirCacheIterator
 import org.eclipse.jgit.lib.Constants.OBJ_BLOB
 import org.eclipse.jgit.lib.FileMode
 import org.eclipse.jgit.lib.Repository
+import org.eclipse.jgit.revwalk.RevCommit
 import org.eclipse.jgit.treewalk.FileTreeIterator
 import org.eclipse.jgit.treewalk.NameConflictTreeWalk
 import org.eclipse.jgit.treewalk.TreeWalk.OperationType
@@ -49,6 +50,12 @@ fun Git.getCurrentRefCommitCount() = try {
     this.log().call().toSet().size
 } catch (e: NoHeadException) {
     0
+}
+
+fun Git.getStashes(): List<RevCommit> = try {
+    this.stashList().call().toList()
+} catch (e: Exception) {
+    emptyList()
 }
 
 suspend fun Git.stageAll(): Git = command {

--- a/src/main/kotlin/com/codymikol/state/state.kt
+++ b/src/main/kotlin/com/codymikol/state/state.kt
@@ -5,7 +5,9 @@ import com.codymikol.data.diff.DiffTree
 import com.codymikol.data.file.FileDelta
 import com.codymikol.data.file.Index
 import com.codymikol.data.file.WorkingDirectory
+import com.codymikol.data.stash.StashListItem
 import com.codymikol.extensions.getCurrentRefCommitCount
+import com.codymikol.extensions.getStashes
 import com.codymikol.tabs.Tab
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder
@@ -47,6 +49,12 @@ object GitDownState {
     val commitCount = derivedStateOf {
         git.value.getCurrentRefCommitCount()
     }
+
+    val stashes = derivedStateOf {
+        git.value.getStashes().map { StashListItem.make(repo.value, it) }
+    }
+
+    val selectedStash = mutableStateOf<StashListItem?>(null)
 
     val committingAsName = derivedStateOf { repo.value.config.getString("user", null, "name") ?: "" }
 

--- a/src/main/kotlin/com/codymikol/views/StashView.kt
+++ b/src/main/kotlin/com/codymikol/views/StashView.kt
@@ -1,11 +1,96 @@
 package com.codymikol.views
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.codymikol.components.Subheader
+import com.codymikol.components.stash.StashRow
+import com.codymikol.data.Colors
+import com.codymikol.state.GitDownState
 
 @Composable
 @Preview
 fun StashView() {
-    Text("TODO - Stash")
+    Row(modifier = Modifier.fillMaxWidth().fillMaxHeight()) {
+        Column(
+            modifier = Modifier
+                .background(Colors.DarkGrayBackground)
+                .weight(40f)
+                .fillMaxHeight()
+                .border(width = 1.dp, color = Color.Black)
+        ) {
+            StashList()
+        }
+        Column(
+            modifier = Modifier
+                .weight(60f)
+                .fillMaxHeight()
+                .background(Colors.DarkGrayBackground)
+                .border(width = 1.dp, color = Color.Black)
+        ) {
+            StashDiffPanel()
+        }
+    }
+}
+
+@Composable
+private fun ColumnScope.StashList() {
+    Subheader("Stashes")
+    when (GitDownState.stashes.value.isNotEmpty()) {
+        true -> Column(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .verticalScroll(state = rememberScrollState())
+        ) {
+            GitDownState.stashes.value.forEach { stash ->
+                StashRow(
+                    stash = stash,
+                    selected = GitDownState.selectedStash.value == stash,
+                    onClick = { GitDownState.selectedStash.value = stash }
+                )
+            }
+        }
+        false -> StashEmptyState("No stashes")
+    }
+}
+
+@Composable
+private fun StashDiffPanel() = when (GitDownState.selectedStash.value) {
+    null -> Column { StashEmptyState("No stash selected") }
+    else -> Column { StashEmptyState("Stash diff view coming soon") }
+}
+
+@Composable
+private fun ColumnScope.StashEmptyState(message: String) {
+    Column(
+        modifier = Modifier
+            .weight(1f)
+            .fillMaxWidth()
+            .fillMaxHeight(),
+        verticalArrangement = Arrangement.Center
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.CenterHorizontally),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Text(message, color = Color.Gray)
+        }
+    }
 }

--- a/src/test/kotlin/com/codymikol/data/stash/StashListItemSpec.kt
+++ b/src/test/kotlin/com/codymikol/data/stash/StashListItemSpec.kt
@@ -1,0 +1,92 @@
+package com.codymikol.data.stash
+
+import com.codymikol.repository.TestRepository.Companion.createTestRepository
+import com.codymikol.state.GitDownState
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+class StashListItemSpec : DescribeSpec({
+
+    describe("GitDownState.stashes") {
+
+        describe("A default stash with no custom message") {
+
+            autoClose(
+                createTestRepository()
+                    .addFile("foo.txt", "one\n")
+                    .stageAll()
+                    .commitAll("init")
+                    .appendToFile("foo.txt", "two\n")
+                    .stashCreate()
+                    .transferIntoGitDownState()
+            )
+
+            val stash = GitDownState.stashes.value.single()
+
+            it("should be described as WIP") {
+                stash.description shouldBe "WIP"
+            }
+
+            it("should reference the branch the stash was made on") {
+                stash.branchOrSha shouldBe GitDownState.branchName.value
+            }
+
+            it("should reference the commit the stash was made on top of") {
+                stash.commitMessage shouldContain "init"
+            }
+
+            it("should render a title containing the abbreviated sha") {
+                stash.title shouldContain stash.sha.take(7)
+            }
+
+        }
+
+        describe("A stash with a custom message") {
+
+            autoClose(
+                createTestRepository()
+                    .addFile("foo.txt", "one\n")
+                    .stageAll()
+                    .commitAll("init")
+                    .appendToFile("foo.txt", "two\n")
+                    .stashCreate("my custom message")
+                    .transferIntoGitDownState()
+            )
+
+            val stash = GitDownState.stashes.value.single()
+
+            it("should use the custom message as the description") {
+                stash.description shouldBe "my custom message"
+            }
+
+            it("should reference the branch the stash was made on") {
+                stash.branchOrSha shouldBe GitDownState.branchName.value
+            }
+
+        }
+
+        describe("Multiple stashes") {
+
+            autoClose(
+                createTestRepository()
+                    .addFile("foo.txt", "one\n")
+                    .stageAll()
+                    .commitAll("init")
+                    .appendToFile("foo.txt", "two\n")
+                    .stashCreate()
+                    .appendToFile("foo.txt", "three\n")
+                    .stashCreate()
+                    .transferIntoGitDownState()
+            )
+
+            it("should list both stashes") {
+                GitDownState.stashes.value shouldHaveSize 2
+            }
+
+        }
+
+    }
+
+})

--- a/src/test/kotlin/com/codymikol/repository/TestRepository.kt
+++ b/src/test/kotlin/com/codymikol/repository/TestRepository.kt
@@ -45,6 +45,15 @@ data class TestRepository(
         this.git.commitAll(message)
     }
 
+    fun stashCreate(message: String? = null) = this.also {
+        val command = this.git.stashCreate()
+        // setWorkingDirectoryMessage is a MessageFormat template ({0}=branch, {1}=abbrev sha,
+        // {2}=HEAD short message), matching "On {0}: <message>" reproduces the shape `git
+        // stash push -m` produces so StashListItem's parsing sees a realistic custom message.
+        message?.let { command.setWorkingDirectoryMessage("On {0}: $it") }
+        command.call()
+    }
+
     fun transferIntoGitDownState() = this.also {
         this.closeGitRepo()
         GitDownState.gitDirectory.value = this.dir.toString() + "/.git"


### PR DESCRIPTION
## Summary
- Get the current repo's stashes via JGit's `Git.stashList()` and expose them as `GitDownState.stashes` (a list of `StashListItem`).
- Render each stash on the left as a clickable list item: title = `<7-char sha>    <MM/dd/yy>, <h:mm a>`, body = `<description or WIP> on <branch/sha>: <original commit sha + subject>`.
- Layout mirrors `CommitView`'s 40/60 list-vs-diff split and dark-gray/bordered panels; the right pane shows a placeholder ("No stash selected" / "Stash diff view coming soon") until stash diff rendering is implemented.
- Added `StashListItemSpec` covering default (`WIP on <branch>`) and custom-message stashes, plus a `stashCreate()` test helper on `TestRepository`.

Closes #136

## Notes for reviewer
- Could not run `./gradlew build`/`test` locally (sandbox has no JDK/network for nix or gradle deps) — relying on CI (JDK 21) to validate the build. Code was manually cross-checked against the JGit 7.0.0 source for API correctness (`stashList()`, `stashCreate()`, `RevCommit` accessors, `RevWalk.parseCommit`).
- `StashListItem` derives the "commit stashed on top of" info (sha + short message) by walking the stash commit's first parent via `RevWalk`, rather than relying on string-parsing alone — this is robust for both default and custom stash messages.
- Diff rendering for the selected stash is intentionally out of scope per the issue ("eventually we will display the diff contents").