### PR TITLE
feat(map): add lazy-loading branch/commit graph view

### DIFF
--- a/src/main/kotlin/com/codymikol/data/map/CommitGraphNode.kt
+++ b/src/main/kotlin/com/codymikol/data/map/CommitGraphNode.kt
@@ -1,0 +1,28 @@
+package com.codymikol.data.map
+
+import org.eclipse.jgit.revwalk.RevCommit
+import java.util.Date
+
+data class CommitGraphNode(
+    val sha: String,
+    val shortSha: String,
+    val shortMessage: String,
+    val authorName: String,
+    val date: Date,
+    val parentShas: List<String>,
+) {
+
+    val isMergeCommit: Boolean
+        get() = parentShas.size > 1
+
+    companion object {
+        fun make(revCommit: RevCommit): CommitGraphNode = CommitGraphNode(
+            sha = revCommit.name,
+            shortSha = revCommit.name.take(7),
+            shortMessage = revCommit.shortMessage,
+            authorName = revCommit.authorIdent?.name ?: "",
+            date = Date(revCommit.commitTime.toLong() * 1000),
+            parentShas = revCommit.parents.map { it.name },
+        )
+    }
+}

--- a/src/main/kotlin/com/codymikol/data/map/CommitHistoryWalker.kt
+++ b/src/main/kotlin/com/codymikol/data/map/CommitHistoryWalker.kt
@@ -1,0 +1,37 @@
+package com.codymikol.data.map
+
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.lib.Ref
+import org.eclipse.jgit.revwalk.RevWalk
+
+/**
+ * Wraps a single JGit RevWalk so a branch's history can be paged in incrementally
+ * instead of walking the whole history up front - the walk only advances as far
+ * as nextPage() has been asked to go.
+ */
+class CommitHistoryWalker(git: Git, ref: Ref) : AutoCloseable {
+
+    private val walk = RevWalk(git.repository).also { it.markStart(it.parseCommit(ref.objectId)) }
+
+    var hasMore = true
+        private set
+
+    fun nextPage(size: Int): List<CommitGraphNode> {
+        if (!hasMore) return emptyList()
+
+        val page = mutableListOf<CommitGraphNode>()
+
+        while (page.size < size) {
+            val commit = walk.next()
+            if (commit == null) {
+                hasMore = false
+                break
+            }
+            page.add(CommitGraphNode.make(commit))
+        }
+
+        return page
+    }
+
+    override fun close() = walk.close()
+}

--- a/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
+++ b/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
@@ -22,6 +22,7 @@ import org.eclipse.jgit.dircache.DirCacheEntry
 import org.eclipse.jgit.dircache.DirCacheIterator
 import org.eclipse.jgit.lib.Constants.OBJ_BLOB
 import org.eclipse.jgit.lib.FileMode
+import org.eclipse.jgit.lib.Ref
 import org.eclipse.jgit.lib.Repository
 import org.eclipse.jgit.revwalk.RevCommit
 import org.eclipse.jgit.revwalk.RevWalk
@@ -63,6 +64,12 @@ fun Git.getCurrentRefCommitCount() = try {
 
 fun Git.getStashes(): List<RevCommit> = try {
     this.stashList().call().toList()
+} catch (e: Exception) {
+    emptyList()
+}
+
+fun Git.listLocalBranches(): List<Ref> = try {
+    this.branchList().call()
 } catch (e: Exception) {
     emptyList()
 }

--- a/src/main/kotlin/com/codymikol/state/MapState.kt
+++ b/src/main/kotlin/com/codymikol/state/MapState.kt
@@ -1,0 +1,46 @@
+package com.codymikol.state
+
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateMapOf
+import com.codymikol.data.map.CommitGraphNode
+import com.codymikol.data.map.CommitHistoryWalker
+import com.codymikol.extensions.listLocalBranches
+import org.eclipse.jgit.lib.Ref
+
+/**
+ * Backs the Map view. Branch history is walked lazily - loadMore() only advances
+ * a branch's RevWalk as far as the UI has actually scrolled, one CommitHistoryWalker
+ * per branch, kept open across calls so re-walking from the start is never needed.
+ */
+object MapState {
+
+    const val PAGE_SIZE = 30
+
+    private val walkers = mutableMapOf<String, CommitHistoryWalker>()
+
+    val commitsByBranch = mutableStateMapOf<String, MutableList<CommitGraphNode>>()
+
+    val hasMoreByBranch = mutableStateMapOf<String, Boolean>()
+
+    val branches = derivedStateOf {
+        GitDownState.git.value.listLocalBranches().sortedBy { it.name }
+    }
+
+    fun loadMore(branch: Ref) {
+        if (hasMoreByBranch[branch.name] == false) return
+
+        val walker = walkers.getOrPut(branch.name) { CommitHistoryWalker(GitDownState.git.value, branch) }
+        val page = walker.nextPage(PAGE_SIZE)
+
+        commitsByBranch.getOrPut(branch.name) { mutableStateListOf() }.addAll(page)
+        hasMoreByBranch[branch.name] = walker.hasMore
+    }
+
+    fun reset() {
+        walkers.values.forEach { it.close() }
+        walkers.clear()
+        commitsByBranch.clear()
+        hasMoreByBranch.clear()
+    }
+}

--- a/src/main/kotlin/com/codymikol/typography/GitDownTypography.kt
+++ b/src/main/kotlin/com/codymikol/typography/GitDownTypography.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.sp
 import com.codymikol.gitdown.generated.resources.*
 import org.jetbrains.compose.resources.Font
@@ -93,6 +94,30 @@ object GitDownTypography {
             color = color,
             fontFamily = jetbrainsMono(),
             fontSize = 12.sp
+        )
+    }
+
+    @Composable
+    fun CommitSha(value: String) {
+        Text(
+            value,
+            color = Color(whiteLevel, whiteLevel, whiteLevel),
+            fontSize = 10.sp,
+            fontWeight = FontWeight.Bold,
+            fontFamily = jetbrainsMono(),
+        )
+    }
+
+    @Composable
+    fun CommitSubject(value: String) {
+        Text(
+            value,
+            modifier = Modifier.fillMaxWidth(),
+            color = Color(whiteLevel, whiteLevel, whiteLevel),
+            fontSize = 11.sp,
+            fontFamily = jetbrainsMono(),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
         )
     }
 

--- a/src/main/kotlin/com/codymikol/views/MapView.kt
+++ b/src/main/kotlin/com/codymikol/views/MapView.kt
@@ -1,11 +1,168 @@
 package com.codymikol.views
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.unit.dp
+import com.codymikol.components.Subheader
+import com.codymikol.data.Colors
+import com.codymikol.data.map.CommitGraphNode
+import com.codymikol.state.GitDownState
+import com.codymikol.state.MapState
+import com.codymikol.typography.GitDownTypography
+import org.eclipse.jgit.lib.Ref
+
+private val LaneWidth = 260.dp
+private val NodeRadius = 5.dp
+private val GutterX = 20.dp
+private const val LoadMoreThreshold = 5
 
 @Composable
 @Preview
 fun MapView() {
-    Text("TODO - Map")
+
+    LaunchedEffect(GitDownState.gitDirectory.value) {
+        MapState.reset()
+    }
+
+    val branches = MapState.branches.value
+
+    when (branches.isEmpty()) {
+        true -> MapEmptyState()
+        false -> LazyRow(
+            state = rememberLazyListState(),
+            modifier = Modifier.fillMaxWidth().fillMaxHeight().background(Colors.DarkGrayBackground)
+        ) {
+            items(branches, key = { it.name }) { branch -> BranchLane(branch) }
+        }
+    }
+}
+
+@Composable
+private fun MapEmptyState() {
+    Column(
+        modifier = Modifier.fillMaxWidth().fillMaxHeight().background(Colors.DarkGrayBackground),
+        verticalArrangement = Arrangement.Center
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().align(Alignment.CenterHorizontally),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Text("No branches found", color = Color.Gray)
+        }
+    }
+}
+
+@Composable
+private fun BranchLane(branch: Ref) {
+    val branchName = branch.name.removePrefix("refs/heads/")
+    val commits = MapState.commitsByBranch[branch.name] ?: emptyList()
+    val hasMore = MapState.hasMoreByBranch[branch.name] ?: true
+    val listState = rememberLazyListState()
+
+    // Loading this lane's first page only happens once it's actually composed,
+    // which LazyRow only does once the lane scrolls into view - this is what
+    // lazily loads branches horizontally.
+    LaunchedEffect(branch.name) {
+        if (MapState.commitsByBranch[branch.name] == null) {
+            MapState.loadMore(branch)
+        }
+    }
+
+    LaunchedEffect(branch.name, commits.size, hasMore) {
+        snapshotFlow { listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index }
+            .collect { lastVisibleIndex ->
+                val nearBottom = lastVisibleIndex != null && lastVisibleIndex >= commits.size - LoadMoreThreshold
+                if (hasMore && nearBottom) {
+                    MapState.loadMore(branch)
+                }
+            }
+    }
+
+    Column(
+        modifier = Modifier
+            .width(LaneWidth)
+            .fillMaxHeight()
+            .border(width = 1.dp, color = Color.Black)
+    ) {
+        Subheader(branchName)
+        LazyColumn(state = listState, modifier = Modifier.fillMaxWidth().fillMaxHeight()) {
+            itemsIndexed(commits, key = { _, commit -> commit.sha }) { index, commit ->
+                CommitNode(
+                    commit = commit,
+                    showLeadingGuideline = index != 0,
+                    showTrailingGuideline = index != commits.lastIndex || hasMore,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CommitNode(commit: CommitGraphNode, showLeadingGuideline: Boolean, showTrailingGuideline: Boolean) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(48.dp)
+            .drawBehind { drawCommitNode(commit, showLeadingGuideline, showTrailingGuideline) }
+            .padding(start = 40.dp, top = 4.dp, end = 8.dp, bottom = 4.dp)
+    ) {
+        Column {
+            GitDownTypography.CommitSha(commit.shortSha)
+            GitDownTypography.CommitSubject(commit.shortMessage)
+        }
+    }
+}
+
+private fun DrawScope.drawCommitNode(commit: CommitGraphNode, showLeadingGuideline: Boolean, showTrailingGuideline: Boolean) {
+    val x = GutterX.toPx()
+    val centerY = size.height / 2f
+
+    if (showLeadingGuideline) {
+        drawLine(color = Colors.LightGrayText, start = Offset(x, 0f), end = Offset(x, centerY), strokeWidth = 2f)
+    }
+
+    if (showTrailingGuideline) {
+        drawLine(color = Colors.LightGrayText, start = Offset(x, centerY), end = Offset(x, size.height), strokeWidth = 2f)
+    }
+
+    when (commit.isMergeCommit) {
+        true -> drawDiamond(center = Offset(x, centerY), radius = NodeRadius.toPx(), color = Colors.FileModified)
+        false -> drawCircle(color = Colors.FileAdded, radius = NodeRadius.toPx(), center = Offset(x, centerY))
+    }
+}
+
+private fun DrawScope.drawDiamond(center: Offset, radius: Float, color: Color) {
+    val path = Path().apply {
+        moveTo(center.x, center.y - radius)
+        lineTo(center.x + radius, center.y)
+        lineTo(center.x, center.y + radius)
+        lineTo(center.x - radius, center.y)
+        close()
+    }
+    drawPath(path, color = color)
 }

--- a/src/test/kotlin/com/codymikol/data/map/CommitHistoryWalkerSpec.kt
+++ b/src/test/kotlin/com/codymikol/data/map/CommitHistoryWalkerSpec.kt
@@ -1,0 +1,94 @@
+package com.codymikol.data.map
+
+import com.codymikol.extensions.listLocalBranches
+import com.codymikol.repository.TestRepository.Companion.createTestRepository
+import com.codymikol.state.GitDownState
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+class CommitHistoryWalkerSpec : DescribeSpec({
+
+    describe("CommitHistoryWalker") {
+
+        beforeContainer { GitDownState.git.value.close() }
+
+        describe("a branch with five commits") {
+
+            autoClose(
+                createTestRepository()
+                    .addFile("a.txt", "a")
+                    .stageAll()
+                    .commitAll("commit 1")
+                    .appendToFile("a.txt", "b")
+                    .stageAll()
+                    .commitAll("commit 2")
+                    .appendToFile("a.txt", "c")
+                    .stageAll()
+                    .commitAll("commit 3")
+                    .appendToFile("a.txt", "d")
+                    .stageAll()
+                    .commitAll("commit 4")
+                    .appendToFile("a.txt", "e")
+                    .stageAll()
+                    .commitAll("commit 5")
+                    .transferIntoGitDownState()
+            )
+
+            val branch = GitDownState.git.value.listLocalBranches().single()
+
+            it("should page through history newest first") {
+                val walker = CommitHistoryWalker(GitDownState.git.value, branch)
+
+                val firstPage = walker.nextPage(3)
+                firstPage.map { it.shortMessage } shouldBe listOf("commit 5", "commit 4", "commit 3")
+                walker.hasMore shouldBe true
+
+                val secondPage = walker.nextPage(3)
+                secondPage.map { it.shortMessage } shouldBe listOf("commit 2", "commit 1")
+                walker.hasMore shouldBe false
+
+                val thirdPage = walker.nextPage(3)
+                thirdPage shouldHaveSize 0
+
+                walker.close()
+            }
+        }
+
+        describe("a branch with a merge commit") {
+
+            val initial = createTestRepository()
+                .addFile("a.txt", "a")
+                .stageAll()
+                .commitAll("init")
+
+            val defaultBranchName = initial.git.repository.branch
+
+            autoClose(
+                initial
+                    .createBranch("feature")
+                    .checkout("feature")
+                    .appendToFile("a.txt", "b")
+                    .stageAll()
+                    .commitAll("feature work")
+                    .checkout(defaultBranchName)
+                    .merge("feature", "merge feature")
+                    .transferIntoGitDownState()
+            )
+
+            it("should mark the merge commit as a merge commit with two parents") {
+                val branch = GitDownState.git.value.listLocalBranches()
+                    .first { it.name.endsWith(defaultBranchName) }
+
+                val walker = CommitHistoryWalker(GitDownState.git.value, branch)
+                val page = walker.nextPage(10)
+
+                val mergeCommits = page.filter { it.isMergeCommit }
+                mergeCommits shouldHaveSize 1
+                mergeCommits.single().parentShas shouldHaveSize 2
+
+                walker.close()
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/codymikol/extensions/ListLocalBranchesSpec.kt
+++ b/src/test/kotlin/com/codymikol/extensions/ListLocalBranchesSpec.kt
@@ -1,0 +1,42 @@
+package com.codymikol.extensions
+
+import com.codymikol.repository.TestRepository.Companion.createTestRepository
+import com.codymikol.state.GitDownState
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+class ListLocalBranchesSpec : DescribeSpec({
+
+    describe("Git.listLocalBranches") {
+
+        beforeContainer { GitDownState.git.value.close() }
+
+        describe("a repository with two local branches") {
+
+            autoClose(
+                createTestRepository()
+                    .addFile("a.txt", "a")
+                    .stageAll()
+                    .commitAll("init")
+                    .createBranch("feature")
+                    .transferIntoGitDownState()
+            )
+
+            it("should list both branches") {
+                val names = GitDownState.git.value.listLocalBranches().map { it.name }
+                names shouldHaveSize 2
+                names.any { it.endsWith("feature") } shouldBe true
+            }
+        }
+
+        describe("a repository with no commits") {
+
+            autoClose(createTestRepository().transferIntoGitDownState())
+
+            it("should return an empty list") {
+                GitDownState.git.value.listLocalBranches() shouldHaveSize 0
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/codymikol/repository/TestRepository.kt
+++ b/src/test/kotlin/com/codymikol/repository/TestRepository.kt
@@ -5,6 +5,7 @@ import com.codymikol.extensions.scanForChanges
 import com.codymikol.extensions.stageAll
 import com.codymikol.state.GitDownState
 import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.api.MergeCommand
 import java.io.File
 import java.nio.file.Path
 
@@ -43,6 +44,23 @@ data class TestRepository(
 
     suspend fun commitAll(message: String) = this.also {
         this.git.commitAll(message)
+    }
+
+    fun createBranch(name: String) = this.also {
+        this.git.branchCreate().setName(name).call()
+    }
+
+    fun checkout(name: String) = this.also {
+        this.git.checkout().setName(name).call()
+    }
+
+    // Forces a real merge commit even when the merge could fast-forward, since this
+    // fixture exists to produce multi-parent commits for diamond-graph test coverage.
+    fun merge(branchName: String, message: String? = null) = this.also {
+        val ref = this.git.repository.findRef(branchName)
+        val command = this.git.merge().include(ref).setFastForward(MergeCommand.FastForwardMode.NO_FF)
+        message?.let { command.setMessage(it) }
+        command.call()
     }
 
     fun stashCreate(message: String? = null) = this.also {

--- a/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
@@ -1,0 +1,69 @@
+package com.codymikol.state
+
+import com.codymikol.repository.TestRepository.Companion.createTestRepository
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+class MapStateSpec : DescribeSpec({
+
+    describe("MapState") {
+
+        beforeContainer {
+            GitDownState.git.value.close()
+            MapState.reset()
+        }
+
+        describe("a branch with four commits") {
+
+            autoClose(
+                createTestRepository()
+                    .addFile("a.txt", "a")
+                    .stageAll()
+                    .commitAll("commit 1")
+                    .appendToFile("a.txt", "b")
+                    .stageAll()
+                    .commitAll("commit 2")
+                    .appendToFile("a.txt", "c")
+                    .stageAll()
+                    .commitAll("commit 3")
+                    .appendToFile("a.txt", "d")
+                    .stageAll()
+                    .commitAll("commit 4")
+                    .transferIntoGitDownState()
+            )
+
+            it("should expose exactly one local branch") {
+                MapState.branches.value shouldHaveSize 1
+            }
+
+            it("should load every commit into commitsByBranch and mark the branch exhausted") {
+                val branch = MapState.branches.value.single()
+
+                MapState.loadMore(branch)
+
+                (MapState.commitsByBranch[branch.name] ?: emptyList()) shouldHaveSize 4
+                MapState.hasMoreByBranch[branch.name] shouldBe false
+            }
+
+            it("should not duplicate rows once a branch is exhausted") {
+                val branch = MapState.branches.value.single()
+
+                MapState.loadMore(branch)
+                MapState.loadMore(branch)
+
+                (MapState.commitsByBranch[branch.name] ?: emptyList()) shouldHaveSize 4
+            }
+
+            it("should clear loaded state on reset") {
+                val branch = MapState.branches.value.single()
+                MapState.loadMore(branch)
+
+                MapState.reset()
+
+                MapState.commitsByBranch.isEmpty() shouldBe true
+                MapState.hasMoreByBranch.isEmpty() shouldBe true
+            }
+        }
+    }
+})


### PR DESCRIPTION
## Summary

Replaces the "TODO - Map" placeholder with a working commit-graph view:

- **Horizontal lazy loading of branches**: the Map tab renders a `LazyRow` of branch lanes; each lane's commit history is only fetched once that lane actually scrolls into view (Compose's native `LazyRow` composition laziness).
- **Vertical lazy loading of history**: each lane is a `LazyColumn` backed by an incremental JGit `RevWalk` (`CommitHistoryWalker`) that only advances as far as the user has scrolled — no branch's full history is ever walked eagerly.
- **Diamond merge markers**: commits with more than one parent (`CommitGraphNode.isMergeCommit`) render as a diamond instead of a circle, connected to neighboring commits in the lane by a guideline, mirroring the existing `drawCommitGuideline` pattern used elsewhere in the app.

### New files
- `data/map/CommitGraphNode.kt` — `RevCommit` → display node wrapper
- `data/map/CommitHistoryWalker.kt` — pages a branch's history off a single retained `RevWalk`
- `state/MapState.kt` — snapshot-backed per-branch commit pages / load-more state
- `views/MapView.kt` — the lane/graph UI (was previously `Text("TODO - Map")`)

### Changed
- `extensions/GitExtensions.kt` — `Git.listLocalBranches()`
- `typography/GitDownTypography.kt` — `CommitSha`/`CommitSubject` text styles
- `repository/TestRepository.kt` (test fixture) — `createBranch`/`checkout`/`merge` helpers (merge forces `NO_FF` so the fixture can produce real merge commits for diamond coverage)

### Notes for reviewer
- No true 2D lazy grid exists in this codebase yet, so each lane owns an independent vertical scroll state — lanes are not scroll-synced with each other. Cross-lane connector lines for a merge commit's non-primary parents are also out of scope for this pass (only same-lane guidelines are drawn); flagging this as a reasonable place to extend later if a synced-lane experience is wanted.
- **Could not run `./gradlew build` locally** — this sandbox has no JDK and `nix develop` fails (`/nix/store` is root-owned with no daemon reachable from this container), so compilation/tests are unverified locally. I did a careful manual review of every new/changed file for JGit/Compose API correctness. CI (which provisions JDK 21 via `actions/setup-java`) will be the first real compile/test signal — please keep an eye on it.

Closes #175