### PR TITLE
fix(menu): share dropdown color scheme across cog and repo menus

### DIFF
--- a/src/main/kotlin/com/codymikol/components/commit/diff/file/header/action/buttons/FileHeaderCogButton.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/diff/file/header/action/buttons/FileHeaderCogButton.kt
@@ -1,14 +1,11 @@
 package com.codymikol.components.commit.diff.file.header.action.buttons
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.Divider
-import androidx.compose.material.DropdownMenu
-import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -17,11 +14,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.codymikol.components.commit.diff.file.header.colors.HeaderButtonColors
-import com.codymikol.data.Colors
+import com.codymikol.components.menu.MenuColors
+import com.codymikol.components.menu.ThemedDropdownMenu
+import com.codymikol.components.menu.ThemedDropdownMenuItem
 import com.codymikol.data.diff.FileDeltaNode
 import com.codymikol.data.file.Status
 import org.slf4j.LoggerFactory
@@ -43,23 +41,22 @@ fun FileHeaderCogButton(fileDeltaNode: FileDeltaNode) {
             Text("⚙", fontSize = 10.sp)
         }
 
-        DropdownMenu(
+        ThemedDropdownMenu(
             expanded = expanded,
-            onDismissRequest = { expanded = false },
-            modifier = Modifier.background(Colors.DarkGrayBackground)
+            onDismissRequest = { expanded = false }
         ) {
             when (fileDeltaNode.fileDelta.type) {
                 Status.WORKING_DIRECTORY -> {
                     FileActionMenuItem("View in Diff Tool", "workingDirectory.viewInDiffTool") { expanded = false }
-                    Divider(color = Colors.DisabledGray)
+                    Divider(color = MenuColors.Divider)
                     FileActionMenuItem("Open File", "workingDirectory.openFile") { expanded = false }
                     FileActionMenuItem("Show In Files", "workingDirectory.showInFiles") { expanded = false }
-                    Divider(color = Colors.DisabledGray)
+                    Divider(color = MenuColors.Divider)
                     FileActionMenuItem("Delete File", "workingDirectory.deleteFile") { expanded = false }
                 }
                 Status.INDEX -> {
                     FileActionMenuItem("View in Diff Tool", "index.viewInDiffTool") { expanded = false }
-                    Divider(color = Colors.DisabledGray)
+                    Divider(color = MenuColors.Divider)
                     FileActionMenuItem("Open File", "index.openFile") { expanded = false }
                     FileActionMenuItem("Show In Files", "index.showInFiles") { expanded = false }
                 }
@@ -70,9 +67,10 @@ fun FileHeaderCogButton(fileDeltaNode: FileDeltaNode) {
 }
 
 @Composable
-private fun FileActionMenuItem(label: String, actionId: String, onSelect: () -> Unit) = DropdownMenuItem(onClick = {
-    logger.info("todo: $actionId")
-    onSelect()
-}) {
-    Text(label, color = Color.White, fontSize = 12.sp)
-}
+private fun FileActionMenuItem(label: String, actionId: String, onSelect: () -> Unit) = ThemedDropdownMenuItem(
+    label = label,
+    onClick = {
+        logger.info("todo: $actionId")
+        onSelect()
+    }
+)

--- a/src/main/kotlin/com/codymikol/components/menu/MenuColors.kt
+++ b/src/main/kotlin/com/codymikol/components/menu/MenuColors.kt
@@ -1,0 +1,11 @@
+package com.codymikol.components.menu
+
+import androidx.compose.ui.graphics.Color
+import com.codymikol.data.Colors
+
+object MenuColors {
+    val Background = Colors.LightGrayBackground
+    val Highlight = Colors.DisabledGray
+    val Divider = Colors.MediumGrayBackground
+    val Text = Color.White
+}

--- a/src/main/kotlin/com/codymikol/components/menu/ThemedDropdownMenu.kt
+++ b/src/main/kotlin/com/codymikol/components/menu/ThemedDropdownMenu.kt
@@ -1,0 +1,49 @@
+package com.codymikol.components.menu
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun ThemedDropdownMenu(
+    expanded: Boolean,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit
+) = DropdownMenu(
+    expanded = expanded,
+    onDismissRequest = onDismissRequest,
+    modifier = modifier
+        .background(MenuColors.Background)
+        .border(1.dp, MenuColors.Divider),
+    content = content
+)
+
+@Composable
+fun ThemedDropdownMenuItem(
+    label: String,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isHovered by interactionSource.collectIsHoveredAsState()
+
+    DropdownMenuItem(
+        onClick = onClick,
+        interactionSource = interactionSource,
+        modifier = modifier.background(if (isHovered) MenuColors.Highlight else MenuColors.Background)
+    ) {
+        Text(label, color = MenuColors.Text, fontSize = 12.sp)
+    }
+}

--- a/src/main/kotlin/com/codymikol/windows/DirectorySelector.kt
+++ b/src/main/kotlin/com/codymikol/windows/DirectorySelector.kt
@@ -7,8 +7,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.window.WindowDraggableArea
-import androidx.compose.material.DropdownMenu
-import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
@@ -24,6 +22,8 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.*
+import com.codymikol.components.menu.ThemedDropdownMenu
+import com.codymikol.components.menu.ThemedDropdownMenuItem
 import com.codymikol.data.Colors
 import com.codymikol.data.recent.RecentProject
 import com.codymikol.data.recent.RecentProjects
@@ -68,28 +68,26 @@ fun RecentProjectSelector(x: Int, y: Int, closeHandler: () -> Unit, recent: Rece
             isResizable = false
             isVisible = true
             setContent {
-                DropdownMenu(
-                    modifier = Modifier.background(Color.Transparent).fillMaxWidth(),
+                ThemedDropdownMenu(
+                    modifier = Modifier.fillMaxWidth(),
                     expanded = true,
                     onDismissRequest = {}) {
                     recent.projects.forEach {
-                        DropdownMenuItem(modifier = Modifier.fillMaxWidth(), onClick = {
-                            try { 
+                        ThemedDropdownMenuItem(label = it.name, modifier = Modifier.fillMaxWidth(), onClick = {
+                            try {
                               println("Handling directory selection")
-                              handleDirectorySelection(it.location) 
+                              handleDirectorySelection(it.location)
                               println("Done handling directory selection")
                             }
                             catch(e: Exception) {
                               println("Error selecting directory: $e")
-                              e.printStackTrace() 
+                              e.printStackTrace()
                             }
                             finally {
                               println("Closing recent project selector")
                               closeHandler()
                             }
-                        }) {
-                            Text(it.name)
-                        }
+                        })
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- The file-header cog dropdown (Working Directory / Index file actions) hardcoded `Colors.DarkGrayBackground` + white text, independent from the repository-selection ("Recently Opened...") dropdown, so the two menus looked inconsistent.
- Added `com.codymikol.components.menu.MenuColors`, a shared color palette (background/highlight/divider/text) built from the existing `Colors` object.
- Added `ThemedDropdownMenu` / `ThemedDropdownMenuItem` composables that apply this palette consistently, including a real hover/highlight state (tracked via `MutableInteractionSource`/`collectIsHoveredAsState`) which neither dropdown had before.
- Refactored `FileHeaderCogButton.kt` and `DirectorySelector.kt`'s `RecentProjectSelector` to use these shared composables instead of raw `DropdownMenu`/`DropdownMenuItem`, so future menus can reuse the same theming.

Closes #156

## Note for reviewers
This sandbox had no working local Kotlin/Gradle toolchain (`nix develop` fails on an unrelated pre-existing issue — the `spindrift` flake module reads `prompts/issue-prompt.md`, which isn't present in this checkout — and there's no baked JDK/network package manager available either), so I could not run `./gradlew build` locally. I hand-verified the Compose API usage (`DropdownMenu`'s `content` requires a `ColumnScope` receiver, `DropdownMenuItem` accepts `interactionSource`, etc.) and will watch the GitHub Actions CI run (which sets up JDK 21 directly, independent of the flake) as the real gate.