### PR TITLE
feat(components): add ReversedEllipsisText component

### DIFF
--- a/src/main/kotlin/com/codymikol/components/ReversedEllipsisText.kt
+++ b/src/main/kotlin/com/codymikol/components/ReversedEllipsisText.kt
@@ -1,0 +1,95 @@
+package com.codymikol.components
+
+import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
+
+/**
+ * Truncates [text] from the front, keeping its trailing characters intact, so that
+ * [ellipsis] + the remaining suffix fits within [maxWidthPx] as reported by [measure].
+ * Pulled out as a pure function so the truncation logic can be unit tested without a
+ * Compose measuring environment.
+ */
+fun reversedEllipsis(
+    text: String,
+    maxWidthPx: Float,
+    measure: (String) -> Float,
+    ellipsis: String = "...",
+): String {
+    if (maxWidthPx <= 0f || text.isEmpty()) return text
+    if (measure(text) <= maxWidthPx) return text
+
+    if (measure(ellipsis) > maxWidthPx) return ellipsis
+
+    var low = 0
+    var high = text.length
+    var best = 0
+
+    while (low <= high) {
+        val mid = (low + high) / 2
+        val suffix = text.takeLast(mid)
+        if (measure(ellipsis + suffix) <= maxWidthPx) {
+            best = mid
+            low = mid + 1
+        } else {
+            high = mid - 1
+        }
+    }
+
+    return ellipsis + text.takeLast(best)
+}
+
+@Composable
+fun ReversedEllipsisText(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.White,
+    fontSize: TextUnit = 12.sp,
+    fontWeight: FontWeight = FontWeight.Medium,
+    ellipsis: String = "...",
+) {
+    val textMeasurer = rememberTextMeasurer()
+    val density = LocalDensity.current
+    val style = remember(color, fontSize, fontWeight) {
+        TextStyle(color = color, fontSize = fontSize, fontWeight = fontWeight)
+    }
+
+    BoxWithConstraints(modifier = modifier) {
+        val maxWidthPx = with(density) { maxWidth.toPx() }
+
+        val displayText = remember(text, maxWidthPx, style, ellipsis) {
+            reversedEllipsis(
+                text = text,
+                maxWidthPx = maxWidthPx,
+                measure = { candidate -> textMeasurer.measure(candidate, style).size.width.toFloat() },
+                ellipsis = ellipsis,
+            )
+        }
+
+        Text(
+            text = displayText,
+            color = color,
+            fontSize = fontSize,
+            fontWeight = fontWeight,
+            softWrap = false,
+            maxLines = 1,
+        )
+    }
+}
+
+@Composable
+@Preview
+fun PreviewReversedEllipsisText() = ReversedEllipsisText(
+    "src/main/kotlin/com/codymikol/components/commit/diff/file/header/text/FileHeaderText.kt",
+    modifier = Modifier,
+)

--- a/src/test/kotlin/com/codymikol/components/ReversedEllipsisTextSpec.kt
+++ b/src/test/kotlin/com/codymikol/components/ReversedEllipsisTextSpec.kt
@@ -1,0 +1,111 @@
+package com.codymikol.components
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+private val charWidth = 1f
+
+private fun monospaceMeasure(text: String): Float = text.length * charWidth
+
+class ReversedEllipsisTextSpec : DescribeSpec({
+
+    describe("reversedEllipsis") {
+
+        describe("when the text fits within the available width") {
+
+            it("should return the text unchanged") {
+                reversedEllipsis(
+                    text = "short.kt",
+                    maxWidthPx = 20f,
+                    measure = ::monospaceMeasure,
+                ) shouldBe "short.kt"
+            }
+
+        }
+
+        describe("when the text is too long for the available width") {
+
+            val text = "src/main/kotlin/com/codymikol/components/commit/diff/file/header/text/FileHeaderText.kt"
+
+            it("should truncate from the front and prefix with an ellipsis") {
+                val result = reversedEllipsis(
+                    text = text,
+                    maxWidthPx = 20f,
+                    measure = ::monospaceMeasure,
+                )
+
+                result shouldBe ("..." + text.takeLast(17))
+            }
+
+            it("should end with the original text's suffix, preserving the filename") {
+                val result = reversedEllipsis(
+                    text = text,
+                    maxWidthPx = 20f,
+                    measure = ::monospaceMeasure,
+                )
+
+                text.endsWith(result.removePrefix("...")) shouldBe true
+            }
+
+            it("should never exceed the available width") {
+                val result = reversedEllipsis(
+                    text = text,
+                    maxWidthPx = 20f,
+                    measure = ::monospaceMeasure,
+                )
+
+                (monospaceMeasure(result) <= 20f) shouldBe true
+            }
+
+            it("should support a custom ellipsis string") {
+                val result = reversedEllipsis(
+                    text = text,
+                    maxWidthPx = 20f,
+                    measure = ::monospaceMeasure,
+                    ellipsis = "…",
+                )
+
+                result shouldBe ("…" + text.takeLast(19))
+            }
+
+        }
+
+        describe("when even the ellipsis does not fit") {
+
+            it("should return just the ellipsis") {
+                reversedEllipsis(
+                    text = "FileHeaderText.kt",
+                    maxWidthPx = 1f,
+                    measure = ::monospaceMeasure,
+                ) shouldBe "..."
+            }
+
+        }
+
+        describe("when the text is empty") {
+
+            it("should return an empty string") {
+                reversedEllipsis(
+                    text = "",
+                    maxWidthPx = 20f,
+                    measure = ::monospaceMeasure,
+                ) shouldBe ""
+            }
+
+        }
+
+        describe("when the available width is zero") {
+
+            it("should return the text unchanged") {
+                reversedEllipsis(
+                    text = "FileHeaderText.kt",
+                    maxWidthPx = 0f,
+                    measure = ::monospaceMeasure,
+                ) shouldBe "FileHeaderText.kt"
+            }
+
+        }
+
+    }
+
+})


### PR DESCRIPTION
## Summary
- Adds `ReversedEllipsisText`, a Compose component that truncates long text (e.g. file paths) from the *front* and prefixes an ellipsis, keeping the trailing text (e.g. the filename) intact — Compose's built-in `TextOverflow.Ellipsis` only truncates at the end.
- The truncation logic (`reversedEllipsis`) is a pure function (text, available width, a width-measuring function) so it's unit-testable without a Compose UI test harness; the composable wires it to `rememberTextMeasurer()` + `BoxWithConstraints` for real layout measurement.
- Adds `ReversedEllipsisTextSpec` covering: fits-as-is, truncates-and-preserves-suffix, respects available width, custom ellipsis string, ellipsis-doesn't-fit, empty text, and zero width.

Closes #35

## Note for reviewer
This sandbox has no writable Nix store / JDK, so `./gradlew test` could not be run locally (`nix develop` fails with a permission-denied error on `/nix/store`, which is root-owned and read-only here). The new files are plain, straightforward Kotlin/Compose mirroring existing patterns in this repo (e.g. `CommitBottomToolbar.kt`'s `BoxWithConstraints` usage), and I traced the binary-search truncation math by hand against the test cases, but CI is the first real compile/test run — please double check.

## Test plan
- [ ] CI (`./gradlew build`) passes