### PR TITLE
feat(stash): select first stash when tab gains focus

### DIFF
--- a/src/main/kotlin/com/codymikol/components/TabButton.kt
+++ b/src/main/kotlin/com/codymikol/components/TabButton.kt
@@ -79,7 +79,7 @@ fun tabButton(
         modifier = Modifier
             .width(38.dp)
             .height(28.dp)
-            .clickable { GitDownState.currentTab.value = tab }
+            .clickable { GitDownState.selectTab(tab) }
             .clip(getTabButtonShape(location))
     ) {
         Box(

--- a/src/main/kotlin/com/codymikol/state/state.kt
+++ b/src/main/kotlin/com/codymikol/state/state.kt
@@ -173,6 +173,14 @@ object GitDownState {
     //todo(mikol): this is not ideal, work out a better way to manage this...
     val lastRequestedUpdateTimestamp = mutableStateOf(System.currentTimeMillis())
 
+    fun selectTab(tab: Tab) {
+        currentTab.value = tab
+
+        if (tab == Tab.Stash) {
+            selectedStash.value = stashes.value.firstOrNull()
+        }
+    }
+
     fun selectAdjacentFile(offset: Int) {
         val current = selectedFiles.singleOrNull() ?: return
 

--- a/src/test/kotlin/com/codymikol/state/GitDownStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/GitDownStateSpec.kt
@@ -6,6 +6,7 @@ import com.codymikol.extensions.stageAll
 import com.codymikol.extensions.stageSelectedLines
 import com.codymikol.extensions.stageLinesForAddedFile
 import com.codymikol.repository.TestRepository.Companion.createTestRepository
+import com.codymikol.tabs.Tab
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
@@ -701,6 +702,70 @@ class GitDownStateSpec : DescribeSpec({
                     GitDownState.selectAdjacentFile(1)
 
                     GitDownState.selectedFiles.toList() shouldBe listOf(indexFiles[1])
+                }
+
+            }
+
+        }
+
+        describe("selectTab") {
+
+            describe("when switching to the Stash tab and stashes exist") {
+
+                autoClose(
+                    createTestRepository()
+                        .addFile("foo.txt", "one\n")
+                        .stageAll()
+                        .commitAll("init")
+                        .appendToFile("foo.txt", "two\n")
+                        .stashCreate()
+                        .transferIntoGitDownState()
+                )
+
+                it("should automatically select the first stash") {
+                    GitDownState.selectedStash.value = null
+
+                    GitDownState.selectTab(Tab.Stash)
+
+                    GitDownState.currentTab.value shouldBe Tab.Stash
+                    GitDownState.selectedStash.value shouldBe GitDownState.stashes.value.first()
+                }
+
+            }
+
+            describe("when switching to the Stash tab and no stashes exist") {
+
+                autoClose(
+                    createTestRepository()
+                        .addFile("foo.txt", "Foo")
+                        .transferIntoGitDownState()
+                )
+
+                it("should leave no stash selected") {
+                    GitDownState.selectedStash.value = null
+
+                    GitDownState.selectTab(Tab.Stash)
+
+                    GitDownState.selectedStash.value shouldBe null
+                }
+
+            }
+
+            describe("when switching to a non-Stash tab") {
+
+                autoClose(
+                    createTestRepository()
+                        .addFile("foo.txt", "Foo")
+                        .transferIntoGitDownState()
+                )
+
+                it("should not touch the stash selection") {
+                    GitDownState.selectedStash.value = null
+
+                    GitDownState.selectTab(Tab.Commit)
+
+                    GitDownState.currentTab.value shouldBe Tab.Commit
+                    GitDownState.selectedStash.value shouldBe null
                 }
 
             }


### PR DESCRIPTION
## Summary
- Focusing the Stash tab now automatically selects the first stash in the list, so the diff panel shows something useful right away instead of the "No stash selected" empty state.
- Introduced `GitDownState.selectTab(tab)` to centralize tab-switch side effects; `TabButton` now calls it instead of assigning `currentTab.value` directly.

## Test plan
- [x] Added `GitDownStateSpec` cases covering: stashes exist → first one auto-selected, no stashes → selection stays null, switching to a non-Stash tab leaves stash selection untouched.
- [x] `./gradlew test` passes (run via a bwrap-merged Nix store since the default Nix devShell was unusable in this sandbox — unrelated to the change).

Closes #164