### PR TITLE
feat: navigate file selection with arrow keys

### DIFF
--- a/src/main/kotlin/com/codymikol/state/state.kt
+++ b/src/main/kotlin/com/codymikol/state/state.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.*
 import com.codymikol.data.diff.DiffTree
 import com.codymikol.data.file.FileDelta
 import com.codymikol.data.file.Index
+import com.codymikol.data.file.Status
 import com.codymikol.data.file.WorkingDirectory
 import com.codymikol.data.stash.StashListItem
 import com.codymikol.extensions.getCurrentRefCommitCount
@@ -146,5 +147,22 @@ object GitDownState {
 
     //todo(mikol): this is not ideal, work out a better way to manage this...
     val lastRequestedUpdateTimestamp = mutableStateOf(System.currentTimeMillis())
+
+    fun selectAdjacentFile(offset: Int) {
+        val current = selectedFiles.singleOrNull() ?: return
+
+        val siblings = when (current.type) {
+            Status.WORKING_DIRECTORY -> workingDirectory.value
+            Status.INDEX -> index.value
+        }.toList()
+
+        val currentIndex = siblings.indexOf(current)
+        if (currentIndex < 0) return
+
+        val nextIndex = (currentIndex + offset).coerceIn(siblings.indices)
+
+        selectedFiles.clear()
+        selectedFiles.add(siblings[nextIndex])
+    }
 
 }

--- a/src/main/kotlin/com/codymikol/views/CommitView.kt
+++ b/src/main/kotlin/com/codymikol/views/CommitView.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.*
 import androidx.compose.ui.graphics.drawscope.DrawScope
@@ -47,6 +48,7 @@ import kotlinx.coroutines.launch
 
 val commitMessage = mutableStateOf("")
 val isConfirmingDiscardAll = mutableStateOf(false)
+val isCommitMessageFocused = mutableStateOf(false)
 
 @Composable
 @Preview
@@ -132,6 +134,7 @@ private fun CommitMessageInput() {
             .fillMaxSize()
             .padding(top = 8.dp, start = 8.dp, bottom = 0.dp, end = 8.dp)
             .background(Colors.DarkGrayBackground)
+            .onFocusChanged { isCommitMessageFocused.value = it.isFocused }
             .onPreviewKeyEvent { event ->
                 val isShiftEnter = event.type == KeyEventType.KeyDown &&
                     event.key == Key.Enter &&

--- a/src/main/kotlin/com/codymikol/windows/GitDown.kt
+++ b/src/main/kotlin/com/codymikol/windows/GitDown.kt
@@ -13,8 +13,12 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.isCtrlPressed
 import androidx.compose.ui.input.key.isShiftPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -32,6 +36,7 @@ import com.codymikol.state.GitDownState
 import com.codymikol.state.Keys
 import com.codymikol.tabs.Tab
 import com.codymikol.views.CommitView
+import com.codymikol.views.isCommitMessageFocused
 import com.codymikol.views.MapView
 import com.codymikol.views.StashView
 import java.awt.Dimension
@@ -44,7 +49,19 @@ fun GitDown() {
         onKeyEvent = {
             Keys.isShiftPressed.value = it.isShiftPressed
             Keys.isCtrlPressed.value = it.isCtrlPressed
-            false
+
+            val isFileSelectionArrow = it.type == KeyEventType.KeyDown &&
+                (it.key == Key.DirectionUp || it.key == Key.DirectionDown) &&
+                GitDownState.currentTab.value == Tab.Commit &&
+                !isCommitMessageFocused.value &&
+                GitDownState.selectedFiles.size == 1
+
+            if (isFileSelectionArrow) {
+                GitDownState.selectAdjacentFile(if (it.key == Key.DirectionUp) -1 else 1)
+                true
+            } else {
+                false
+            }
         },
         onCloseRequest = {
             GitDownState.gitDirectory.value = ""

--- a/src/test/kotlin/com/codymikol/state/GitDownStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/GitDownStateSpec.kt
@@ -612,5 +612,100 @@ class GitDownStateSpec : DescribeSpec({
             }
         }
 
+        describe("selectAdjacentFile") {
+
+            describe("when there are multiple files in the working directory") {
+
+                autoClose(
+                    createTestRepository()
+                        .addFile("a.txt", "A")
+                        .addFile("b.txt", "B")
+                        .addFile("c.txt", "C")
+                        .transferIntoGitDownState()
+                )
+
+                val files = GitDownState.workingDirectory.value.toList()
+
+                it("should select the next file when moving down") {
+                    GitDownState.selectedFiles.clear()
+                    GitDownState.selectedFiles.add(files[0])
+
+                    GitDownState.selectAdjacentFile(1)
+
+                    GitDownState.selectedFiles.toList() shouldBe listOf(files[1])
+                }
+
+                it("should select the previous file when moving up") {
+                    GitDownState.selectedFiles.clear()
+                    GitDownState.selectedFiles.add(files[1])
+
+                    GitDownState.selectAdjacentFile(-1)
+
+                    GitDownState.selectedFiles.toList() shouldBe listOf(files[0])
+                }
+
+                it("should stay on the first file when moving up from the top") {
+                    GitDownState.selectedFiles.clear()
+                    GitDownState.selectedFiles.add(files[0])
+
+                    GitDownState.selectAdjacentFile(-1)
+
+                    GitDownState.selectedFiles.toList() shouldBe listOf(files[0])
+                }
+
+                it("should stay on the last file when moving down from the bottom") {
+                    GitDownState.selectedFiles.clear()
+                    GitDownState.selectedFiles.add(files[2])
+
+                    GitDownState.selectAdjacentFile(1)
+
+                    GitDownState.selectedFiles.toList() shouldBe listOf(files[2])
+                }
+
+                it("should do nothing when there is no selection") {
+                    GitDownState.selectedFiles.clear()
+
+                    GitDownState.selectAdjacentFile(1)
+
+                    GitDownState.selectedFiles.toList() shouldBe emptyList()
+                }
+
+                it("should do nothing when multiple files are selected") {
+                    GitDownState.selectedFiles.clear()
+                    GitDownState.selectedFiles.add(files[0])
+                    GitDownState.selectedFiles.add(files[1])
+
+                    GitDownState.selectAdjacentFile(1)
+
+                    GitDownState.selectedFiles.toList() shouldBe listOf(files[0], files[1])
+                }
+
+            }
+
+            describe("when a file in the index is selected") {
+
+                autoClose(
+                    createTestRepository()
+                        .addFile("foo.txt", "Foo")
+                        .addFile("bar.txt", "Bar")
+                        .stageAll()
+                        .transferIntoGitDownState()
+                )
+
+                val indexFiles = GitDownState.index.value.toList()
+
+                it("should navigate within the index, not the working directory") {
+                    GitDownState.selectedFiles.clear()
+                    GitDownState.selectedFiles.add(indexFiles[0])
+
+                    GitDownState.selectAdjacentFile(1)
+
+                    GitDownState.selectedFiles.toList() shouldBe listOf(indexFiles[1])
+                }
+
+            }
+
+        }
+
     }
 })


### PR DESCRIPTION
## Summary
- In the Commit view, pressing Up/Down while a single file is selected in the Working Directory or Index panel now moves the selection to the previous/next file within that same panel's list.
- Arrow-key navigation is skipped while the commit message text field is focused, so cursor movement in the multi-line message input is unaffected.
- Added `GitDownState.selectAdjacentFile(offset)` which resolves the currently selected file's panel (Working Directory vs Index) via `FileDelta.type` and clamps at the list boundaries (no wraparound).

Closes #40

## Notes for reviewer
- No focus-management/`FocusRequester` infrastructure existed in this codebase yet, so navigation is wired through the existing global `Window(onKeyEvent = ...)` handler in `GitDown.kt` (same pattern already used there for Shift/Ctrl tracking), gated on: Commit tab active, commit message field not focused, and exactly one file selected.
- Navigation order matches render order because both draw from the same `GitDownState.workingDirectory.value` / `GitDownState.index.value` `Set<FileDelta>`.
- Added unit tests in `GitDownStateSpec.kt` covering next/prev, top/bottom boundary clamping, no-op on empty/multi-selection, and index-vs-working-directory scoping.
- Could not run a local Gradle/JDK build in this sandbox (no JDK available, `nix develop` can't write to the read-only Nix store) — relying on CI's `./gradlew build` to verify compilation and tests.