### PR TITLE
feat(git): add service to open a file in the configured editor

### DIFF
--- a/src/main/kotlin/com/codymikol/extensions/EditorExtensions.kt
+++ b/src/main/kotlin/com/codymikol/extensions/EditorExtensions.kt
@@ -1,0 +1,56 @@
+package com.codymikol.extensions
+
+import org.eclipse.jgit.api.Git
+import org.slf4j.LoggerFactory
+import java.awt.Desktop
+import java.io.File
+import java.nio.file.Path
+
+private val logger = LoggerFactory.getLogger("EditorExtensions")
+
+/**
+ *  Mirrors git's own precedence for choosing an editor: the GIT_EDITOR
+ *  environment variable wins over the repository's core.editor config.
+ *  Returns null when neither is configured so callers can fall back to
+ *  the system's default file handler.
+ */
+fun Git.getConfiguredEditor(getenv: (String) -> String? = System::getenv): String? =
+    getenv("GIT_EDITOR")?.takeIf { it.isNotBlank() }
+        ?: this.repository.config.getString("core", null, "editor")?.takeIf { it.isNotBlank() }
+
+/**
+ *  Splits a configured editor command (which may itself carry flags, e.g.
+ *  `code --wait`, and quoted paths, e.g. `"/opt/My Editor/bin/edit" -w`)
+ *  into process arguments and appends the target file, without involving a
+ *  shell.
+ */
+fun buildEditorCommand(editorCommand: String, file: File): List<String> {
+    val tokenPattern = Regex("""'([^']*)'|"([^"]*)"|(\S+)""")
+    val tokens = tokenPattern.findAll(editorCommand.trim()).map { match ->
+        match.groupValues.drop(1).firstOrNull { it.isNotEmpty() } ?: ""
+    }.filter { it.isNotEmpty() }.toList()
+
+    return tokens + file.absolutePath
+}
+
+private fun openWithSystemDefaultEditor(file: File) {
+    if (!Desktop.isDesktopSupported() || !Desktop.getDesktop().isSupported(Desktop.Action.OPEN)) {
+        logger.error("Desktop open is not supported on this platform, unable to open file: ${file.absolutePath}")
+        return
+    }
+    Desktop.getDesktop().open(file)
+}
+
+fun Git.openFile(path: Path): Unit = try {
+    val file = this.repository.workTree.resolve(path.toFile())
+
+    when (val editor = getConfiguredEditor()) {
+        null -> openWithSystemDefaultEditor(file)
+        else -> {
+            ProcessBuilder(buildEditorCommand(editor, file)).start()
+            Unit
+        }
+    }
+} catch (e: Exception) {
+    logger.error("An exception was thrown while opening file $path: ${e.message}")
+}

--- a/src/test/kotlin/com/codymikol/extensions/EditorExtensionsSpec.kt
+++ b/src/test/kotlin/com/codymikol/extensions/EditorExtensionsSpec.kt
@@ -1,0 +1,66 @@
+package com.codymikol.extensions
+
+import com.codymikol.repository.TestRepository.Companion.createTestRepository
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.io.File
+
+class EditorExtensionsSpec : DescribeSpec({
+
+    describe("Git.getConfiguredEditor") {
+
+        it("prefers the GIT_EDITOR environment variable over core.editor") {
+            val repo = createTestRepository()
+            repo.git.repository.config.setString("core", null, "editor", "configured-editor")
+
+            repo.git.getConfiguredEditor(getenv = { key -> if (key == "GIT_EDITOR") "env-editor" else null }) shouldBe "env-editor"
+
+            repo.closeGitRepo()
+        }
+
+        it("falls back to core.editor when GIT_EDITOR is unset") {
+            val repo = createTestRepository()
+            repo.git.repository.config.setString("core", null, "editor", "configured-editor")
+
+            repo.git.getConfiguredEditor(getenv = { null }) shouldBe "configured-editor"
+
+            repo.closeGitRepo()
+        }
+
+        it("returns null when neither is configured") {
+            val repo = createTestRepository()
+
+            repo.git.getConfiguredEditor(getenv = { null }) shouldBe null
+
+            repo.closeGitRepo()
+        }
+
+        it("treats a blank GIT_EDITOR as unset") {
+            val repo = createTestRepository()
+            repo.git.repository.config.setString("core", null, "editor", "configured-editor")
+
+            repo.git.getConfiguredEditor(getenv = { key -> if (key == "GIT_EDITOR") "" else null }) shouldBe "configured-editor"
+
+            repo.closeGitRepo()
+        }
+
+    }
+
+    describe("buildEditorCommand") {
+
+        it("appends the file path to a simple command") {
+            buildEditorCommand("vim", File("/tmp/foo.txt")) shouldBe listOf("vim", "/tmp/foo.txt")
+        }
+
+        it("splits flags from the editor command") {
+            buildEditorCommand("code --wait", File("/tmp/foo.txt")) shouldBe listOf("code", "--wait", "/tmp/foo.txt")
+        }
+
+        it("preserves quoted segments containing spaces as a single token") {
+            buildEditorCommand("\"/opt/My Editor/bin/edit\" -w", File("/tmp/foo.txt")) shouldBe
+                listOf("/opt/My Editor/bin/edit", "-w", "/tmp/foo.txt")
+        }
+
+    }
+
+})


### PR DESCRIPTION
## Summary
- Adds `Git.openFile(path)` service-layer function that resolves an editor via `GIT_EDITOR` env var, then `core.editor` git config (mirroring git's own precedence), and falls back to the OS default file handler (`java.awt.Desktop`) when neither is configured.
- Adds `buildEditorCommand` to tokenize a configured editor command (handling quoted paths/flags) and launch it directly via `ProcessBuilder` without a shell, avoiding shell-injection risk.
- Per the issue, this is intentionally **not wired** into the "Open File" button in the Working Directory Cog Dropdown — that's left for a future item.

## Test plan
- Added `EditorExtensionsSpec` covering `getConfiguredEditor` precedence (env var over config, blank env var treated as unset, null when unconfigured) and `buildEditorCommand` tokenization (simple command, flags, quoted paths with spaces).
- Could not run `./gradlew test` locally — this sandbox has no JDK, no archive extraction tool (no `tar`/`unzip`), and `nix develop` fails with a read-only `/nix/store` (`Permission denied` writing lock files, confirmed with a minimal `nix build nixpkgs#hello` repro). Relying on CI (`actions/setup-java` + `./gradlew build`) to be the verification gate for this PR.

Closes #153