### PR TITLE
fix: retry stageAll on locked git index

### DIFF
--- a/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
+++ b/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.ResetCommand
+import org.eclipse.jgit.api.errors.JGitInternalException
 import org.eclipse.jgit.api.errors.NoHeadException
 import org.eclipse.jgit.diff.DiffEntry
 import org.eclipse.jgit.diff.DiffFormatter
@@ -20,6 +21,7 @@ import org.eclipse.jgit.dircache.DirCacheBuildIterator
 import org.eclipse.jgit.dircache.DirCacheEditor
 import org.eclipse.jgit.dircache.DirCacheEntry
 import org.eclipse.jgit.dircache.DirCacheIterator
+import org.eclipse.jgit.errors.LockFailedException
 import org.eclipse.jgit.lib.Constants.OBJ_BLOB
 import org.eclipse.jgit.lib.FileMode
 import org.eclipse.jgit.lib.Ref
@@ -113,23 +115,56 @@ fun Git.getStashDiff(stash: RevCommit): List<FileDelta> = try {
     emptyList()
 }
 
+private const val INDEX_LOCK_RETRY_MAX_ATTEMPTS = 6
+private const val INDEX_LOCK_RETRY_INITIAL_DELAY_MS = 100L
+private const val INDEX_LOCK_RETRY_BACKOFF_MULTIPLIER = 2
+
+/**
+ *  jgit's add/commit commands lock .git/index while they run, which can throw
+ *  a LockFailedException (wrapped in JGitInternalException) if another process
+ *  is holding that lock. Retry with exponential backoff until it clears.
+ */
+internal fun <T> retryOnIndexLock(
+    maxAttempts: Int = INDEX_LOCK_RETRY_MAX_ATTEMPTS,
+    initialDelayMs: Long = INDEX_LOCK_RETRY_INITIAL_DELAY_MS,
+    fn: () -> T
+): T {
+    var attempt = 1
+    var delayMs = initialDelayMs
+    while (true) {
+        try {
+            return fn()
+        } catch (e: JGitInternalException) {
+            if (e.cause !is LockFailedException || attempt >= maxAttempts) throw e
+            logger.warn("Git index is locked, retrying in ${delayMs}ms (attempt $attempt/$maxAttempts)")
+            Thread.sleep(delayMs)
+            attempt++
+            delayMs *= INDEX_LOCK_RETRY_BACKOFF_MULTIPLIER
+        }
+    }
+}
+
 suspend fun Git.stageAll(): Git = command {
 
     // setUpdate allows us to add deleted files, but disallows adding new files. So we have to do this twice...
-    this@stageAll
-        .add()
-        .addFilepattern(".")
-        .setUpdate(true)
-        .call()
-        .also { logger.info("Staging all files") }
-        .unit()
+    retryOnIndexLock {
+        this@stageAll
+            .add()
+            .addFilepattern(".")
+            .setUpdate(true)
+            .call()
+            .also { logger.info("Staging all files") }
+            .unit()
+    }
 
-    this@stageAll
-        .add()
-        .addFilepattern(".")
-        .call()
-        .also { logger.info("Staging all files") }
-        .unit()
+    retryOnIndexLock {
+        this@stageAll
+            .add()
+            .addFilepattern(".")
+            .call()
+            .also { logger.info("Staging all files") }
+            .unit()
+    }
 
 }
 

--- a/src/test/kotlin/com/codymikol/extensions/GitExtensions.kt
+++ b/src/test/kotlin/com/codymikol/extensions/GitExtensions.kt
@@ -9,11 +9,16 @@ import com.codymikol.data.file.Index
 import com.codymikol.data.file.Status
 import com.codymikol.repository.TestRepository.Companion.createTestRepository
 import com.codymikol.state.GitDownState
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import java.io.File
 import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicInteger
+import org.eclipse.jgit.api.errors.JGitInternalException
+import org.eclipse.jgit.errors.LockFailedException
 
 private fun content(lines: List<String>) = lines.joinToString("\n", postfix = "\n")
 
@@ -730,6 +735,72 @@ class GitExtensions : DescribeSpec({
 
             it("should no longer report the file as missing") {
                 GitDownState.workingDirectory.value.any { it.getPath() == "foo.txt" } shouldBe false
+            }
+
+        }
+
+    }
+
+    describe("stageAll") {
+
+        describe("Staging when the index is locked by another process") {
+
+            val repo = createTestRepository().addFile("foo.txt", "content")
+
+            val lockFile = File(repo.dir.toString(), ".git/index.lock")
+            val lockCreated = lockFile.createNewFile()
+
+            Thread {
+                Thread.sleep(150)
+                lockFile.delete()
+            }.start()
+
+            autoClose(
+                repo
+                    .stageAll()
+                    .transferIntoGitDownState()
+            )
+
+            it("should retry until the lock clears and stage the file") {
+                lockCreated shouldBe true
+                GitDownState.index.value.any { it.getPath() == "foo.txt" } shouldBe true
+            }
+
+        }
+
+    }
+
+    describe("retryOnIndexLock") {
+
+        describe("when every attempt fails because the index is locked") {
+
+            val attempts = AtomicInteger(0)
+            val thrown = shouldThrow<JGitInternalException> {
+                retryOnIndexLock(maxAttempts = 3, initialDelayMs = 1L) {
+                    attempts.incrementAndGet()
+                    throw JGitInternalException("locked", LockFailedException(File("index.lock"), "locked"))
+                }
+            }
+
+            it("should retry until maxAttempts is reached, then rethrow the exception") {
+                attempts.get() shouldBe 3
+                thrown.cause.shouldBeInstanceOf<LockFailedException>()
+            }
+
+        }
+
+        describe("when the failure is not caused by a locked index") {
+
+            val attempts = AtomicInteger(0)
+            shouldThrow<JGitInternalException> {
+                retryOnIndexLock(maxAttempts = 5, initialDelayMs = 1000L) {
+                    attempts.incrementAndGet()
+                    throw JGitInternalException("boom", RuntimeException("not a lock"))
+                }
+            }
+
+            it("should rethrow immediately without retrying") {
+                attempts.get() shouldBe 1
             }
 
         }


### PR DESCRIPTION
## Summary
- Retry jgit's `add` calls in `Git.stageAll()` with exponential backoff when `.git/index.lock` is held by another process, instead of throwing `JGitInternalException`/`LockFailedException` immediately.
- Backoff: 6 attempts, starting at 100ms, doubling each retry.

## Test plan
- [x] New unit test simulates a locked index (creates `.git/index.lock`, releases it after 150ms on a background thread) and asserts `stageAll()` retries and eventually stages the file.
- [x] `./gradlew test` — full suite green.
- [x] `./gradlew build` — green.

Closes #165