### PR TITLE
feat: implement Show in Files service

### DIFF
--- a/src/main/kotlin/com/codymikol/Main.kt
+++ b/src/main/kotlin/com/codymikol/Main.kt
@@ -2,6 +2,7 @@ package com.codymikol// Copyright 2000-2021 JetBrains s.r.o. and contributors. U
 import androidx.compose.ui.window.application
 import com.codymikol.config.BeansModule
 import com.codymikol.config.RepositoriesModule
+import com.codymikol.config.ServicesModule
 import org.koin.core.context.startKoin
 import org.koin.ksp.generated.module
 
@@ -17,6 +18,7 @@ fun main(args: Array<String>) = application {
         modules(
             RepositoriesModule().module,
             BeansModule().module,
+            ServicesModule().module,
         )
     }
     App(this)

--- a/src/main/kotlin/com/codymikol/config/ServicesModule.kt
+++ b/src/main/kotlin/com/codymikol/config/ServicesModule.kt
@@ -1,0 +1,8 @@
+package com.codymikol.config
+
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+
+@Module
+@ComponentScan("com.codymikol.services")
+class ServicesModule

--- a/src/main/kotlin/com/codymikol/services/FileSystemService.kt
+++ b/src/main/kotlin/com/codymikol/services/FileSystemService.kt
@@ -1,0 +1,30 @@
+package com.codymikol.services
+
+import org.koin.core.annotation.Single
+import java.awt.Desktop
+import java.io.File
+import java.nio.file.Path
+
+@Single
+class FileSystemService {
+
+    /**
+     * Reveals [path] in the operating system's default file viewer. [reveal] is injected so
+     * the file/directory resolution can be unit tested without invoking the real AWT Desktop.
+     */
+    fun showInFiles(path: Path, reveal: (File) -> Unit = ::revealInDesktop) {
+        reveal(path.toFile())
+    }
+
+    companion object {
+        fun revealInDesktop(file: File) {
+            val desktop = Desktop.getDesktop()
+            if (desktop.isSupported(Desktop.Action.BROWSE_FILE_DIR)) {
+                desktop.browseFileDirectory(file)
+            } else {
+                desktop.open(file.parentFile)
+            }
+        }
+    }
+
+}

--- a/src/test/kotlin/com/codymikol/services/FileSystemServiceSpec.kt
+++ b/src/test/kotlin/com/codymikol/services/FileSystemServiceSpec.kt
@@ -1,0 +1,28 @@
+package com.codymikol.services
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.io.File
+import java.nio.file.Path
+
+class FileSystemServiceSpec : DescribeSpec({
+
+    describe("FileSystemService") {
+
+        describe("showInFiles") {
+
+            it("should reveal the file at the given path") {
+                val service = FileSystemService()
+                val path = Path.of("/tmp/gitdown/example.txt")
+                var revealed: File? = null
+
+                service.showInFiles(path) { file -> revealed = file }
+
+                revealed shouldBe path.toFile()
+            }
+
+        }
+
+    }
+
+})


### PR DESCRIPTION
## Summary
- Adds `FileSystemService.showInFiles(path)`, a service-layer function that reveals a given file path in the OS's default file viewer (AWT `Desktop` `BROWSE_FILE_DIR`, falling back to opening the parent directory when unsupported).
- Registers the new service via a `ServicesModule` (Koin `@ComponentScan("com.codymikol.services")`), wired into `Main.kt` alongside the existing `RepositoriesModule`/`BeansModule`.
- Adds a unit test (`FileSystemServiceSpec`) covering path resolution by injecting the reveal action, following the same testability idiom already used by `reversedEllipsis` (inject the side-effecting call so logic is testable without invoking real OS/Compose APIs).
- Per the issue, the "Show In Files" cog menu item is intentionally **not** wired to this service yet — it remains a logging stub (`FileHeaderCogButton.kt`), to be wired in a future item.

Closes #154

## Note for reviewer
This sandbox had no usable local JDK/nix toolchain (`/nix/store` is read-only with no writable daemon in this environment, so `nix develop` failed even on a clean tree), so the build/tests could not be run locally. Changes were verified by careful manual review against existing conventions (Koin `@Single`/`@ComponentScan` pattern from `repositories/`, AWT `Desktop` usage precedent from `windows/DirectorySelector.kt`, and Kotest `DescribeSpec` test style). CI runs on a real JDK 21 and should be the authoritative check here.

## Test plan
- [ ] CI (`./gradlew build`) passes