### PR TITLE
feat: remove header menu bar from map/commit/stash view

### DIFF
--- a/src/main/kotlin/com/codymikol/App.kt
+++ b/src/main/kotlin/com/codymikol/App.kt
@@ -9,6 +9,6 @@ import com.codymikol.windows.GitDown
 @Composable
 @Preview
 fun App(applicationScope: ApplicationScope) = when (GitDownState.isValidGitDirectory.value) {
-    true -> GitDown()
+    true -> GitDown(applicationScope)
     false -> DirectorySelector(applicationScope)
 }

--- a/src/main/kotlin/com/codymikol/windows/GitDown.kt
+++ b/src/main/kotlin/com/codymikol/windows/GitDown.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.ApplicationScope
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowPlacement
 import androidx.compose.ui.window.WindowPosition
@@ -51,7 +52,7 @@ import java.awt.Dimension
 
 @Preview
 @Composable
-fun GitDown() {
+fun GitDown(applicationScope: ApplicationScope) {
 
     Window(
         onKeyEvent = {
@@ -76,6 +77,7 @@ fun GitDown() {
         },
         title = GitDownState.projectName.value,
         icon = painterResource(Res.drawable.icon),
+        undecorated = true,
         state = rememberWindowState(
             width = windowWidth.dp,
             height = windowHeight.dp,
@@ -107,7 +109,7 @@ fun GitDown() {
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
                     WindowDraggableArea(modifier = Modifier.fillMaxWidth()) {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
+                        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
                             Row(modifier = Modifier.padding(10.dp)) {
 
                                 tabButton(
@@ -150,6 +152,8 @@ fun GitDown() {
                                     modifier = Modifier.padding(0.dp, 3.dp, 0.dp, 0.dp)
                                 )
                             }
+                            Spacer(modifier = Modifier.weight(1f))
+                            ExitButton(applicationScope)
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Remove the default OS title bar from the main GitDown window (`undecorated = true`), matching the splash screen's clean look and dropping the redundant project-name title.
- Add an Exit ("X") button to the right of the map/commit/stash toolbar, reusing the existing `ExitButton` composable from `DirectorySelector.kt` (same package, no duplication) so the window remains closable without native chrome.
- Thread `ApplicationScope` into `GitDown()` (from `App.kt`) so the new Exit button can call `applicationScope.exitApplication()`.

## Notes for reviewer
- Window remains draggable via the existing `WindowDraggableArea` wrapping the toolbar row.
- The Exit button performs a full `exitApplication()` (quits the app), matching the naming/behavior of the splash screen's Exit button. This differs from the window's existing `onCloseRequest` (which just clears the selected git directory and returns to the splash screen) — that native close path is now unreachable since the OS chrome is hidden, so the new X button is the primary way to leave the main window.
- Verified `./gradlew build` (compile + full kotest suite) passes locally.

Closes #181