### PR TITLE
fix(commit): theme discard-changes confirm dialog

### DIFF
--- a/src/main/kotlin/com/codymikol/components/commit/ConfirmDialog.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/ConfirmDialog.kt
@@ -1,20 +1,30 @@
 package com.codymikol.components.commit
 
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.codymikol.components.SlimButton
+import com.codymikol.data.Colors
+import com.codymikol.typography.jetbrainsMono
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun ConfirmDialog(title: String? = null, content: String, onDismiss: () -> Unit, onConfirm: () -> Unit) {
     AlertDialog(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().border(1.dp, Color.Black, RoundedCornerShape(4.dp)),
         onDismissRequest = { onDismiss() },
+        backgroundColor = Colors.LightGrayBackground,
+        contentColor = Color.White,
+        shape = RoundedCornerShape(4.dp),
         text = {
             Column (
                 modifier = Modifier
@@ -24,21 +34,19 @@ fun ConfirmDialog(title: String? = null, content: String, onDismiss: () -> Unit,
                 if (!title.isNullOrEmpty()) {
                     Text(title,
                         modifier = Modifier.padding(vertical = 8.dp),
+                        color = Color.White,
+                        fontFamily = jetbrainsMono(),
                         style = MaterialTheme.typography.subtitle1)
                 }
 
-                Text(content)
+                Text(content, color = Colors.LightGrayText, fontFamily = jetbrainsMono(), fontSize = 12.sp)
             }
         },
         dismissButton = {
-            Button(onClick = { onDismiss() }) {
-                Text("No")
-            }
+            SlimButton("No", onClick = { onDismiss() })
         },
         confirmButton = {
-            Button(onClick = { onConfirm() }) {
-                Text("Yes")
-            }
+            SlimButton("Yes", onClick = { onConfirm() })
         }
     )
 }


### PR DESCRIPTION
## Summary
- Restyles the "Discard Changes?" confirmation dialog (`ConfirmDialog.kt`), which previously rendered with stock Compose Material light-theme defaults (white background, black text, purple buttons) that clashed with the rest of the app's dark gray/white/JetBrains Mono theme.
- Uses the shared `Colors` palette (`LightGrayBackground`, `LightGrayText`) for background/text, `jetbrainsMono()` for typography, and the existing `SlimButton` component for the Yes/No buttons, mirroring the pattern used by `ThemedDropdownMenu` and `DirectorySelector` elsewhere in the app.

Closes #54

## Note for reviewer
This sandbox has no JVM/JDK available and `nix develop` can't fetch flake inputs (read-only `/nix/store`, no daemon), so I could not run `./gradlew build` locally. The change was verified by manual review against the existing Compose Material `AlertDialog` API and the app's established theming patterns (`ThemedDropdownMenu.kt`, `DirectorySelector.kt`, `SlimButton.kt`). CI (`./gradlew build` on JDK 21) will be the first actual compile of this change — please keep an eye on it.

## Test plan
- [ ] CI build passes
- [ ] Manually trigger "Discard All..." in the app and confirm the dialog now uses dark background / white text / themed buttons instead of the default Material light theme