### PR TITLE
fix(commit): justify bottom toolbar and hide items on shrink

### DIFF
--- a/src/main/kotlin/com/codymikol/components/commit/CommitBottomToolbar.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/CommitBottomToolbar.kt
@@ -82,12 +82,25 @@ fun CommitBottomToolbar(
     val unstageWidth = 100.dp
     val commitWidth = 100.dp
     val amendCheckboxWidth = 50.dp
-    val amendTextWidth = 80.dp
+    val amendHeadTextWidth = 80.dp
+    val amendOnlyTextWidth = 50.dp
     val committingAsWidth = 90.dp
+    val onBranchWidth = 70.dp
+    val usernameWidth = 100.dp
 
-        val totalFixedWidth = unstageWidth + commitWidth + amendTextWidth + amendCheckboxWidth + committingAsWidth
+        val fullWidth = unstageWidth + commitWidth + amendCheckboxWidth + amendHeadTextWidth +
+            committingAsWidth + onBranchWidth + usernameWidth
 
-        val showComittingAs = constraints.maxWidth > totalFixedWidth
+        val showComittingAs = constraints.maxWidth > fullWidth
+        val widthWithoutCommittingAs = fullWidth - committingAsWidth
+
+        val showOnBranch = constraints.maxWidth > widthWithoutCommittingAs
+        val widthWithoutOnBranch = widthWithoutCommittingAs - onBranchWidth
+
+        val showAmendHeadSuffix = constraints.maxWidth > widthWithoutOnBranch
+        val widthWithoutAmendHeadSuffix = widthWithoutOnBranch - (amendHeadTextWidth - amendOnlyTextWidth)
+
+        val showUsername = constraints.maxWidth > widthWithoutAmendHeadSuffix
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -95,18 +108,23 @@ fun CommitBottomToolbar(
         modifier = Modifier.background(color = Colors.LightGrayBackground).fillMaxWidth().requiredHeight(48.dp)
             .padding(10.dp)
     ) {
-        SlimButton("Unstage All", onClick = {
-            scope.launch {
-                GitDownState.git.value.unstageAll()
-                GitDownState.selectedFiles.clear()
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            SlimButton("Unstage All", onClick = {
+                scope.launch {
+                    GitDownState.git.value.unstageAll()
+                    GitDownState.selectedFiles.clear()
+                }
+            })
+
+            if(showComittingAs) RegularText("Commiting as ", modifier = Modifier.requiredWidth(committingAsWidth))
+            if(showUsername) {
+                BoldText("$committingAsName <$committingAsEmail> ")
+            } else {
+                BoldText("$committingAsEmail ")
             }
-        })
-
-
-        if(showComittingAs) RegularText("Commiting as ", modifier = Modifier.requiredWidth(committingAsWidth))
-        BoldText("$committingAsName <$committingAsEmail> ")
-        RegularText(getObjectNamePrefix(isDetachedHead))
-        BoldText(getObjectName(isDetachedHead, branchName), modifier = Modifier.widthIn(max = 100.dp, min = 100.dp))
+            if(showOnBranch) RegularText(getObjectNamePrefix(isDetachedHead))
+            BoldText(getObjectName(isDetachedHead, branchName), modifier = Modifier.widthIn(max = 100.dp, min = 100.dp))
+        }
 
         Row(verticalAlignment = Alignment.CenterVertically) {
             Checkbox(
@@ -114,8 +132,9 @@ fun CommitBottomToolbar(
                 checked = amendEnabled.value,
                 onCheckedChange = { toggleAmendHead() })
             Text(
-                modifier = Modifier.padding(0.dp, 0.dp, 12.dp, 0.dp).requiredWidth(80.dp),
-                text = "Amend Head",
+                modifier = Modifier.padding(0.dp, 0.dp, 12.dp, 0.dp)
+                    .requiredWidth(if (showAmendHeadSuffix) amendHeadTextWidth else amendOnlyTextWidth),
+                text = if (showAmendHeadSuffix) "Amend Head" else "Amend",
                 fontSize = 12.sp,
                 color = Color.White,
                 overflow = TextOverflow.Ellipsis,


### PR DESCRIPTION
## Summary
- Split the commit bottom toolbar into a left-aligned group (Unstage All, Committing As, branch) and a right-aligned group (Amend checkbox, Amend Head label, Commit button) instead of spreading all items evenly.
- Added progressive hide-on-shrink behavior, in priority order: "Commiting as" label → "on branch"/"on detached" prefix → " Head" suffix (leaving just "Amend") → the committing-as username (dropping the `<` / `>` around the email once the name is removed).

Closes #155

## Notes for reviewer
Could not run the Kotlin/Gradle build locally in this sandbox — no JDK is present and `nix develop` fails with a read-only Nix store (`Permission denied` on the flake's local-source lock file), unrelated to this change. CI (`.github/workflows/ci.yml`) runs `./gradlew build` with JDK 21 and will validate compilation.