### PR TITLE
feat(git): implement discardFile working directory revert

### DIFF
--- a/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
+++ b/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
@@ -36,6 +36,7 @@ import org.eclipse.jgit.util.io.DisabledOutputStream
 import org.slf4j.LoggerFactory
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.File
 import java.io.IOException
 import java.io.InputStream
 import java.nio.file.Path
@@ -125,8 +126,18 @@ suspend fun Git.stageAll(): Git = command {
 
 }
 
-suspend fun Git.discardFile(location: String): Git = command {
-    TODO()
+suspend fun Git.discardFile(fileDeltaNode: FileDeltaNode): Git = command {
+    val path = fileDeltaNode.getPath()
+
+    when (fileDeltaNode.fileDelta) {
+        // untracked files aren't in the index, so there is nothing for jgit's
+        // checkout command to restore them from. Deleting is the only revert.
+        is WorkingDirectory.FileAdded -> File(this@discardFile.repository.workTree, path).delete()
+        // path-limited checkout returns a null Ref (only branch checkouts return one),
+        // so chaining .unit() here would force a non-null check and NPE on that null.
+        else -> this@discardFile.checkout().addPath(path).call()
+    }
+        .also { logger.info("Discarding changes to $path") }
 }
 
 suspend fun Git.unstageLines(lines: List<LineNode>): Git = command {

--- a/src/test/kotlin/com/codymikol/extensions/GitExtensions.kt
+++ b/src/test/kotlin/com/codymikol/extensions/GitExtensions.kt
@@ -12,6 +12,7 @@ import com.codymikol.state.GitDownState
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import java.io.File
 import java.nio.file.Path
 
 private fun content(lines: List<String>) = lines.joinToString("\n", postfix = "\n")
@@ -447,6 +448,85 @@ class GitExtensions : DescribeSpec({
         describe("Unstaging a few lines between two hunks") {
 
 
+
+        }
+
+    }
+
+    describe("discardFile") {
+
+        describe("Discarding changes to a modified tracked file") {
+
+            val repo = autoClose(
+                createTestRepository()
+                    .addFile("foo.txt", "original\n")
+                    .stageAll()
+                    .commitAll("init")
+                    .addFile("foo.txt", "changed\n")
+                    .transferIntoGitDownState()
+            )
+
+            val workingNode = fileDeltaNodeFor("foo.txt", Status.WORKING_DIRECTORY)
+
+            GitDownState.git.value.discardFile(workingNode)
+
+            it("should restore the file's committed content on disk") {
+                File(repo.dir.toString(), "foo.txt").readText() shouldBe "original\n"
+            }
+
+            it("should no longer report the file as changed") {
+                GitDownState.workingDirectory.value.any { it.getPath() == "foo.txt" } shouldBe false
+            }
+
+        }
+
+        describe("Discarding a newly added untracked file") {
+
+            val repo = autoClose(
+                createTestRepository()
+                    .addFile("init.txt", "init")
+                    .stageAll()
+                    .commitAll("init")
+                    .addFile("new.txt", "new content\n")
+                    .transferIntoGitDownState()
+            )
+
+            val workingNode = fileDeltaNodeFor("new.txt", Status.WORKING_DIRECTORY)
+
+            GitDownState.git.value.discardFile(workingNode)
+
+            it("should delete the file from disk") {
+                File(repo.dir.toString(), "new.txt").exists() shouldBe false
+            }
+
+            it("should no longer report the file in the working directory") {
+                GitDownState.workingDirectory.value.any { it.getPath() == "new.txt" } shouldBe false
+            }
+
+        }
+
+        describe("Discarding a deleted tracked file") {
+
+            val repo = autoClose(
+                createTestRepository()
+                    .addFile("foo.txt", "original\n")
+                    .stageAll()
+                    .commitAll("init")
+                    .deleteFile("foo.txt")
+                    .transferIntoGitDownState()
+            )
+
+            val workingNode = fileDeltaNodeFor("foo.txt", Status.WORKING_DIRECTORY)
+
+            GitDownState.git.value.discardFile(workingNode)
+
+            it("should restore the file's committed content on disk") {
+                File(repo.dir.toString(), "foo.txt").readText() shouldBe "original\n"
+            }
+
+            it("should no longer report the file as missing") {
+                GitDownState.workingDirectory.value.any { it.getPath() == "foo.txt" } shouldBe false
+            }
 
         }
 


### PR DESCRIPTION
## Summary
- Implement `Git.discardFile(fileDeltaNode: FileDeltaNode)` in `GitExtensions.kt`, replacing the `TODO()` stub.
- Modified/deleted tracked files are restored via jgit's `checkout().addPath(...)`, which repopulates the working tree from the index — the same primitive `discardAllWorkingDirectory` already uses, scoped to a single path (least-effort jgit approach per the issue).
- Untracked (newly added) files have no index entry to restore from, so they're deleted from disk instead.
- Not wired to any button yet, per the issue — this is service-level only.

## Test plan
- Added `describe("discardFile")` coverage in `src/test/kotlin/com/codymikol/extensions/GitExtensions.kt` for: reverting a modified tracked file, deleting an untracked added file, and restoring a deleted tracked file.
- Could not run `./gradlew test` locally — this sandbox has no JDK and a read-only Nix store, so the toolchain can't be fetched. CI (`actions/setup-java` + `./gradlew build`) will exercise the full suite.

Closes #152