### PR TITLE
fix: prune recently opened entry when repo is gone

### DIFF
--- a/src/main/kotlin/com/codymikol/repositories/RecentProjectRepository.kt
+++ b/src/main/kotlin/com/codymikol/repositories/RecentProjectRepository.kt
@@ -48,6 +48,14 @@ class RecentProjectRepository(
         setRecentProjects(newRecentProjects)
     }
 
+    fun removeRecentProject(location: String) {
+        val currentRecentProjects = getRecentProjects()
+        val newProjects = currentRecentProjects.projects.filterNot { it.location == location }
+        if (newProjects.size != currentRecentProjects.projects.size) {
+            setRecentProjects(RecentProjects(newProjects))
+        }
+    }
+
     private fun getFile() = File("${requireNotNull(userDirectoryRepository.getUserDataDir())}/$recentFilename")
 
     private fun initializeRecentProjects(): RecentProjects {

--- a/src/main/kotlin/com/codymikol/repositories/UserDirectoryRepository.kt
+++ b/src/main/kotlin/com/codymikol/repositories/UserDirectoryRepository.kt
@@ -5,7 +5,7 @@ import net.harawata.appdirs.AppDirsFactory
 import org.koin.core.annotation.Single
 
 @Single
-class UserDirectoryRepository {
+open class UserDirectoryRepository {
 
     private val appDirs : AppDirs by lazy { AppDirsFactory.getInstance() }
 
@@ -13,6 +13,6 @@ class UserDirectoryRepository {
     private val projectVersion = "0.0.0"
     private val author = "Cody Mikol"
 
-    fun getUserDataDir(): String? = appDirs.getUserDataDir(projectName, projectVersion, author)
+    open fun getUserDataDir(): String? = appDirs.getUserDataDir(projectName, projectVersion, author)
 
 }

--- a/src/main/kotlin/com/codymikol/windows/DirectorySelector.kt
+++ b/src/main/kotlin/com/codymikol/windows/DirectorySelector.kt
@@ -129,15 +129,16 @@ fun DirectorySelector(applicationScope: ApplicationScope) =
 
         val borderSize = 12.dp
 
-        val recentProjects = remember { recentProjectsRepository.getRecentProjects() }
+        val recentProjects = remember { mutableStateOf(recentProjectsRepository.getRecentProjects()) }
 
-        val closeDropdown = { 
-          showRecentProjectDropdown.value = false 
+        val closeDropdown = {
+          showRecentProjectDropdown.value = false
+          recentProjects.value = recentProjectsRepository.getRecentProjects()
           println("Closed selector dropdown")
         }
 
         if (showRecentProjectDropdown.value) {
-            RecentProjectSelector(x = window.x, y = window.y, closeHandler = closeDropdown, recent = recentProjects)
+            RecentProjectSelector(x = window.x, y = window.y, closeHandler = closeDropdown, recent = recentProjects.value)
         }
 
         Box(
@@ -248,12 +249,16 @@ private fun AppleFileWindow(
 )
 
 fun handleDirectorySelection(dir: String) {
-    val dirFile = File(dir)
-    recentProjectsRepository.addRecentProject(
-        RecentProject(name = dirFile.parentFile.name, location = dir)
-    )
-    println("Selected: $dir")
     GitDownState.gitDirectory.value = dir
+    if (GitDownState.isValidGitDirectory.value) {
+        val dirFile = File(dir)
+        recentProjectsRepository.addRecentProject(
+            RecentProject(name = dirFile.parentFile.name, location = dir)
+        )
+    } else {
+        recentProjectsRepository.removeRecentProject(dir)
+    }
+    println("Selected: $dir")
     isAppleDialogOpen.value = false
 }
 

--- a/src/test/kotlin/com/codymikol/repositories/RecentProjectRepositorySpec.kt
+++ b/src/test/kotlin/com/codymikol/repositories/RecentProjectRepositorySpec.kt
@@ -1,0 +1,71 @@
+package com.codymikol.repositories
+
+import com.codymikol.beans.ObjectMapperBean
+import com.codymikol.data.recent.RecentProject
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import kotlin.io.path.createTempDirectory
+
+private class TestUserDirectoryRepository(private val dir: String) : UserDirectoryRepository() {
+    override fun getUserDataDir(): String = dir
+}
+
+class RecentProjectRepositorySpec : DescribeSpec({
+
+    describe("RecentProjectRepository") {
+
+        fun createRepository() = RecentProjectRepository(
+            ObjectMapperBean(),
+            TestUserDirectoryRepository(createTempDirectory("git-down-recent-projects-test-").toString())
+        )
+
+        it("starts with an empty list of recent projects") {
+            createRepository().getRecentProjects().projects shouldBe emptyList()
+        }
+
+        it("adds a project to the front of the list") {
+            val repository = createRepository()
+
+            repository.addRecentProject(RecentProject(name = "foo", location = "/foo/.git"))
+
+            repository.getRecentProjects().projects shouldBe listOf(RecentProject(name = "foo", location = "/foo/.git"))
+        }
+
+        it("moves an existing project to the front when re-added") {
+            val repository = createRepository()
+
+            repository.addRecentProject(RecentProject(name = "foo", location = "/foo/.git"))
+            repository.addRecentProject(RecentProject(name = "bar", location = "/bar/.git"))
+            repository.addRecentProject(RecentProject(name = "foo", location = "/foo/.git"))
+
+            repository.getRecentProjects().projects.map { it.location } shouldBe listOf("/foo/.git", "/bar/.git")
+        }
+
+        describe("removeRecentProject") {
+
+            it("removes the project matching the given location") {
+                val repository = createRepository()
+
+                repository.addRecentProject(RecentProject(name = "foo", location = "/foo/.git"))
+                repository.addRecentProject(RecentProject(name = "bar", location = "/bar/.git"))
+
+                repository.removeRecentProject("/foo/.git")
+
+                repository.getRecentProjects().projects shouldBe listOf(RecentProject(name = "bar", location = "/bar/.git"))
+            }
+
+            it("does nothing when no project matches the given location") {
+                val repository = createRepository()
+
+                repository.addRecentProject(RecentProject(name = "foo", location = "/foo/.git"))
+
+                repository.removeRecentProject("/does/not/exist/.git")
+
+                repository.getRecentProjects().projects shouldBe listOf(RecentProject(name = "foo", location = "/foo/.git"))
+            }
+
+        }
+
+    }
+
+})


### PR DESCRIPTION
## Summary
- `RecentProjectRepository` gains `removeRecentProject(location)` to drop an entry by location.
- `handleDirectorySelection` now checks `GitDownState.isValidGitDirectory` after setting the target directory: if valid, the entry is (re)added to the recent list as before; if invalid, any matching entry is pruned instead.
- The recently-opened dropdown's remembered list now re-reads the store when it closes, so a pruned entry disappears from the UI immediately instead of requiring an app restart.
- `UserDirectoryRepository` is now `open` so tests can point `RecentProjectRepository` at a temp directory instead of the real OS user-data dir.
- Added `RecentProjectRepositorySpec` covering add/dedupe/remove behavior.

Closes #162

## Note for reviewer
Could not run `make test` / `nix develop` in the agent sandbox — `/nix/store` is not writable by the agent user here (confirmed with a minimal `nix shell nixpkgs#jdk21`, same `Permission denied` on a lock file, even on a clean checkout), and no JDK exists on the baked PATH. Changes were reviewed manually for correctness; CI is the first real build/test signal for this PR.