### PR TITLE
style: add subtle border radius to viewport panels

### DIFF
--- a/src/main/kotlin/com/codymikol/views/CommitView.kt
+++ b/src/main/kotlin/com/codymikol/views/CommitView.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -12,6 +13,7 @@ import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
@@ -46,6 +48,8 @@ import com.codymikol.typography.GitDownTypography
 import kotlinx.coroutines.launch
 
 
+private val ViewportCornerRadius = 4.dp
+
 val commitMessage = mutableStateOf("")
 val isConfirmingDiscardAll = mutableStateOf(false)
 val isCommitMessageFocused = mutableStateOf(false)
@@ -77,9 +81,10 @@ fun CommitView() {
         Row(modifier = Modifier.weight(40f, true).fillMaxWidth()) {
             Column(
                 modifier = Modifier
-                    .background(Colors.DarkGrayBackground)
                     .weight(40f).fillMaxHeight()
-                    .border(width = 1.dp, color = Color.Black)
+                    .clip(RoundedCornerShape(ViewportCornerRadius))
+                    .background(Colors.DarkGrayBackground)
+                    .border(width = 1.dp, color = Color.Black, shape = RoundedCornerShape(ViewportCornerRadius))
             ) {
                 Column(modifier = Modifier.weight(50f)) { CommitWorkingDirectory() }
                 Column(modifier = Modifier.weight(50f)) { CommitIndex() }
@@ -88,8 +93,9 @@ fun CommitView() {
                 modifier = Modifier
                     .weight(60f)
                     .fillMaxHeight()
+                    .clip(RoundedCornerShape(ViewportCornerRadius))
                     .background(Colors.DarkGrayBackground)
-                    .border(width = 1.dp, color = Color.Black)
+                    .border(width = 1.dp, color = Color.Black, shape = RoundedCornerShape(ViewportCornerRadius))
             ) {
                 DiffPanel()
             }

--- a/src/main/kotlin/com/codymikol/views/MapView.kt
+++ b/src/main/kotlin/com/codymikol/views/MapView.kt
@@ -16,12 +16,14 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -39,6 +41,7 @@ import org.eclipse.jgit.lib.Ref
 private val LaneWidth = 260.dp
 private val NodeRadius = 5.dp
 private val GutterX = 20.dp
+private val ViewportCornerRadius = 4.dp
 private const val LoadMoreThreshold = 5
 
 @Composable
@@ -107,7 +110,8 @@ private fun BranchLane(branch: Ref) {
         modifier = Modifier
             .width(LaneWidth)
             .fillMaxHeight()
-            .border(width = 1.dp, color = Color.Black)
+            .clip(RoundedCornerShape(ViewportCornerRadius))
+            .border(width = 1.dp, color = Color.Black, shape = RoundedCornerShape(ViewportCornerRadius))
     ) {
         Subheader(branchName)
         LazyColumn(state = listState, modifier = Modifier.fillMaxWidth().fillMaxHeight()) {

--- a/src/main/kotlin/com/codymikol/views/StashView.kt
+++ b/src/main/kotlin/com/codymikol/views/StashView.kt
@@ -10,11 +10,13 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.codymikol.components.Subheader
@@ -23,16 +25,19 @@ import com.codymikol.components.stash.StashRow
 import com.codymikol.data.Colors
 import com.codymikol.state.GitDownState
 
+private val ViewportCornerRadius = 4.dp
+
 @Composable
 @Preview
 fun StashView() {
     Row(modifier = Modifier.fillMaxWidth().fillMaxHeight()) {
         Column(
             modifier = Modifier
-                .background(Colors.DarkGrayBackground)
                 .weight(40f)
                 .fillMaxHeight()
-                .border(width = 1.dp, color = Color.Black)
+                .clip(RoundedCornerShape(ViewportCornerRadius))
+                .background(Colors.DarkGrayBackground)
+                .border(width = 1.dp, color = Color.Black, shape = RoundedCornerShape(ViewportCornerRadius))
         ) {
             StashList()
         }
@@ -40,8 +45,9 @@ fun StashView() {
             modifier = Modifier
                 .weight(60f)
                 .fillMaxHeight()
+                .clip(RoundedCornerShape(ViewportCornerRadius))
                 .background(Colors.DarkGrayBackground)
-                .border(width = 1.dp, color = Color.Black)
+                .border(width = 1.dp, color = Color.Black, shape = RoundedCornerShape(ViewportCornerRadius))
         ) {
             StashDiffPanel()
         }


### PR DESCRIPTION
## Summary
- Round the corners of the map (branch lane), commit (working directory / index / diff), and stash (list / diff) viewport panels with a shared 4dp `RoundedCornerShape`, matching the rounded style already used by `TabButton`, `DirectorySelector`, and `ConfirmDialog`.
- Each panel gets `.clip(...)` before its `.background(...)` so the background is actually clipped to the rounded shape, plus a matching `shape` on the `.border(...)` call so the outline follows the same curve.

## Test plan
- No UI test harness exists in this repo (Kotest specs only cover pure functions); this is a declarative styling-only change with no new logic to unit test.
- Could not run `./gradlew test` locally — no JVM/nix devShell available in this sandbox (nix store is read-only here, blocking even basic flake evaluation). CI will compile and run the existing test suite.

Closes #201