### PR TITLE
feat(components): wire cog dropdown actions to file services

### DIFF
--- a/src/main/kotlin/com/codymikol/components/commit/diff/file/header/action/buttons/FileHeaderCogButton.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/diff/file/header/action/buttons/FileHeaderCogButton.kt
@@ -10,9 +10,13 @@ import androidx.compose.ui.unit.sp
 import com.codymikol.components.commit.diff.file.header.colors.HeaderButtonColors
 import com.codymikol.components.menu.ThemedDropdownMenu
 import com.codymikol.components.menu.ThemedDropdownMenuItem
-import org.slf4j.LoggerFactory
+import com.codymikol.services.DiffToolService
+import com.codymikol.services.FileSystemService
+import kotlinx.coroutines.launch
+import org.koin.java.KoinJavaComponent.inject
 
-private val logger = LoggerFactory.getLogger("FileHeaderCogButton")
+internal val diffToolService: DiffToolService by inject(DiffToolService::class.java)
+internal val fileSystemService: FileSystemService by inject(FileSystemService::class.java)
 
 @Composable
 internal fun FileHeaderCogButton(menuItems: @Composable (dismiss: () -> Unit) -> Unit) {
@@ -39,10 +43,14 @@ internal fun FileHeaderCogButton(menuItems: @Composable (dismiss: () -> Unit) ->
 }
 
 @Composable
-internal fun FileActionMenuItem(label: String, actionId: String, onSelect: () -> Unit) = ThemedDropdownMenuItem(
-    label = label,
-    onClick = {
-        logger.info("todo: $actionId")
-        onSelect()
-    }
-)
+internal fun FileActionMenuItem(label: String, dismiss: () -> Unit, action: suspend () -> Unit) {
+    val scope = rememberCoroutineScope()
+
+    ThemedDropdownMenuItem(
+        label = label,
+        onClick = {
+            scope.launch { action() }
+            dismiss()
+        }
+    )
+}

--- a/src/main/kotlin/com/codymikol/components/commit/diff/file/header/action/buttons/FileHeaderCogButtonIndex.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/diff/file/header/action/buttons/FileHeaderCogButtonIndex.kt
@@ -4,11 +4,13 @@ import androidx.compose.material.Divider
 import androidx.compose.runtime.Composable
 import com.codymikol.components.menu.MenuColors
 import com.codymikol.data.diff.FileDeltaNode
+import com.codymikol.extensions.openFile
+import com.codymikol.state.GitDownState
 
 @Composable
 fun FileHeaderCogButtonIndex(fileDeltaNode: FileDeltaNode) = FileHeaderCogButton { dismiss ->
-    FileActionMenuItem("View in Diff Tool", "index.viewInDiffTool", dismiss)
+    FileActionMenuItem("View in Diff Tool", dismiss) { diffToolService.launchDiffTool(fileDeltaNode.fileDelta) }
     Divider(color = MenuColors.Divider)
-    FileActionMenuItem("Open File", "index.openFile", dismiss)
-    FileActionMenuItem("Show In Files", "index.showInFiles", dismiss)
+    FileActionMenuItem("Open File", dismiss) { GitDownState.git.value.openFile(fileDeltaNode.fileDelta.location) }
+    FileActionMenuItem("Show In Files", dismiss) { fileSystemService.showInFiles(fileDeltaNode.fileDelta.location) }
 }

--- a/src/main/kotlin/com/codymikol/components/commit/diff/file/header/action/buttons/FileHeaderCogButtonWorkingDirectory.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/diff/file/header/action/buttons/FileHeaderCogButtonWorkingDirectory.kt
@@ -2,16 +2,63 @@ package com.codymikol.components.commit.diff.file.header.action.buttons
 
 import androidx.compose.material.Divider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import com.codymikol.components.commit.ConfirmDialog
 import com.codymikol.components.menu.MenuColors
-import com.codymikol.data.Colors
+import com.codymikol.components.menu.ThemedDropdownMenuItem
 import com.codymikol.data.diff.FileDeltaNode
+import com.codymikol.extensions.deleteFile
+import com.codymikol.extensions.discardFile
+import com.codymikol.extensions.openFile
+import com.codymikol.state.GitDownState
+import kotlinx.coroutines.launch
 
 @Composable
-fun FileHeaderCogButtonWorkingDirectory(fileDeltaNode: FileDeltaNode) = FileHeaderCogButton { dismiss ->
-    FileActionMenuItem("View in Diff Tool", "workingDirectory.viewInDiffTool", dismiss)
-    Divider(color = MenuColors.Divider)
-    FileActionMenuItem("Open File", "workingDirectory.openFile", dismiss)
-    FileActionMenuItem("Show In Files", "workingDirectory.showInFiles", dismiss)
-    Divider(color = MenuColors.Divider)
-    FileActionMenuItem("Delete File", "workingDirectory.deleteFile", dismiss)
+fun FileHeaderCogButtonWorkingDirectory(fileDeltaNode: FileDeltaNode) {
+
+    val scope = rememberCoroutineScope()
+    var isConfirmingDiscard by remember { mutableStateOf(false) }
+    var isConfirmingDelete by remember { mutableStateOf(false) }
+
+    FileHeaderCogButton { dismiss ->
+        FileActionMenuItem("View in Diff Tool", dismiss) { diffToolService.launchDiffTool(fileDeltaNode.fileDelta) }
+        Divider(color = MenuColors.Divider)
+        FileActionMenuItem("Open File", dismiss) { GitDownState.git.value.openFile(fileDeltaNode.fileDelta.location) }
+        FileActionMenuItem("Show In Files", dismiss) { fileSystemService.showInFiles(fileDeltaNode.fileDelta.location) }
+        Divider(color = MenuColors.Divider)
+        ThemedDropdownMenuItem(label = "Discard Changes", onClick = { isConfirmingDiscard = true; dismiss() })
+        ThemedDropdownMenuItem(label = "Delete File", onClick = { isConfirmingDelete = true; dismiss() })
+    }
+
+    if (isConfirmingDiscard) {
+        ConfirmDialog(
+            title = "Discard Changes?",
+            content = "This will discard changes to ${fileDeltaNode.getPath()}, are you sure?",
+            onDismiss = { isConfirmingDiscard = false },
+            onConfirm = {
+                scope.launch {
+                    GitDownState.git.value.discardFile(fileDeltaNode)
+                    isConfirmingDiscard = false
+                }
+            }
+        )
+    }
+
+    if (isConfirmingDelete) {
+        ConfirmDialog(
+            title = "Delete File?",
+            content = "This will permanently delete ${fileDeltaNode.getPath()} from disk, are you sure?",
+            onDismiss = { isConfirmingDelete = false },
+            onConfirm = {
+                scope.launch {
+                    GitDownState.git.value.deleteFile(fileDeltaNode.getPath())
+                    isConfirmingDelete = false
+                }
+            }
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Wires the "cog" dropdown menu on file rows (Working Directory and Index) to the service implementations added in #150-#154, replacing the placeholder `logger.info("todo: $actionId")` handler that previously backed every menu item.

- **View in Diff Tool** → `DiffToolService.launchDiffTool` (#150)
- **Open File** → `Git.openFile` (#153)
- **Show In Files** → `FileSystemService.showInFiles` (#154)
- **Discard Changes** (new, Working Directory only) → `Git.discardFile` (#152) — reverts a modified/deleted file to HEAD, or deletes an untracked file
- **Delete File** (Working Directory only) → `Git.deleteFile` (#151) — unconditionally removes the file from disk

`Discard Changes` and `Delete File` are destructive, so both are gated behind a `ConfirmDialog`, mirroring the existing "Discard All..." confirmation flow in `CommitView.kt`. The Index menu has no destructive actions and stays limited to the three read-only/navigation items.

`FileActionMenuItem` was changed from a synchronous `onSelect: () -> Unit` (that only logged) to a `suspend action: () -> Unit`, launched via `rememberCoroutineScope()`, matching the pattern already used by `FileHeaderButton`.

## Reviewer notes

- This sandbox has no JDK and `nix develop` fails here on a pre-existing `/nix/store` permission error unrelated to this change (reproduced identically on `main`), so I could not run `./gradlew compileKotlin`/`test` locally. Please confirm CI compiles/tests green.
- No prior Compose UI test harness exists for this component tree (confirmed via git history of the sibling #149 refactor), so no new tests were added — consistent with existing conventions.

Closes #176