### PR TITLE
fix(ui): shorten invalid git directory message

### DIFF
--- a/src/main/kotlin/com/codymikol/windows/DirectorySelector.kt
+++ b/src/main/kotlin/com/codymikol/windows/DirectorySelector.kt
@@ -164,7 +164,7 @@ fun DirectorySelector(applicationScope: ApplicationScope) =
                 Spacer(modifier = Modifier.height(14.dp))
                 if (GitDownState.isInvalidGitDirectorySelected.value) {
                     Text(
-                        "Git has not been initialized for the selected directory.",
+                        "Selected directory is not a git repository.",
                         color = Colors.FileRemoved,
                         fontSize = 11.sp,
                         textAlign = TextAlign.Center,


### PR DESCRIPTION
## Summary
- Shortened the "Git has not been initialized for the selected directory." message shown on the home screen when a non-git directory is selected, since it wrapped and broke the viewport.
- New text: "Selected directory is not a git repository." (about half the length, same meaning).

Closes #158

## Test plan
- No JDK/toolchain available in this sandbox to run `./gradlew build` locally; CI provisions JDK 21 and runs the full build/test suite.
- Verified no test or other source asserts the old string text.