### PR TITLE
feat(stash): render stash diff using shared Diff component

### DIFF
--- a/src/main/kotlin/com/codymikol/components/commit/diff/Diff.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/diff/Diff.kt
@@ -1,0 +1,219 @@
+package com.codymikol.components.commit.diff
+
+import androidx.compose.foundation.*
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.dp
+import com.codymikol.components.commit.diff.file.header.FileHeader
+import com.codymikol.data.diff.FileDeltaNode
+import com.codymikol.data.diff.Hunk
+import com.codymikol.data.diff.LineNode
+import com.codymikol.extensions.*
+import com.codymikol.state.Keys
+import com.codymikol.typography.GitDownTypography
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun Diff(fileDeltaNodes: List<FileDeltaNode>, showActions: Boolean = true) {
+    val dragState = remember { DragSelectionState() }
+    val listState = rememberLazyListState()
+    val diffItems by remember(fileDeltaNodes) {
+        derivedStateOf { buildDiffItems(fileDeltaNodes) }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .pointerInput(diffItems, listState) {
+                detectTapGestures { position ->
+                    val lineItem = findLineItemAtPosition(position.y, diffItems, listState) ?: return@detectTapGestures
+                    val fileLines = lineItem.parentFileNode.hunkNodes.map { it.lineNodes }.flatten()
+                    val lineNode = lineItem.lineNode
+                    when {
+                        Keys.isShiftPressed.value -> shiftSelectLine(fileLines, lineNode)
+                        Keys.isCtrlPressed.value -> ctrlSelectLine(lineNode)
+                        else -> unmodifiedLineSelect(fileLines, lineNode)
+                    }
+                }
+            }
+            .pointerInput(diffItems, listState) {
+                detectDragGestures(
+                    onDragStart = { position ->
+                        val lineItem = findLineItemAtPosition(position.y, diffItems, listState) ?: return@detectDragGestures
+                        val fileLines = lineItem.parentFileNode.hunkNodes.map { it.lineNodes }.flatten()
+                        val startIndex = fileLines.indexOf(lineItem.lineNode)
+                        if (startIndex < 0) return@detectDragGestures
+
+                        dragState.isDragging.value = true
+                        dragState.didDrag.value = false
+                        dragState.startIndex.value = startIndex
+                        dragState.activeFileNode.value = lineItem.parentFileNode
+
+                        if (!Keys.isCtrlPressed.value) {
+                            if (!Keys.isShiftPressed.value) {
+                                fileLines.forEach { it.line.selected.value = false }
+                            }
+                            lineItem.lineNode.line.selected.value = true
+                        }
+                    },
+                    onDrag = { change, _ ->
+                        if (!dragState.isDragging.value) return@detectDragGestures
+                        val lineItem = findLineItemAtPosition(change.position.y, diffItems, listState) ?: return@detectDragGestures
+                        if (dragState.activeFileNode.value != lineItem.parentFileNode) return@detectDragGestures
+
+                        val fileLines = lineItem.parentFileNode.hunkNodes.map { it.lineNodes }.flatten()
+                        val startIndex = dragState.startIndex.value ?: return@detectDragGestures
+                        val currentIndex = fileLines.indexOf(lineItem.lineNode)
+                        if (currentIndex < 0) return@detectDragGestures
+
+                        dragState.didDrag.value = true
+                        selectRange(fileLines, startIndex, currentIndex, Keys.isShiftPressed.value)
+                    },
+                    onDragEnd = { dragState.reset() },
+                    onDragCancel = { dragState.reset() }
+                )
+            }
+    ) {
+        LazyColumn(state = listState) {
+            diffItems.forEach { item ->
+                when (item) {
+                    is DiffItem.FileHeaderItem -> stickyHeader { FileHeader(item.fileDeltaNode, showActions = showActions) }
+                    is DiffItem.HunkHeaderItem -> item { HunkHeader(item.hunk) }
+                    is DiffItem.LineItem -> item { DiffLine(item.lineNode) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LineNumberGutter(lineNumber: UInt?) {
+    Row(
+        modifier = Modifier
+            .width(36.dp)
+            .fillMaxHeight()
+    ) {
+        GitDownTypography.LineNumber(lineNumber?.toString() ?: "")
+    }
+}
+
+@Composable
+private fun ModificationTypeGutter(lineNode: LineNode) {
+    Box(modifier = Modifier.width(24.dp).fillMaxSize()) { GitDownTypography.DiffType(lineNode.line.symbol) }
+}
+
+@Composable
+private fun DiffLine(lineNode: LineNode) {
+
+    Box(modifier = Modifier
+        .background(lineNode.line.getBackgroundColor())
+        .fillMaxWidth()
+        .wrapContentHeight()) {
+        Row(modifier = Modifier.fillMaxSize()) {
+            LineNumberGutter(lineNode.line.originalLineNumber)
+            LineNumberGutter(lineNode.line.newLineNumber)
+            ModificationTypeGutter(lineNode)
+
+            val displayLine = lineNode.line.value.replace("\t", "  ")
+
+            GitDownTypography.DiffContent(displayLine, lineNode.line.getTextColor())
+        }
+    }
+}
+
+@Composable
+private fun HunkHeader(hunk: Hunk) {
+    Row(modifier = Modifier.background(Color(8, 8, 8)).fillMaxWidth()) {
+        Spacer(modifier = Modifier.width(86.dp))
+        GitDownTypography.DiffHunkHeader(hunk.delimiter)
+    }
+}
+
+private fun shiftSelectLine(fileLines: List<LineNode>, lineNode: LineNode) {
+    val current = fileLines.indexOf(lineNode)
+    val low = fileLines.indexOfFirstOrNull { it.line.selected.value }
+    val high = fileLines.indexOfLastOrNull { it.line.selected.value }
+    if (null == high || null == low) {
+        unmodifiedLineSelect(fileLines, lineNode)
+    } else {
+        if (current > high) (high until current + 1).forEach { fileLines[it].line.selected.value = true }
+        if (current < low) (current until low).forEach { fileLines[it].line.selected.value = true }
+    }
+}
+
+private fun unmodifiedLineSelect(fileLines: List<LineNode>, lineNode: LineNode) {
+    fileLines.forEach { if (lineNode != it) it.line.selected.value = false }
+    lineNode.line.toggleSelected()
+}
+
+private fun ctrlSelectLine(lineNode: LineNode) {
+    lineNode.line.toggleSelected()
+}
+
+private fun selectRange(fileLines: List<LineNode>, startIndex: Int, endIndex: Int, additive: Boolean) {
+    val low = minOf(startIndex, endIndex)
+    val high = maxOf(startIndex, endIndex)
+
+    if (!additive) {
+        fileLines.forEach { it.line.selected.value = false }
+    }
+
+    (low..high).forEach { fileLines[it].line.selected.value = true }
+}
+
+private class DragSelectionState {
+    val isDragging = mutableStateOf(false)
+    val didDrag = mutableStateOf(false)
+    val startIndex = mutableStateOf<Int?>(null)
+    val activeFileNode = mutableStateOf<FileDeltaNode?>(null)
+
+    fun reset() {
+        isDragging.value = false
+        didDrag.value = false
+        startIndex.value = null
+        activeFileNode.value = null
+    }
+}
+
+private sealed class DiffItem {
+    data class FileHeaderItem(val fileDeltaNode: FileDeltaNode) : DiffItem()
+    data class HunkHeaderItem(val hunk: Hunk) : DiffItem()
+    data class LineItem(val lineNode: LineNode, val parentFileNode: FileDeltaNode) : DiffItem()
+}
+
+private fun buildDiffItems(fileDeltaNodes: List<FileDeltaNode>): List<DiffItem> {
+    val items = ArrayList<DiffItem>()
+    fileDeltaNodes.forEach { fileDeltaNode ->
+        items.add(DiffItem.FileHeaderItem(fileDeltaNode))
+        fileDeltaNode.hunkNodes.forEach { hunkNode ->
+            items.add(DiffItem.HunkHeaderItem(hunkNode.hunk))
+            hunkNode.lineNodes.forEach { lineNode ->
+                items.add(DiffItem.LineItem(lineNode, fileDeltaNode))
+            }
+        }
+    }
+    return items
+}
+
+private fun findLineItemAtPosition(
+    y: Float,
+    diffItems: List<DiffItem>,
+    listState: LazyListState
+): DiffItem.LineItem? {
+    val visibleItem = listState.layoutInfo.visibleItemsInfo.firstOrNull { itemInfo ->
+        val start = itemInfo.offset
+        val end = itemInfo.offset + itemInfo.size
+        y >= start && y < end
+    } ?: return null
+
+    val item = diffItems.getOrNull(visibleItem.index)
+    return item as? DiffItem.LineItem
+}

--- a/src/main/kotlin/com/codymikol/components/commit/diff/file/header/FileHeader.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/diff/file/header/FileHeader.kt
@@ -12,7 +12,7 @@ import com.codymikol.components.commit.diff.file.header.text.FileHeaderText
 import com.codymikol.data.diff.FileDeltaNode
 
 @Composable
-fun FileHeader(fileDeltaNode: FileDeltaNode) = Row(
+fun FileHeader(fileDeltaNode: FileDeltaNode, showActions: Boolean = true) = Row(
     modifier = Modifier.height(32.dp)
         .background(fileDeltaNode.fileDelta.color)
         .fillMaxWidth(),
@@ -36,15 +36,17 @@ fun FileHeader(fileDeltaNode: FileDeltaNode) = Row(
 
         }
 
-        Row(
-            modifier = Modifier.fillMaxHeight().width(140.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.Center
-        ) {
+        if (showActions) {
+            Row(
+                modifier = Modifier.fillMaxHeight().width(140.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center
+            ) {
 
-            FileHeaderActions(fileDeltaNode)
+                FileHeaderActions(fileDeltaNode)
 
-            Spacer(modifier = Modifier.width(6.dp))
+                Spacer(modifier = Modifier.width(6.dp))
+            }
         }
     }
 

--- a/src/main/kotlin/com/codymikol/components/commit/diff/file/header/action/FileHeaderAction.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/diff/file/header/action/FileHeaderAction.kt
@@ -25,6 +25,7 @@ fun FileHeaderActions(fileDeltaNode: FileDeltaNode) = when (fileDeltaNode.isSele
 private fun LineActions(fileDeltaNode: FileDeltaNode) = when (fileDeltaNode.fileDelta.type) {
     Status.WORKING_DIRECTORY -> StageLinesButton(fileDeltaNode)
     Status.INDEX -> UnstageLinesButton(fileDeltaNode)
+    Status.STASH -> Unit
 }
 
 @Composable
@@ -32,6 +33,7 @@ private fun FileActions(fileDeltaNode: FileDeltaNode) = Row(verticalAlignment = 
     when (fileDeltaNode.fileDelta.type) {
         Status.WORKING_DIRECTORY -> StageFileButton(fileDeltaNode)
         Status.INDEX -> UnstageFileButton(fileDeltaNode)
+        Status.STASH -> Unit
     }
     Spacer(modifier = Modifier.width(6.dp))
     FileHeaderCogButton(fileDeltaNode)

--- a/src/main/kotlin/com/codymikol/components/commit/diff/file/header/action/buttons/FileHeaderCogButton.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/diff/file/header/action/buttons/FileHeaderCogButton.kt
@@ -63,6 +63,7 @@ fun FileHeaderCogButton(fileDeltaNode: FileDeltaNode) {
                     FileActionMenuItem("Open File", "index.openFile") { expanded = false }
                     FileActionMenuItem("Show In Files", "index.showInFiles") { expanded = false }
                 }
+                Status.STASH -> Unit
             }
         }
     }

--- a/src/main/kotlin/com/codymikol/data/file/FileDelta.kt
+++ b/src/main/kotlin/com/codymikol/data/file/FileDelta.kt
@@ -42,6 +42,7 @@ interface FileDelta {
         when(this.type) {
             Status.INDEX -> loadIndexDiff(stream)
             Status.WORKING_DIRECTORY -> loadWorkingDirectoryDiff(stream)
+            Status.STASH -> Unit
         }
 
         return stream.toString()

--- a/src/main/kotlin/com/codymikol/data/file/Stash.kt
+++ b/src/main/kotlin/com/codymikol/data/file/Stash.kt
@@ -1,0 +1,33 @@
+package com.codymikol.data.file
+
+import androidx.compose.ui.graphics.Color
+import com.codymikol.data.Colors
+import java.nio.file.Path
+
+object Stash {
+
+    class FileModified(override val location: Path, private val diff: String) : FileDelta {
+        override val letter: String get() = "M"
+        override val color: Color get() = Colors.FileModified
+        override val borderColor: Color get() = Colors.FileModifiedBorder
+        override val type: Status get() = Status.STASH
+        override fun getDiff(): String = diff
+    }
+
+    class FileAdded(override val location: Path, private val diff: String) : FileDelta {
+        override val letter: String get() = "A"
+        override val color: Color get() = Colors.FileAdded
+        override val borderColor: Color get() = Colors.FileAddedBorder
+        override val type: Status get() = Status.STASH
+        override fun getDiff(): String = diff
+    }
+
+    class FileDeleted(override val location: Path, private val diff: String) : FileDelta {
+        override val letter: String get() = "D"
+        override val color: Color get() = Colors.FileRemoved
+        override val borderColor: Color get() = Colors.FileRemovedBorder
+        override val type: Status get() = Status.STASH
+        override fun getDiff(): String = diff
+    }
+
+}

--- a/src/main/kotlin/com/codymikol/data/file/Status.kt
+++ b/src/main/kotlin/com/codymikol/data/file/Status.kt
@@ -2,5 +2,6 @@ package com.codymikol.data.file
 
 enum class Status {
     INDEX,
-    WORKING_DIRECTORY
+    WORKING_DIRECTORY,
+    STASH
 }

--- a/src/main/kotlin/com/codymikol/data/stash/StashListItem.kt
+++ b/src/main/kotlin/com/codymikol/data/stash/StashListItem.kt
@@ -15,6 +15,7 @@ data class StashListItem(
     val description: String,
     val branchOrSha: String,
     val commitMessage: String,
+    val revCommit: RevCommit,
 ) {
 
     val title: String
@@ -53,6 +54,7 @@ data class StashListItem(
                 description = description,
                 branchOrSha = branchOrSha,
                 commitMessage = commitMessage,
+                revCommit = revCommit,
             )
         }
     }

--- a/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
+++ b/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.MutableState
 import com.codymikol.data.diff.FileDeltaNode
 import com.codymikol.data.diff.LineNode
 import com.codymikol.data.diff.LineType
+import com.codymikol.data.file.FileDelta
+import com.codymikol.data.file.Stash
 import com.codymikol.data.file.WorkingDirectory
 import com.codymikol.state.GitDownState
 import kotlinx.coroutines.Dispatchers
@@ -11,6 +13,8 @@ import kotlinx.coroutines.withContext
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.ResetCommand
 import org.eclipse.jgit.api.errors.NoHeadException
+import org.eclipse.jgit.diff.DiffEntry
+import org.eclipse.jgit.diff.DiffFormatter
 import org.eclipse.jgit.dircache.DirCache
 import org.eclipse.jgit.dircache.DirCacheBuildIterator
 import org.eclipse.jgit.dircache.DirCacheEditor
@@ -20,6 +24,7 @@ import org.eclipse.jgit.lib.Constants.OBJ_BLOB
 import org.eclipse.jgit.lib.FileMode
 import org.eclipse.jgit.lib.Repository
 import org.eclipse.jgit.revwalk.RevCommit
+import org.eclipse.jgit.revwalk.RevWalk
 import org.eclipse.jgit.treewalk.FileTreeIterator
 import org.eclipse.jgit.treewalk.NameConflictTreeWalk
 import org.eclipse.jgit.treewalk.TreeWalk.OperationType
@@ -27,10 +32,13 @@ import org.eclipse.jgit.treewalk.WorkingTreeIterator
 import org.eclipse.jgit.treewalk.TreeWalk
 import org.eclipse.jgit.treewalk.filter.PathFilter
 import org.eclipse.jgit.treewalk.filter.PathFilterGroup
+import org.eclipse.jgit.util.io.DisabledOutputStream
 import org.slf4j.LoggerFactory
 import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.io.InputStream
+import java.nio.file.Path
 
 class GitExtensions
 
@@ -55,6 +63,45 @@ fun Git.getCurrentRefCommitCount() = try {
 fun Git.getStashes(): List<RevCommit> = try {
     this.stashList().call().toList()
 } catch (e: Exception) {
+    emptyList()
+}
+
+fun Git.getStashDiff(stash: RevCommit): List<FileDelta> = try {
+    RevWalk(this.repository).use { walk ->
+        val commit = walk.parseCommit(stash)
+
+        when (commit.parentCount > 0) {
+            false -> emptyList()
+            true -> {
+                val parent = walk.parseCommit(commit.getParent(0))
+
+                DiffFormatter(DisabledOutputStream.INSTANCE).use { scanner ->
+                    scanner.setRepository(this.repository)
+                    scanner.scan(parent.tree, commit.tree).map { entry ->
+
+                        val diffText = ByteArrayOutputStream().also { stream ->
+                            DiffFormatter(stream).use { formatter ->
+                                formatter.setRepository(this.repository)
+                                formatter.format(entry)
+                            }
+                        }.toString()
+
+                        val path = Path.of(
+                            if (entry.changeType == DiffEntry.ChangeType.DELETE) entry.oldPath else entry.newPath
+                        )
+
+                        when (entry.changeType) {
+                            DiffEntry.ChangeType.ADD -> Stash.FileAdded(path, diffText)
+                            DiffEntry.ChangeType.DELETE -> Stash.FileDeleted(path, diffText)
+                            else -> Stash.FileModified(path, diffText)
+                        }
+                    }
+                }
+            }
+        }
+    }
+} catch (e: Exception) {
+    logger.error("An exception was thrown while diffing a stash: ${e.message}")
     emptyList()
 }
 

--- a/src/main/kotlin/com/codymikol/state/state.kt
+++ b/src/main/kotlin/com/codymikol/state/state.kt
@@ -8,6 +8,7 @@ import com.codymikol.data.file.Status
 import com.codymikol.data.file.WorkingDirectory
 import com.codymikol.data.stash.StashListItem
 import com.codymikol.extensions.getCurrentRefCommitCount
+import com.codymikol.extensions.getStashDiff
 import com.codymikol.extensions.getStashes
 import com.codymikol.tabs.Tab
 import org.eclipse.jgit.api.Git
@@ -76,6 +77,10 @@ object GitDownState {
     }
 
     val selectedStash = mutableStateOf<StashListItem?>(null)
+
+    val stashDiffTree = derivedStateOf {
+        DiffTree.make(selectedStash.value?.let { git.value.getStashDiff(it.revCommit) } ?: emptyList())
+    }
 
     val committingAsName = derivedStateOf { repo.value.config.getString("user", null, "name") ?: "" }
 
@@ -174,6 +179,7 @@ object GitDownState {
         val siblings = when (current.type) {
             Status.WORKING_DIRECTORY -> workingDirectory.value
             Status.INDEX -> index.value
+            Status.STASH -> emptySet<FileDelta>()
         }.toList()
 
         val currentIndex = siblings.indexOf(current)

--- a/src/main/kotlin/com/codymikol/views/CommitView.kt
+++ b/src/main/kotlin/com/codymikol/views/CommitView.kt
@@ -34,7 +34,7 @@ import com.codymikol.components.Subheader
 import com.codymikol.components.commit.ChangedFile
 import com.codymikol.components.commit.CommitBottomToolbar
 import com.codymikol.components.commit.ConfirmDialog
-import com.codymikol.components.commit.diff.file.header.FileHeader
+import com.codymikol.components.commit.diff.Diff
 import com.codymikol.data.Colors
 import com.codymikol.data.diff.*
 import com.codymikol.data.file.FileDelta
@@ -171,214 +171,15 @@ private fun CommitMessageInput() {
 }
 
 @Composable
-private fun LineNumberGutter(lineNumber: UInt?) {
-    Row(
-        modifier = Modifier
-            .width(36.dp)
-            .fillMaxHeight()
-    ) {
-        GitDownTypography.LineNumber(lineNumber?.toString() ?: "")
-    }
-}
-
-@Composable
-private fun ModificationTypeGutter(lineNode: LineNode) {
-    Box(modifier = Modifier.width(24.dp).fillMaxSize()) { GitDownTypography.DiffType(lineNode.line.symbol) }
-}
-
-@Composable
 private fun DiffPanel() = when(GitDownState.diffTree.value.fileDeltaNodes.size > 0) {
-    true -> Diff()
+    true -> Diff(GitDownState.diffTree.value.fileDeltaNodes)
     false -> Column { EmptyState("No file selected") }
-}
-
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-private fun Diff() {
-    val dragState = remember { DragSelectionState() }
-    val listState = rememberLazyListState()
-    val diffItems by remember(GitDownState.diffTree.value.fileDeltaNodes) {
-        derivedStateOf { buildDiffItems(GitDownState.diffTree.value.fileDeltaNodes) }
-    }
-
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .pointerInput(diffItems, listState) {
-                detectTapGestures { position ->
-                    val lineItem = findLineItemAtPosition(position.y, diffItems, listState) ?: return@detectTapGestures
-                    val fileLines = lineItem.parentFileNode.hunkNodes.map { it.lineNodes }.flatten()
-                    val lineNode = lineItem.lineNode
-                    when {
-                        Keys.isShiftPressed.value -> shiftSelectLine(fileLines, lineNode)
-                        Keys.isCtrlPressed.value -> ctrlSelectLine(lineNode)
-                        else -> unmodifiedLineSelect(fileLines, lineNode)
-                    }
-                }
-            }
-            .pointerInput(diffItems, listState) {
-                detectDragGestures(
-                    onDragStart = { position ->
-                        val lineItem = findLineItemAtPosition(position.y, diffItems, listState) ?: return@detectDragGestures
-                        val fileLines = lineItem.parentFileNode.hunkNodes.map { it.lineNodes }.flatten()
-                        val startIndex = fileLines.indexOf(lineItem.lineNode)
-                        if (startIndex < 0) return@detectDragGestures
-
-                        dragState.isDragging.value = true
-                        dragState.didDrag.value = false
-                        dragState.startIndex.value = startIndex
-                        dragState.activeFileNode.value = lineItem.parentFileNode
-
-                        if (!Keys.isCtrlPressed.value) {
-                            if (!Keys.isShiftPressed.value) {
-                                fileLines.forEach { it.line.selected.value = false }
-                            }
-                            lineItem.lineNode.line.selected.value = true
-                        }
-                    },
-                    onDrag = { change, _ ->
-                        if (!dragState.isDragging.value) return@detectDragGestures
-                        val lineItem = findLineItemAtPosition(change.position.y, diffItems, listState) ?: return@detectDragGestures
-                        if (dragState.activeFileNode.value != lineItem.parentFileNode) return@detectDragGestures
-
-                        val fileLines = lineItem.parentFileNode.hunkNodes.map { it.lineNodes }.flatten()
-                        val startIndex = dragState.startIndex.value ?: return@detectDragGestures
-                        val currentIndex = fileLines.indexOf(lineItem.lineNode)
-                        if (currentIndex < 0) return@detectDragGestures
-
-                        dragState.didDrag.value = true
-                        selectRange(fileLines, startIndex, currentIndex, Keys.isShiftPressed.value)
-                    },
-                    onDragEnd = { dragState.reset() },
-                    onDragCancel = { dragState.reset() }
-                )
-            }
-    ) {
-        LazyColumn(state = listState) {
-            diffItems.forEach { item ->
-                when (item) {
-                    is DiffItem.FileHeaderItem -> stickyHeader { FileHeader(item.fileDeltaNode) }
-                    is DiffItem.HunkHeaderItem -> item { HunkHeader(item.hunk) }
-                    is DiffItem.LineItem -> item { DiffLine(item.lineNode) }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun DiffLine(lineNode: LineNode) {
-
-    //todo(mikol): limit click hitbox to around the gutter area
-
-    Box(modifier = Modifier
-        .background(lineNode.line.getBackgroundColor())
-        .fillMaxWidth()
-        .wrapContentHeight()) {
-        Row(modifier = Modifier.fillMaxSize()) {
-            LineNumberGutter(lineNode.line.originalLineNumber)
-            LineNumberGutter(lineNode.line.newLineNumber)
-            ModificationTypeGutter(lineNode)
-
-            val displayLine = lineNode.line.value.replace("\t", "  ")
-
-            GitDownTypography.DiffContent(displayLine, lineNode.line.getTextColor())
-        }
-    }
-}
-
-private fun shiftSelectLine(fileLines: List<LineNode>, lineNode: LineNode) {
-    val current = fileLines.indexOf(lineNode)
-    val low = fileLines.indexOfFirstOrNull { it.line.selected.value }
-    val high = fileLines.indexOfLastOrNull { it.line.selected.value }
-    if (null == high || null == low) {
-        unmodifiedLineSelect(fileLines, lineNode)
-    } else {
-        if (current > high) (high until current + 1).forEach { fileLines[it].line.selected.value = true }
-        if (current < low) (current until low).forEach { fileLines[it].line.selected.value = true }
-    }
-}
-
-private fun unmodifiedLineSelect(fileLines: List<LineNode>, lineNode: LineNode) {
-    fileLines.forEach { if (lineNode != it) it.line.selected.value = false }
-    lineNode.line.toggleSelected()
-}
-
-private fun ctrlSelectLine(lineNode: LineNode) {
-    lineNode.line.toggleSelected()
-}
-
-private fun selectRange(fileLines: List<LineNode>, startIndex: Int, endIndex: Int, additive: Boolean) {
-    val low = minOf(startIndex, endIndex)
-    val high = maxOf(startIndex, endIndex)
-
-    if (!additive) {
-        fileLines.forEach { it.line.selected.value = false }
-    }
-
-    (low..high).forEach { fileLines[it].line.selected.value = true }
-}
-
-private class DragSelectionState {
-    val isDragging = mutableStateOf(false)
-    val didDrag = mutableStateOf(false)
-    val startIndex = mutableStateOf<Int?>(null)
-    val activeFileNode = mutableStateOf<FileDeltaNode?>(null)
-
-    fun reset() {
-        isDragging.value = false
-        didDrag.value = false
-        startIndex.value = null
-        activeFileNode.value = null
-    }
-}
-
-private sealed class DiffItem {
-    data class FileHeaderItem(val fileDeltaNode: FileDeltaNode) : DiffItem()
-    data class HunkHeaderItem(val hunk: Hunk) : DiffItem()
-    data class LineItem(val lineNode: LineNode, val parentFileNode: FileDeltaNode) : DiffItem()
-}
-
-private fun buildDiffItems(fileDeltaNodes: List<FileDeltaNode>): List<DiffItem> {
-    val items = ArrayList<DiffItem>()
-    fileDeltaNodes.forEach { fileDeltaNode ->
-        items.add(DiffItem.FileHeaderItem(fileDeltaNode))
-        fileDeltaNode.hunkNodes.forEach { hunkNode ->
-            items.add(DiffItem.HunkHeaderItem(hunkNode.hunk))
-            hunkNode.lineNodes.forEach { lineNode ->
-                items.add(DiffItem.LineItem(lineNode, fileDeltaNode))
-            }
-        }
-    }
-    return items
-}
-
-private fun findLineItemAtPosition(
-    y: Float,
-    diffItems: List<DiffItem>,
-    listState: androidx.compose.foundation.lazy.LazyListState
-): DiffItem.LineItem? {
-    val visibleItem = listState.layoutInfo.visibleItemsInfo.firstOrNull { itemInfo ->
-        val start = itemInfo.offset
-        val end = itemInfo.offset + itemInfo.size
-        y >= start && y < end
-    } ?: return null
-
-    val item = diffItems.getOrNull(visibleItem.index)
-    return item as? DiffItem.LineItem
-}
-
-@Composable
-private fun HunkHeader(hunk: Hunk) {
-    Row(modifier = Modifier.background(Color(8, 8, 8)).fillMaxWidth()) {
-        Spacer(modifier = Modifier.width(86.dp))
-        GitDownTypography.DiffHunkHeader(hunk.delimiter)
-    }
 }
 
 private fun getDeltaEmptyStateMessage(status: Status) = when(status) {
     Status.INDEX -> "No changes in index"
     Status.WORKING_DIRECTORY -> "No changes in working directory"
+    Status.STASH -> "No changes in stash"
 }
 
 @Composable

--- a/src/main/kotlin/com/codymikol/views/StashView.kt
+++ b/src/main/kotlin/com/codymikol/views/StashView.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.codymikol.components.Subheader
+import com.codymikol.components.commit.diff.Diff
 import com.codymikol.components.stash.StashRow
 import com.codymikol.data.Colors
 import com.codymikol.state.GitDownState
@@ -72,7 +73,10 @@ private fun ColumnScope.StashList() {
 @Composable
 private fun StashDiffPanel() = when (GitDownState.selectedStash.value) {
     null -> Column { StashEmptyState("No stash selected") }
-    else -> Column { StashEmptyState("Stash diff view coming soon") }
+    else -> when (GitDownState.stashDiffTree.value.fileDeltaNodes.isNotEmpty()) {
+        true -> Diff(GitDownState.stashDiffTree.value.fileDeltaNodes, showActions = false)
+        false -> Column { StashEmptyState("No changes in stash") }
+    }
 }
 
 @Composable

--- a/src/test/kotlin/com/codymikol/extensions/GitExtensions.kt
+++ b/src/test/kotlin/com/codymikol/extensions/GitExtensions.kt
@@ -20,6 +20,7 @@ private fun fileDeltaNodeFor(path: String, status: Status): FileDeltaNode {
     val fileDelta = when (status) {
         Status.WORKING_DIRECTORY -> GitDownState.workingDirectory.value.firstOrNull { it.getPath() == path }
         Status.INDEX -> GitDownState.index.value.firstOrNull { it.getPath() == path }
+        Status.STASH -> null
     }
     fileDelta.shouldNotBeNull()
     GitDownState.selectedFiles.clear()

--- a/src/test/kotlin/com/codymikol/extensions/StashDiffSpec.kt
+++ b/src/test/kotlin/com/codymikol/extensions/StashDiffSpec.kt
@@ -1,0 +1,65 @@
+package com.codymikol.extensions
+
+import com.codymikol.data.diff.LineType
+import com.codymikol.repository.TestRepository.Companion.createTestRepository
+import com.codymikol.state.GitDownState
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+class StashDiffSpec : DescribeSpec({
+
+    describe("Git.getStashDiff") {
+
+        describe("A stash with a single modified file") {
+
+            autoClose(
+                createTestRepository()
+                    .addFile("foo.txt", "one\n")
+                    .stageAll()
+                    .commitAll("init")
+                    .appendToFile("foo.txt", "two\n")
+                    .stashCreate()
+                    .transferIntoGitDownState()
+            )
+
+            val stash = GitDownState.stashes.value.single()
+
+            it("should contain a single file delta") {
+                GitDownState.git.value.getStashDiff(stash.revCommit) shouldHaveSize 1
+            }
+
+            it("should expose the added line through GitDownState.stashDiffTree") {
+                GitDownState.selectedStash.value = stash
+
+                val node = GitDownState.stashDiffTree.value.fileDeltaNodes.single()
+                val addedValues = node.hunkNodes
+                    .flatMap { it.lineNodes }
+                    .filter { it.line.type == LineType.Added }
+                    .map { it.line.value }
+
+                addedValues shouldBe listOf("two")
+            }
+
+        }
+
+        describe("No stash selected") {
+
+            autoClose(
+                createTestRepository()
+                    .addFile("init.txt", "init")
+                    .stageAll()
+                    .commitAll("init")
+                    .transferIntoGitDownState()
+            )
+
+            it("should produce an empty diff tree") {
+                GitDownState.selectedStash.value = null
+                GitDownState.stashDiffTree.value.fileDeltaNodes shouldHaveSize 0
+            }
+
+        }
+
+    }
+
+})


### PR DESCRIPTION
## Summary
- Extracts the file-header/hunk/line diff rendering out of `CommitView` into a standalone, reusable `Diff` composable (`components/commit/diff/Diff.kt`) that takes a `fileDeltaNodes` list and a `showActions` flag.
- Adds `Status.STASH`, a `Stash` `FileDelta` implementation (diff text precomputed rather than read live from the working tree/index), and `Git.getStashDiff()`, which diffs a stash commit's tree against its parent via JGit's `DiffFormatter`.
- Wires the result into a new `GitDownState.stashDiffTree` derived state, and replaces the stash view's "coming soon" placeholder with the shared `Diff` component, hiding the stage/unstage/cog controls (`showActions = false`) since stash entries aren't stageable.
- `StashListItem` now carries the underlying `RevCommit` so the diff can be looked up for the selected stash.

Adding `Status.STASH` required a no-op branch in a few pre-existing exhaustive `when` blocks over `Status` (line/file action buttons, empty-state messages, keyboard file navigation) — none of these paths are reachable from the stash view today.

## Test plan
- [ ] `./gradlew build` (CI)
- Added `StashDiffSpec` covering `Git.getStashDiff` and `GitDownState.stashDiffTree` for a modified-file stash and the no-selection case.

Note for reviewers: this sandbox has no JDK available, so I could not run `./gradlew build`/tests locally before pushing — please rely on CI for the build/test gate.

Closes #157