### PR TITLE
fix: add right padding to Unstage All button

### DIFF
--- a/src/main/kotlin/com/codymikol/components/commit/CommitBottomToolbar.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/CommitBottomToolbar.kt
@@ -114,7 +114,7 @@ fun CommitBottomToolbar(
             .padding(10.dp)
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
-            SlimButton("Unstage All", onClick = {
+            SlimButton("Unstage All", modifier = Modifier.padding(end = 12.dp), onClick = {
                 scope.launch {
                     GitDownState.git.value.unstageAll()
                     GitDownState.selectedFiles.clear()


### PR DESCRIPTION
## Summary
- Adds `end = 12.dp` padding to the "Unstage All" button's modifier in `CommitBottomToolbar.kt` so it isn't butted directly against the "Commiting as" text next to it.

Closes #177

## Note for reviewer
Build/compile could not be verified in this environment (no JDK available and `nix develop` failed with a sandboxed read-only `/nix/store`, unable to fetch/copy the flake source). The change is a single-line modifier addition consistent with the existing pattern used elsewhere in the same file (e.g. `Modifier.padding(0.dp, 0.dp, 12.dp, 0.dp)` for the Amend Head text).