### PR TITLE
fix(cli): restore directory opening via command line args

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ world projects until I have a stable release published.
 
 Simply run `./gradlew run`
 
+#### Command line arguments
+
+GitDown can be pointed at a repository directly from the command line. See
+[CLI Documentation](./docs/CLI.md) for details.
+
 #### File selection view
 
 <div style="width:100%; display:flex; justify-content:center;">

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,27 @@
+## CLI Documentation
+
+GitDown can be launched directly against a repository by passing the
+repository's path as the first command line argument. If the path points to
+a valid git repository, GitDown will open it immediately instead of showing
+the directory selection screen.
+
+#### Usage
+
+```
+./git-down <path-to-repository>
+```
+
+For example, to open a repository checked out at `~/projects/git-down`:
+
+```
+./git-down ~/projects/git-down
+```
+
+While developing, you can pass the argument through Gradle:
+
+```
+./gradlew run --args="/path/to/repository"
+```
+
+Only a single path argument is supported. If no argument is given, or more
+than one is given, GitDown falls back to the directory selection screen.

--- a/src/main/kotlin/com/codymikol/Main.kt
+++ b/src/main/kotlin/com/codymikol/Main.kt
@@ -3,16 +3,11 @@ import androidx.compose.ui.window.application
 import com.codymikol.config.BeansModule
 import com.codymikol.config.RepositoriesModule
 import com.codymikol.config.ServicesModule
+import com.codymikol.windows.handleDirectorySelection
 import org.koin.core.context.startKoin
 import org.koin.ksp.generated.module
 
 fun main(args: Array<String>) = application {
-
-    // todo(mikol): we should move this into a load directory service and make it more robust eventually...
-    if (args.size == 0) {
-//        println("requested directory: " + args[-1])
-//        GitDownState.gitDirectory.value = args[-1] + "/.git"
-    }
 
     startKoin {
         modules(
@@ -21,5 +16,11 @@ fun main(args: Array<String>) = application {
             ServicesModule().module,
         )
     }
+
+    // todo(mikol): we should move this into a load directory service and make it more robust eventually...
+    if (args.size == 1) {
+        handleDirectorySelection(args[0] + "/.git")
+    }
+
     App(this)
 }


### PR DESCRIPTION
## Summary
- `Main.kt`'s CLI arg handling had been silently broken since commit `c03cc53`: the condition was inverted to `args.size == 0`, the body was commented out, and it referenced an unimported `GitDownState`. Restored it to open the repo passed as the single CLI argument, routed through `handleDirectorySelection` (the same path the directory-picker UI uses) so recent-projects tracking stays consistent.
- Added `docs/CLI.md` documenting the `./git-down <path>` usage, and linked it from the README.

Closes #112

## Test plan
- [ ] CI build/test (`./gradlew build`) — could not run Gradle locally in this sandbox (no JDK, `/nix/store` not writable, no nix daemon), so CI is the first real compile check for this change.
- [ ] Manually launch `./git-down <path-to-a-git-repo>` and confirm it opens directly instead of showing the directory selector.