### PR TITLE
feat(git): add service layer for deleting a file

### DIFF
--- a/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
+++ b/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
@@ -36,6 +36,7 @@ import org.eclipse.jgit.util.io.DisabledOutputStream
 import org.slf4j.LoggerFactory
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.File
 import java.io.IOException
 import java.io.InputStream
 import java.nio.file.Path
@@ -127,6 +128,14 @@ suspend fun Git.stageAll(): Git = command {
 
 suspend fun Git.discardFile(location: String): Git = command {
     TODO()
+}
+
+// Deletes a file from the working directory. Intended for new files with only
+// additions, where there is no committed version for git to check out back to.
+suspend fun Git.deleteFile(location: String): Git = command {
+    File(this@deleteFile.repository.workTree, location)
+        .delete()
+        .also { logger.info("Deleting file $location") }
 }
 
 suspend fun Git.unstageLines(lines: List<LineNode>): Git = command {

--- a/src/test/kotlin/com/codymikol/extensions/DeleteFileSpec.kt
+++ b/src/test/kotlin/com/codymikol/extensions/DeleteFileSpec.kt
@@ -1,0 +1,54 @@
+package com.codymikol.extensions
+
+import com.codymikol.repository.TestRepository.Companion.createTestRepository
+import com.codymikol.state.GitDownState
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.io.File
+
+class DeleteFileSpec : DescribeSpec({
+
+    describe("Git.deleteFile") {
+
+        describe("Deleting a new, untracked file") {
+
+            val repository = createTestRepository()
+                .addFile("init.txt", "init")
+                .stageAll()
+                .commitAll("init")
+                .addFile("new-file.txt", "one\n")
+                .transferIntoGitDownState()
+
+            autoClose(repository)
+
+            GitDownState.git.value.deleteFile("new-file.txt")
+
+            it("should remove the file from disk") {
+                File(repository.dir.toString(), "new-file.txt").exists() shouldBe false
+            }
+
+            it("should no longer report the file as untracked") {
+                GitDownState.untracked.value.contains("new-file.txt") shouldBe false
+            }
+
+        }
+
+        describe("Deleting a file that does not exist") {
+
+            val repository = createTestRepository()
+                .addFile("init.txt", "init")
+                .stageAll()
+                .commitAll("init")
+                .transferIntoGitDownState()
+
+            autoClose(repository)
+
+            it("should not throw") {
+                GitDownState.git.value.deleteFile("missing.txt")
+            }
+
+        }
+
+    }
+
+})


### PR DESCRIPTION
## Summary
- Add `Git.deleteFile(location: String)` to `GitExtensions.kt`, a service-layer function that deletes a file from the working tree on disk (via `File(repository.workTree, location).delete()`), wrapped in the existing `command {}` helper so UI state refreshes afterward.
- This targets new/untracked files with only additions — there is no committed version for git to check out back to, so `discardFile`/`checkout` can't help; a plain filesystem delete is required.
- Per the issue, this is service-layer only. The "Delete File" cog menu item in `FileHeaderCogButton.kt` already exists but is intentionally left unwired (still logs `todo: workingDirectory.deleteFile`) — wiring it up is a future update.
- Added `DeleteFileSpec.kt` covering: deleting an untracked file removes it from disk and from `GitDownState.untracked`, and deleting a non-existent file does not throw.

Closes #151

## Note for reviewer
Could not run `./gradlew test` locally — this sandbox has no JDK and no network egress, and the pinned devShell (`temurin-bin-21`) can't be fetched because the Nix store here is read-only. CI provisions Java via `actions/setup-java`, so this PR's CI run is the first real compile/test verification.

## Test plan
- [ ] CI green (`./gradlew build`, includes `DeleteFileSpec`)