### PR TITLE
feat: select first file when opening commit view

### DIFF
--- a/src/main/kotlin/com/codymikol/state/state.kt
+++ b/src/main/kotlin/com/codymikol/state/state.kt
@@ -173,6 +173,14 @@ object GitDownState {
     //todo(mikol): this is not ideal, work out a better way to manage this...
     val lastRequestedUpdateTimestamp = mutableStateOf(System.currentTimeMillis())
 
+    fun selectFirstFileIfNoneSelected() {
+        if (selectedFiles.isNotEmpty()) return
+
+        val firstFile = workingDirectory.value.firstOrNull() ?: index.value.firstOrNull() ?: return
+
+        selectedFiles.add(firstFile)
+    }
+
     fun selectAdjacentFile(offset: Int) {
         val current = selectedFiles.singleOrNull() ?: return
 

--- a/src/main/kotlin/com/codymikol/views/CommitView.kt
+++ b/src/main/kotlin/com/codymikol/views/CommitView.kt
@@ -56,6 +56,10 @@ fun CommitView() {
 
     val scope = rememberCoroutineScope()
 
+    LaunchedEffect(Unit) {
+        GitDownState.selectFirstFileIfNoneSelected()
+    }
+
     if (isConfirmingDiscardAll.value) {
         ConfirmDialog(title = "Discard Changes?",
             content = "This will discard all changes in the working directory, are you sure?",

--- a/src/test/kotlin/com/codymikol/state/GitDownStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/GitDownStateSpec.kt
@@ -707,6 +707,89 @@ class GitDownStateSpec : DescribeSpec({
 
         }
 
+        describe("selectFirstFileIfNoneSelected") {
+
+            describe("when there are files in the working directory") {
+
+                autoClose(
+                    createTestRepository()
+                        .addFile("a.txt", "A")
+                        .addFile("b.txt", "B")
+                        .transferIntoGitDownState()
+                )
+
+                val files = GitDownState.workingDirectory.value.toList()
+
+                it("should select the first working directory file") {
+                    GitDownState.selectedFiles.clear()
+
+                    GitDownState.selectFirstFileIfNoneSelected()
+
+                    GitDownState.selectedFiles.toList() shouldBe listOf(files[0])
+                }
+
+            }
+
+            describe("when the working directory is empty but the index has files") {
+
+                autoClose(
+                    createTestRepository()
+                        .addFile("a.txt", "A")
+                        .addFile("b.txt", "B")
+                        .stageAll()
+                        .transferIntoGitDownState()
+                )
+
+                val files = GitDownState.index.value.toList()
+
+                it("should select the first index file") {
+                    GitDownState.selectedFiles.clear()
+
+                    GitDownState.selectFirstFileIfNoneSelected()
+
+                    GitDownState.selectedFiles.toList() shouldBe listOf(files[0])
+                }
+
+            }
+
+            describe("when both the working directory and index are empty") {
+
+                autoClose(createTestRepository().transferIntoGitDownState())
+
+                it("should not select anything") {
+                    GitDownState.selectedFiles.clear()
+
+                    GitDownState.selectFirstFileIfNoneSelected()
+
+                    GitDownState.selectedFiles.toList() shouldBe emptyList()
+                }
+
+            }
+
+            describe("when a file is already selected") {
+
+                autoClose(
+                    createTestRepository()
+                        .addFile("a.txt", "A")
+                        .addFile("b.txt", "B")
+                        .transferIntoGitDownState()
+                )
+
+                val files = GitDownState.workingDirectory.value.toList()
+
+                it("should leave the existing selection untouched") {
+                    GitDownState.selectedFiles.clear()
+                    GitDownState.selectedFiles.add(files[1])
+
+                    GitDownState.selectFirstFileIfNoneSelected()
+
+                    GitDownState.selectedFiles.toList() shouldBe listOf(files[1])
+                }
+
+            }
+
+        }
+
         describe("isValidGitDirectory") {
 
             describe("when the selected directory does not have git initialized") {


### PR DESCRIPTION
## Summary
- Auto-select the first file in the Working Directory list (or the first file in the Index list when the working directory has no changes) when the Commit view tab is opened, so the diff panel shows something instead of the "No file selected" empty state.
- Adds `GitDownState.selectFirstFileIfNoneSelected()`, mirroring the existing `selectAdjacentFile` helper, and hooks it into `CommitView()` via a `LaunchedEffect(Unit)` that fires each time the Commit tab enters composition.
- An existing selection is left untouched — this only fills in a selection when none exists.

## Test plan
- [x] `./gradlew test` — all tests pass, including 4 new `GitDownStateSpec` cases covering: working-directory-first-file selection, fallback to index when working directory is empty, no-op when both are empty, and leaving an existing selection untouched.
- [x] `./gradlew compileKotlin` — compiles cleanly.

Closes #163