### PR TITLE
feat(services): add DiffToolService to launch external diff tools

### DIFF
--- a/src/main/kotlin/com/codymikol/Main.kt
+++ b/src/main/kotlin/com/codymikol/Main.kt
@@ -2,6 +2,7 @@ package com.codymikol// Copyright 2000-2021 JetBrains s.r.o. and contributors. U
 import androidx.compose.ui.window.application
 import com.codymikol.config.BeansModule
 import com.codymikol.config.RepositoriesModule
+import com.codymikol.config.ServicesModule
 import org.koin.core.context.startKoin
 import org.koin.ksp.generated.module
 
@@ -17,6 +18,7 @@ fun main(args: Array<String>) = application {
         modules(
             RepositoriesModule().module,
             BeansModule().module,
+            ServicesModule().module,
         )
     }
     App(this)

--- a/src/main/kotlin/com/codymikol/config/ServicesModule.kt
+++ b/src/main/kotlin/com/codymikol/config/ServicesModule.kt
@@ -1,0 +1,8 @@
+package com.codymikol.config
+
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+
+@Module
+@ComponentScan("com.codymikol.services")
+class ServicesModule

--- a/src/main/kotlin/com/codymikol/services/DiffToolService.kt
+++ b/src/main/kotlin/com/codymikol/services/DiffToolService.kt
@@ -1,0 +1,49 @@
+package com.codymikol.services
+
+import com.codymikol.data.file.FileDelta
+import com.codymikol.data.file.Status
+import com.codymikol.state.GitDownState
+import org.koin.core.annotation.Single
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.io.File
+
+@Single
+class DiffToolService {
+
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(DiffToolService::class.java)
+    }
+
+    internal var launchProcess: (List<String>, File) -> Process = { command, workingDirectory ->
+        ProcessBuilder(command).directory(workingDirectory).start()
+    }
+
+    fun getConfiguredDiffTool(): String? = GitDownState.repo.value.config.getString("diff", null, "tool")
+
+    fun buildDiffToolCommand(fileDelta: FileDelta): List<String> {
+        val command = mutableListOf("git", "difftool", "-y")
+        getConfiguredDiffTool()?.let { command.addAll(listOf("-t", it)) }
+        if (fileDelta.type == Status.INDEX) command.add("--cached")
+        command.add("--")
+        command.add(fileDelta.getPath())
+        return command
+    }
+
+    fun launchDiffTool(fileDelta: FileDelta) {
+        if (fileDelta.type == Status.STASH) {
+            logger.warn("Launching an external diff tool for a stashed file is not currently supported")
+            return
+        }
+
+        val command = buildDiffToolCommand(fileDelta)
+
+        try {
+            launchProcess(command, GitDownState.repo.value.workTree)
+            logger.info("Launched diff tool for ${fileDelta.getPath()}: ${command.joinToString(" ")}")
+        } catch (e: Exception) {
+            logger.error("Failed to launch diff tool for ${fileDelta.getPath()}: ${e.message}")
+        }
+    }
+
+}

--- a/src/test/kotlin/com/codymikol/services/DiffToolServiceSpec.kt
+++ b/src/test/kotlin/com/codymikol/services/DiffToolServiceSpec.kt
@@ -1,0 +1,104 @@
+package com.codymikol.services
+
+import com.codymikol.data.file.Index
+import com.codymikol.data.file.Stash
+import com.codymikol.data.file.WorkingDirectory
+import com.codymikol.repository.TestRepository.Companion.createTestRepository
+import com.codymikol.state.GitDownState
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.io.File
+import java.nio.file.Path
+
+class DiffToolServiceSpec : DescribeSpec({
+
+    describe("DiffToolService.getConfiguredDiffTool") {
+
+        it("returns null when no diff tool is configured") {
+            autoClose(createTestRepository().transferIntoGitDownState())
+
+            DiffToolService().getConfiguredDiffTool() shouldBe null
+        }
+
+        it("returns the diff.tool value configured in the repository's gitconfig") {
+            autoClose(createTestRepository().transferIntoGitDownState())
+
+            GitDownState.repo.value.config.setString("diff", null, "tool", "meld")
+            GitDownState.repo.value.config.save()
+
+            DiffToolService().getConfiguredDiffTool() shouldBe "meld"
+        }
+
+    }
+
+    describe("DiffToolService.buildDiffToolCommand") {
+
+        it("builds a working directory diff command without --cached") {
+            autoClose(createTestRepository().transferIntoGitDownState())
+
+            val command = DiffToolService().buildDiffToolCommand(WorkingDirectory.FileModified(Path.of("foo.txt")))
+
+            command shouldBe listOf("git", "difftool", "-y", "--", "foo.txt")
+        }
+
+        it("builds an index diff command with --cached") {
+            autoClose(createTestRepository().transferIntoGitDownState())
+
+            val command = DiffToolService().buildDiffToolCommand(Index.FileModified(Path.of("foo.txt")))
+
+            command shouldBe listOf("git", "difftool", "-y", "--cached", "--", "foo.txt")
+        }
+
+        it("includes the configured diff tool via -t when one is set") {
+            autoClose(createTestRepository().transferIntoGitDownState())
+
+            GitDownState.repo.value.config.setString("diff", null, "tool", "kdiff3")
+            GitDownState.repo.value.config.save()
+
+            val command = DiffToolService().buildDiffToolCommand(WorkingDirectory.FileModified(Path.of("foo.txt")))
+
+            command shouldBe listOf("git", "difftool", "-y", "-t", "kdiff3", "--", "foo.txt")
+        }
+
+    }
+
+    describe("DiffToolService.launchDiffTool") {
+
+        it("launches the built command in the repository's working tree") {
+            autoClose(createTestRepository().transferIntoGitDownState())
+
+            var launchedCommand: List<String>? = null
+            var launchedDirectory: File? = null
+
+            val service = DiffToolService()
+            service.launchProcess = { command, workingDirectory ->
+                launchedCommand = command
+                launchedDirectory = workingDirectory
+                ProcessBuilder("true").start()
+            }
+
+            service.launchDiffTool(WorkingDirectory.FileModified(Path.of("foo.txt")))
+
+            launchedCommand shouldBe listOf("git", "difftool", "-y", "--", "foo.txt")
+            launchedDirectory shouldBe GitDownState.repo.value.workTree
+        }
+
+        it("does not attempt to launch a diff tool for a stashed file") {
+            autoClose(createTestRepository().transferIntoGitDownState())
+
+            var wasLaunched = false
+
+            val service = DiffToolService()
+            service.launchProcess = { command, workingDirectory ->
+                wasLaunched = true
+                ProcessBuilder("true").start()
+            }
+
+            service.launchDiffTool(Stash.FileModified(Path.of("foo.txt"), "diff"))
+
+            wasLaunched shouldBe false
+        }
+
+    }
+
+})


### PR DESCRIPTION
## Summary
- Adds `DiffToolService` (`com.codymikol.services`), the first class in a new service-layer package mirroring the existing `repositories` Koin pattern.
- Reads `diff.tool` from the active repository's gitconfig (via JGit's `StoredConfig`, same mechanism already used for `user.name`/`user.email`) and shells out to `git difftool -y [--cached] -- <path>` for a given `FileDelta`, letting git itself resolve/launch the configured (or default) tool.
- `--cached` is added for `Status.INDEX` deltas so the comparison matches `git diff --cached`; `Status.WORKING_DIRECTORY` compares like plain `git diff`. `Status.STASH` deltas are not launched (logged and no-op) since stash diffing isn't wired yet.
- Registered via a new `ServicesModule` Koin module (`@ComponentScan("com.codymikol.services")`), added alongside the existing `RepositoriesModule`/`BeansModule` in `Main.kt`.
- The actual process launch is behind an internal, test-overridable `launchProcess` field (no interfaces/mocking library in this codebase, so this follows the existing convention of plain injectable fields) so tests can assert the built command/working directory without spawning a real external diff tool.
- Per the issue, this is service-layer only — the "View in Diff Tool" menu item (`FileHeaderCogButton.kt`) is intentionally left as its existing `logger.info("todo: ...")` stub; wiring it up is a follow-up.

## Test plan
- [ ] `./gradlew test` (CI) — added `DiffToolServiceSpec` covering: no-config default, reading a configured `diff.tool`, command building for working-directory vs. index deltas (`--cached` presence), `-t <tool>` inclusion, launching in the repo's work tree, and skipping launch for stash deltas.
- Note: this sandbox has no JDK/toolchain available (nix store is read-only, no network-fetchable JDK), so the suite was not run locally — CI (ubuntu-latest + JDK 21 via `actions/setup-java`) is the first place this actually executes.

Closes #150