### PR TITLE
feat(commit): truncate long branch names in bottom toolbar

### DIFF
--- a/src/main/kotlin/com/codymikol/components/commit/CommitBottomToolbar.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/CommitBottomToolbar.kt
@@ -40,9 +40,14 @@ fun BoldText(_text: String, modifier: Modifier = Modifier) = Text(
 )
 
 
+const val MAX_BRANCH_NAME_LENGTH = 40
+
+fun truncateBranchName(branchName: String, maxLength: Int = MAX_BRANCH_NAME_LENGTH): String =
+    if (branchName.length > maxLength) branchName.take(maxLength) + "..." else branchName
+
 fun getObjectName(isDetatchedHead: Boolean, branchName: String): String = when (isDetatchedHead) {
     true -> "HEAD"
-    false -> branchName
+    false -> truncateBranchName(branchName)
 }
 
 fun getObjectNamePrefix(isDetatchedHead: Boolean): String = "on " + when (isDetatchedHead) {

--- a/src/test/kotlin/com/codymikol/components/commit/CommitBottomToolbarSpec.kt
+++ b/src/test/kotlin/com/codymikol/components/commit/CommitBottomToolbarSpec.kt
@@ -1,0 +1,59 @@
+package com.codymikol.components.commit
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class CommitBottomToolbarSpec : DescribeSpec({
+
+    describe("truncateBranchName") {
+
+        describe("when the branch name is within the limit") {
+
+            it("should return the branch name unchanged") {
+                truncateBranchName("main") shouldBe "main"
+            }
+
+            it("should return a 40 character branch name unchanged") {
+                val branchName = "a".repeat(40)
+                truncateBranchName(branchName) shouldBe branchName
+            }
+
+        }
+
+        describe("when the branch name exceeds the limit") {
+
+            it("should truncate to 40 characters and append an ellipsis") {
+                val branchName = "a".repeat(50)
+                truncateBranchName(branchName) shouldBe ("a".repeat(40) + "...")
+            }
+
+        }
+
+    }
+
+    describe("getObjectName") {
+
+        describe("when the head is detached") {
+
+            it("should return HEAD regardless of branch name length") {
+                getObjectName(true, "a".repeat(50)) shouldBe "HEAD"
+            }
+
+        }
+
+        describe("when the head is not detached") {
+
+            it("should return the branch name unchanged when within the limit") {
+                getObjectName(false, "main") shouldBe "main"
+            }
+
+            it("should return the truncated branch name when it exceeds the limit") {
+                val branchName = "a".repeat(50)
+                getObjectName(false, branchName) shouldBe ("a".repeat(40) + "...")
+            }
+
+        }
+
+    }
+
+})


### PR DESCRIPTION
## Summary
- Truncate branch names over 40 characters in the commit view's bottom toolbar, appending an ellipsis (`...`) so long names don't overflow the fixed-width label.
- Added `truncateBranchName` as a pure, unit-testable helper and wired it into `getObjectName`.
- Added `CommitBottomToolbarSpec` covering both `truncateBranchName` and `getObjectName` for short, exactly-40-char, and over-40-char branch names, plus detached-HEAD behavior.

Note: this sandbox's Nix store is read-only with no daemon and no baked JDK, so `./gradlew test` could not be run locally here. CI (`.github/workflows/ci.yml`) runs `./gradlew build` on a properly provisioned runner and will validate.

Closes #124