### PR TITLE
fix: handle directories with no git initialized

### DIFF
--- a/src/main/kotlin/com/codymikol/state/state.kt
+++ b/src/main/kotlin/com/codymikol/state/state.kt
@@ -43,9 +43,29 @@ object GitDownState {
         Git(repo.value)
     }
 
-    val isValidGitDirectory = derivedStateOf { repo.value.branch != null }
+    val isValidGitDirectory = derivedStateOf {
+        if (gitDirectory.value.isBlank()) {
+            false
+        } else {
+            try {
+                repo.value.branch != null
+            } catch (e: Exception) {
+                false
+            }
+        }
+    }
 
-    val branchName = derivedStateOf { repo.value.branch ?: "" }
+    val isInvalidGitDirectorySelected = derivedStateOf {
+        gitDirectory.value.isNotBlank() && !isValidGitDirectory.value
+    }
+
+    val branchName = derivedStateOf {
+        try {
+            repo.value.branch ?: ""
+        } catch (e: Exception) {
+            ""
+        }
+    }
 
     val commitCount = derivedStateOf {
         git.value.getCurrentRefCommitCount()

--- a/src/main/kotlin/com/codymikol/windows/DirectorySelector.kt
+++ b/src/main/kotlin/com/codymikol/windows/DirectorySelector.kt
@@ -162,6 +162,16 @@ fun DirectorySelector(applicationScope: ApplicationScope) =
                 Spacer(modifier = Modifier.height(4.dp))
                 InspirationText()
                 Spacer(modifier = Modifier.height(14.dp))
+                if (GitDownState.isInvalidGitDirectorySelected.value) {
+                    Text(
+                        "Git has not been initialized for the selected directory.",
+                        color = Colors.FileRemoved,
+                        fontSize = 11.sp,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.padding(horizontal = 16.dp)
+                    )
+                    Spacer(modifier = Modifier.height(14.dp))
+                }
                 SelectRepositoryButton()
                 RecentlyOpenedButton {
                     showRecentProjectDropdown.value = !showRecentProjectDropdown.value

--- a/src/test/kotlin/com/codymikol/state/GitDownStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/GitDownStateSpec.kt
@@ -707,5 +707,27 @@ class GitDownStateSpec : DescribeSpec({
 
         }
 
+        describe("isValidGitDirectory") {
+
+            describe("when the selected directory does not have git initialized") {
+
+                autoClose(createTestRepository().transferIntoGitDownState())
+
+                it("should not throw and should report the directory as invalid") {
+                    val validGitDirectory = GitDownState.gitDirectory.value
+
+                    val uninitializedDir = kotlin.io.path.createTempDirectory("git-down-state-test-no-git-")
+                    GitDownState.gitDirectory.value = uninitializedDir.toString() + "/.git"
+
+                    GitDownState.isValidGitDirectory.value shouldBe false
+                    GitDownState.isInvalidGitDirectorySelected.value shouldBe true
+
+                    GitDownState.gitDirectory.value = validGitDirectory
+                }
+
+            }
+
+        }
+
     }
 })


### PR DESCRIPTION
## Summary
- Selecting a directory that has no `.git` initialized threw an uncaught JGit exception (reading `HEAD` via `Repository.getBranch()`), crashing the app.
- `GitDownState.isValidGitDirectory` and `GitDownState.branchName` now catch that failure and treat the directory as invalid instead of propagating the exception.
- Added `GitDownState.isInvalidGitDirectorySelected`, and the directory selector screen now shows "Git has not been initialized for the selected directory." when this happens, instead of crashing.
- Added a test in `GitDownStateSpec` covering selecting a directory with no git initialized.

## Note for reviewer
Could not run `./gradlew build`/tests locally in this sandbox — no JDK is available and `nix develop` fails here because the Nix store is read-only (`NIX_STORE_WRITABLE=false`). CI (`.github/workflows/ci.yml`) runs `./gradlew build` with JDK 21 via `actions/setup-java`, so that's the first real verification of this change; please keep an eye on it.

Closes #103