### PR TITLE
feat: add file actions cog menu

### DIFF
--- a/src/main/kotlin/com/codymikol/components/commit/diff/file/header/FileHeader.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/diff/file/header/FileHeader.kt
@@ -37,7 +37,7 @@ fun FileHeader(fileDeltaNode: FileDeltaNode) = Row(
         }
 
         Row(
-            modifier = Modifier.fillMaxHeight().width(100.dp),
+            modifier = Modifier.fillMaxHeight().width(140.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Center
         ) {

--- a/src/main/kotlin/com/codymikol/components/commit/diff/file/header/action/FileHeaderAction.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/diff/file/header/action/FileHeaderAction.kt
@@ -1,6 +1,13 @@
 package com.codymikol.components.commit.diff.file.header.action
 
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.codymikol.components.commit.diff.file.header.action.buttons.FileHeaderCogButton
 import com.codymikol.components.commit.diff.file.header.action.buttons.StageFileButton
 import com.codymikol.components.commit.diff.file.header.action.buttons.StageLinesButton
 import com.codymikol.components.commit.diff.file.header.action.buttons.UnstageFileButton
@@ -21,7 +28,11 @@ private fun LineActions(fileDeltaNode: FileDeltaNode) = when (fileDeltaNode.file
 }
 
 @Composable
-private fun FileActions(fileDeltaNode: FileDeltaNode) = when (fileDeltaNode.fileDelta.type) {
-    Status.WORKING_DIRECTORY -> StageFileButton(fileDeltaNode)
-    Status.INDEX -> UnstageFileButton(fileDeltaNode)
+private fun FileActions(fileDeltaNode: FileDeltaNode) = Row(verticalAlignment = Alignment.CenterVertically) {
+    when (fileDeltaNode.fileDelta.type) {
+        Status.WORKING_DIRECTORY -> StageFileButton(fileDeltaNode)
+        Status.INDEX -> UnstageFileButton(fileDeltaNode)
+    }
+    Spacer(modifier = Modifier.width(6.dp))
+    FileHeaderCogButton()
 }

--- a/src/main/kotlin/com/codymikol/components/commit/diff/file/header/action/buttons/FileHeaderCogButton.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/diff/file/header/action/buttons/FileHeaderCogButton.kt
@@ -1,0 +1,80 @@
+package com.codymikol.components.commit.diff.file.header.action.buttons
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Divider
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.OutlinedButton
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.codymikol.components.commit.diff.file.header.colors.HeaderButtonColors
+import com.codymikol.data.Colors
+import org.slf4j.LoggerFactory
+
+private val logger = LoggerFactory.getLogger("FileHeaderCogButton")
+
+@Composable
+fun FileHeaderCogButton() {
+
+    var expanded by remember { mutableStateOf(false) }
+
+    Box {
+        OutlinedButton(
+            onClick = { expanded = true },
+            modifier = Modifier.height(24.dp).width(24.dp).padding(0.dp),
+            colors = HeaderButtonColors(),
+            contentPadding = PaddingValues(0.dp)
+        ) {
+            Text("⚙", fontSize = 10.sp)
+        }
+
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            modifier = Modifier.background(Colors.DarkGrayBackground)
+        ) {
+            FileActionSectionHeader("Working Directory")
+            FileActionMenuItem("View in Diff Tool", "workingDirectory.viewInDiffTool") { expanded = false }
+            Divider(color = Colors.DisabledGray)
+            FileActionMenuItem("Open File", "workingDirectory.openFile") { expanded = false }
+            FileActionMenuItem("Show In Files", "workingDirectory.showInFiles") { expanded = false }
+            Divider(color = Colors.DisabledGray)
+            FileActionMenuItem("Delete File", "workingDirectory.deleteFile") { expanded = false }
+
+            FileActionSectionHeader("Index")
+            FileActionMenuItem("View in Diff Tool", "index.viewInDiffTool") { expanded = false }
+            Divider(color = Colors.DisabledGray)
+            FileActionMenuItem("Open File", "index.openFile") { expanded = false }
+            FileActionMenuItem("Show In Files", "index.showInFiles") { expanded = false }
+        }
+    }
+}
+
+@Composable
+private fun FileActionSectionHeader(text: String) = Text(
+    text,
+    modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+    color = Colors.LightGrayText,
+    fontSize = 10.sp
+)
+
+@Composable
+private fun FileActionMenuItem(label: String, actionId: String, onSelect: () -> Unit) = DropdownMenuItem(onClick = {
+    logger.info("todo: $actionId")
+    onSelect()
+}) {
+    Text(label, color = Color.White, fontSize = 12.sp)
+}


### PR DESCRIPTION
## Summary
- Adds a gear/cog icon button to the right of the Stage File / Unstage File button in the diff file header.
- Clicking it opens a dropdown with two sections, per the issue spec:
  - **Working Directory**: View in Diff Tool, (divider), Open File, Show In Files, (divider), Delete File
  - **Index**: View in Diff Tool, (divider), Open File, Show In Files
- Every item is a stub for now — selecting one logs `todo: <action>` via SLF4J and closes the menu; no behavior is wired up yet.
- Widened the file-header actions column (100dp → 140dp) so the new icon button fits alongside the existing Stage/Unstage button.

## Note for reviewer
Could not run `./gradlew build`/`nix develop` in the sandbox this was authored in (no local JDK, and `/nix/store` is non-writable there), so this has only been verified by careful manual review against existing Compose patterns in the repo — please confirm CI is green.

Closes #142