### PR TITLE
feat: apply syntax highlighting to diff view

### DIFF
--- a/src/main/kotlin/com/codymikol/components/commit/diff/Diff.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/diff/Diff.kt
@@ -20,6 +20,7 @@ import com.codymikol.data.diff.FileDeltaNode
 import com.codymikol.data.diff.Hunk
 import com.codymikol.data.diff.LineNode
 import com.codymikol.extensions.*
+import com.codymikol.highlight.SyntaxHighlighter
 import com.codymikol.state.Keys
 import com.codymikol.typography.GitDownTypography
 
@@ -113,7 +114,7 @@ fun Diff(fileDeltaNodes: List<FileDeltaNode>, showActions: Boolean = true) {
                 when (item) {
                     is DiffItem.FileHeaderItem -> stickyHeader { FileHeader(item.fileDeltaNode, showActions = showActions) }
                     is DiffItem.HunkHeaderItem -> item { HunkHeader(item.hunk) }
-                    is DiffItem.LineItem -> item { DiffLine(item.lineNode) }
+                    is DiffItem.LineItem -> item { DiffLine(item.lineNode, item.parentFileNode.getPath()) }
                 }
             }
         }
@@ -137,7 +138,7 @@ private fun ModificationTypeGutter(lineNode: LineNode) {
 }
 
 @Composable
-private fun DiffLine(lineNode: LineNode) {
+private fun DiffLine(lineNode: LineNode, filePath: String) {
 
     Box(modifier = Modifier
         .background(lineNode.line.getBackgroundColor())
@@ -149,8 +150,9 @@ private fun DiffLine(lineNode: LineNode) {
             ModificationTypeGutter(lineNode)
 
             val displayLine = lineNode.line.value.replace("\t", "  ")
+            val tokens = remember(filePath, displayLine) { SyntaxHighlighter.highlight(filePath, displayLine) }
 
-            GitDownTypography.DiffContent(displayLine, lineNode.line.getTextColor())
+            GitDownTypography.DiffContent(tokens, lineNode.line.getTextColor())
         }
     }
 }

--- a/src/main/kotlin/com/codymikol/highlight/Grammar.kt
+++ b/src/main/kotlin/com/codymikol/highlight/Grammar.kt
@@ -5,5 +5,6 @@ data class Grammar(
     val extensions: Set<String>,
     val keywords: Set<String> = emptySet(),
     val lineComment: String? = null,
-    val stringDelimiters: Set<Char> = setOf('"', '\'')
+    val stringDelimiters: Set<Char> = setOf('"', '\''),
+    val plainText: Boolean = false
 )

--- a/src/main/kotlin/com/codymikol/highlight/Grammar.kt
+++ b/src/main/kotlin/com/codymikol/highlight/Grammar.kt
@@ -1,0 +1,9 @@
+package com.codymikol.highlight
+
+data class Grammar(
+    val id: String,
+    val extensions: Set<String>,
+    val keywords: Set<String> = emptySet(),
+    val lineComment: String? = null,
+    val stringDelimiters: Set<Char> = setOf('"', '\'')
+)

--- a/src/main/kotlin/com/codymikol/highlight/GrammarRegistry.kt
+++ b/src/main/kotlin/com/codymikol/highlight/GrammarRegistry.kt
@@ -1,0 +1,17 @@
+package com.codymikol.highlight
+
+object GrammarRegistry {
+
+    private val grammars = mutableListOf<Grammar>().apply { addAll(Grammars.ALL) }
+
+    fun register(grammar: Grammar) {
+        grammars.removeAll { it.id == grammar.id }
+        grammars.add(grammar)
+    }
+
+    fun forPath(path: String): Grammar {
+        val extension = path.substringAfterLast('.', "").lowercase()
+        return grammars.firstOrNull { extension in it.extensions } ?: Grammars.PLAIN
+    }
+
+}

--- a/src/main/kotlin/com/codymikol/highlight/GrammarRegistry.kt
+++ b/src/main/kotlin/com/codymikol/highlight/GrammarRegistry.kt
@@ -13,7 +13,7 @@ object GrammarRegistry {
 
     fun forPath(path: String): Grammar {
         val extension = path.substringAfterLast('.', "").lowercase()
-        return grammars.firstOrNull { extension in it.extensions } ?: Grammars.PLAIN
+        return grammars.lastOrNull { extension in it.extensions } ?: Grammars.PLAIN
     }
 
 }

--- a/src/main/kotlin/com/codymikol/highlight/GrammarRegistry.kt
+++ b/src/main/kotlin/com/codymikol/highlight/GrammarRegistry.kt
@@ -1,11 +1,13 @@
 package com.codymikol.highlight
 
+import java.util.concurrent.CopyOnWriteArrayList
+
 object GrammarRegistry {
 
-    private val grammars = mutableListOf<Grammar>().apply { addAll(Grammars.ALL) }
+    private val grammars: MutableList<Grammar> = CopyOnWriteArrayList(Grammars.ALL)
 
     fun register(grammar: Grammar) {
-        grammars.removeAll { it.id == grammar.id }
+        grammars.removeIf { it.id == grammar.id }
         grammars.add(grammar)
     }
 

--- a/src/main/kotlin/com/codymikol/highlight/Grammars.kt
+++ b/src/main/kotlin/com/codymikol/highlight/Grammars.kt
@@ -1,0 +1,55 @@
+package com.codymikol.highlight
+
+object Grammars {
+
+    val PLAIN = Grammar(id = "plain", extensions = emptySet())
+
+    val KOTLIN = Grammar(
+        id = "kotlin",
+        extensions = setOf("kt", "kts"),
+        keywords = setOf(
+            "val", "var", "fun", "class", "object", "interface", "if", "else", "when", "for", "while",
+            "return", "import", "package", "null", "true", "false", "is", "as", "in", "private", "public",
+            "protected", "internal", "override", "companion", "data", "sealed", "enum", "try", "catch",
+            "finally", "throw", "this", "super", "typealias", "suspend", "inline", "const", "lateinit"
+        ),
+        lineComment = "//"
+    )
+
+    val JAVA = Grammar(
+        id = "java",
+        extensions = setOf("java"),
+        keywords = setOf(
+            "public", "private", "protected", "class", "interface", "extends", "implements", "static",
+            "final", "void", "int", "long", "double", "float", "boolean", "char", "byte", "short", "if",
+            "else", "for", "while", "return", "new", "import", "package", "null", "true", "false", "this",
+            "super", "try", "catch", "finally", "throw", "enum", "abstract", "synchronized"
+        ),
+        lineComment = "//"
+    )
+
+    val JAVASCRIPT = Grammar(
+        id = "javascript",
+        extensions = setOf("js", "jsx", "ts", "tsx", "mjs", "cjs"),
+        keywords = setOf(
+            "const", "let", "var", "function", "class", "extends", "if", "else", "for", "while", "return",
+            "import", "export", "from", "default", "null", "undefined", "true", "false", "this", "super",
+            "try", "catch", "finally", "throw", "new", "typeof", "instanceof", "async", "await", "yield"
+        ),
+        lineComment = "//"
+    )
+
+    val PYTHON = Grammar(
+        id = "python",
+        extensions = setOf("py", "pyi"),
+        keywords = setOf(
+            "def", "class", "if", "elif", "else", "for", "while", "return", "import", "from", "as", "None",
+            "True", "False", "try", "except", "finally", "raise", "with", "lambda", "yield", "pass",
+            "break", "continue", "global", "nonlocal", "self", "not", "and", "or", "is", "in"
+        ),
+        lineComment = "#"
+    )
+
+    val ALL = listOf(KOTLIN, JAVA, JAVASCRIPT, PYTHON)
+
+}

--- a/src/main/kotlin/com/codymikol/highlight/Grammars.kt
+++ b/src/main/kotlin/com/codymikol/highlight/Grammars.kt
@@ -2,7 +2,7 @@ package com.codymikol.highlight
 
 object Grammars {
 
-    val PLAIN = Grammar(id = "plain", extensions = emptySet())
+    val PLAIN = Grammar(id = "plain", extensions = emptySet(), plainText = true)
 
     val KOTLIN = Grammar(
         id = "kotlin",

--- a/src/main/kotlin/com/codymikol/highlight/Grammars.kt
+++ b/src/main/kotlin/com/codymikol/highlight/Grammars.kt
@@ -34,7 +34,9 @@ object Grammars {
         keywords = setOf(
             "const", "let", "var", "function", "class", "extends", "if", "else", "for", "while", "return",
             "import", "export", "from", "default", "null", "undefined", "true", "false", "this", "super",
-            "try", "catch", "finally", "throw", "new", "typeof", "instanceof", "async", "await", "yield"
+            "try", "catch", "finally", "throw", "new", "typeof", "instanceof", "async", "await", "yield",
+            "interface", "type", "enum", "implements", "declare", "namespace", "readonly", "public",
+            "private", "protected"
         ),
         lineComment = "//"
     )

--- a/src/main/kotlin/com/codymikol/highlight/SyntaxHighlighter.kt
+++ b/src/main/kotlin/com/codymikol/highlight/SyntaxHighlighter.kt
@@ -1,0 +1,8 @@
+package com.codymikol.highlight
+
+object SyntaxHighlighter {
+
+    fun highlight(path: String, line: String): List<Token> =
+        Tokenizer.tokenize(GrammarRegistry.forPath(path), line)
+
+}

--- a/src/main/kotlin/com/codymikol/highlight/Token.kt
+++ b/src/main/kotlin/com/codymikol/highlight/Token.kt
@@ -1,0 +1,3 @@
+package com.codymikol.highlight
+
+data class Token(val text: String, val kind: TokenKind)

--- a/src/main/kotlin/com/codymikol/highlight/TokenColors.kt
+++ b/src/main/kotlin/com/codymikol/highlight/TokenColors.kt
@@ -4,11 +4,16 @@ import androidx.compose.ui.graphics.Color
 
 object TokenColors {
 
+    private val keywordColor = Color(198, 120, 221)
+    private val stringColor = Color(152, 195, 121)
+    private val commentColor = Color(92, 99, 112)
+    private val numberColor = Color(209, 154, 102)
+
     fun colorFor(kind: TokenKind, baseColor: Color): Color = when (kind) {
-        TokenKind.KEYWORD -> Color(198, 120, 221)
-        TokenKind.STRING -> Color(152, 195, 121)
-        TokenKind.COMMENT -> Color(92, 99, 112)
-        TokenKind.NUMBER -> Color(209, 154, 102)
+        TokenKind.KEYWORD -> keywordColor
+        TokenKind.STRING -> stringColor
+        TokenKind.COMMENT -> commentColor
+        TokenKind.NUMBER -> numberColor
         TokenKind.PLAIN -> baseColor
     }
 

--- a/src/main/kotlin/com/codymikol/highlight/TokenColors.kt
+++ b/src/main/kotlin/com/codymikol/highlight/TokenColors.kt
@@ -1,0 +1,15 @@
+package com.codymikol.highlight
+
+import androidx.compose.ui.graphics.Color
+
+object TokenColors {
+
+    fun colorFor(kind: TokenKind, baseColor: Color): Color = when (kind) {
+        TokenKind.KEYWORD -> Color(198, 120, 221)
+        TokenKind.STRING -> Color(152, 195, 121)
+        TokenKind.COMMENT -> Color(92, 99, 112)
+        TokenKind.NUMBER -> Color(209, 154, 102)
+        TokenKind.PLAIN -> baseColor
+    }
+
+}

--- a/src/main/kotlin/com/codymikol/highlight/TokenKind.kt
+++ b/src/main/kotlin/com/codymikol/highlight/TokenKind.kt
@@ -1,0 +1,9 @@
+package com.codymikol.highlight
+
+enum class TokenKind {
+    KEYWORD,
+    STRING,
+    COMMENT,
+    NUMBER,
+    PLAIN
+}

--- a/src/main/kotlin/com/codymikol/highlight/Tokenizer.kt
+++ b/src/main/kotlin/com/codymikol/highlight/Tokenizer.kt
@@ -1,0 +1,67 @@
+package com.codymikol.highlight
+
+object Tokenizer {
+
+    fun tokenize(grammar: Grammar, line: String): List<Token> {
+        val tokens = mutableListOf<Token>()
+        val plain = StringBuilder()
+        var i = 0
+
+        fun flushPlain() {
+            if (plain.isNotEmpty()) {
+                tokens.add(Token(plain.toString(), TokenKind.PLAIN))
+                plain.clear()
+            }
+        }
+
+        while (i < line.length) {
+            val c = line[i]
+
+            if (grammar.lineComment != null && line.startsWith(grammar.lineComment, i)) {
+                flushPlain()
+                tokens.add(Token(line.substring(i), TokenKind.COMMENT))
+                i = line.length
+                continue
+            }
+
+            if (c in grammar.stringDelimiters) {
+                flushPlain()
+                val start = i
+                val quote = c
+                i++
+                while (i < line.length && line[i] != quote) {
+                    if (line[i] == '\\' && i + 1 < line.length) i++
+                    i++
+                }
+                if (i < line.length) i++
+                tokens.add(Token(line.substring(start, i), TokenKind.STRING))
+                continue
+            }
+
+            if (c.isDigit()) {
+                flushPlain()
+                val start = i
+                while (i < line.length && (line[i].isDigit() || line[i] == '.')) i++
+                tokens.add(Token(line.substring(start, i), TokenKind.NUMBER))
+                continue
+            }
+
+            if (c.isLetter() || c == '_') {
+                flushPlain()
+                val start = i
+                while (i < line.length && (line[i].isLetterOrDigit() || line[i] == '_')) i++
+                val word = line.substring(start, i)
+                val kind = if (word in grammar.keywords) TokenKind.KEYWORD else TokenKind.PLAIN
+                tokens.add(Token(word, kind))
+                continue
+            }
+
+            plain.append(c)
+            i++
+        }
+
+        flushPlain()
+        return tokens
+    }
+
+}

--- a/src/main/kotlin/com/codymikol/highlight/Tokenizer.kt
+++ b/src/main/kotlin/com/codymikol/highlight/Tokenizer.kt
@@ -3,6 +3,10 @@ package com.codymikol.highlight
 object Tokenizer {
 
     fun tokenize(grammar: Grammar, line: String): List<Token> {
+        if (grammar.plainText) {
+            return if (line.isEmpty()) emptyList() else listOf(Token(line, TokenKind.PLAIN))
+        }
+
         val tokens = mutableListOf<Token>()
         val plain = StringBuilder()
         var i = 0

--- a/src/main/kotlin/com/codymikol/typography/GitDownTypography.kt
+++ b/src/main/kotlin/com/codymikol/typography/GitDownTypography.kt
@@ -8,13 +8,18 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.sp
 import com.codymikol.gitdown.generated.resources.*
+import com.codymikol.highlight.Token
+import com.codymikol.highlight.TokenColors
 import org.jetbrains.compose.resources.Font
 
 
@@ -68,9 +73,17 @@ object GitDownTypography {
     }
 
     @Composable
-    fun DiffContent(value: String, color: Color) {
+    fun DiffContent(tokens: List<Token>, baseColor: Color) {
+        val annotatedValue = buildAnnotatedString {
+            tokens.forEach { token ->
+                withStyle(SpanStyle(color = TokenColors.colorFor(token.kind, baseColor))) {
+                    append(token.text)
+                }
+            }
+        }
+
         Text(
-            value,
+            annotatedValue,
             modifier = Modifier.drawBehind {
 
                 // todo(mikol): horrible hack to get gutter lines working on wrapped text...
@@ -91,7 +104,6 @@ object GitDownTypography {
                     )
                 }
             },
-            color = color,
             fontFamily = jetbrainsMono(),
             fontSize = 12.sp
         )

--- a/src/test/kotlin/com/codymikol/highlight/GrammarRegistrySpec.kt
+++ b/src/test/kotlin/com/codymikol/highlight/GrammarRegistrySpec.kt
@@ -1,0 +1,51 @@
+package com.codymikol.highlight
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class GrammarRegistrySpec : DescribeSpec({
+
+    describe("GrammarRegistry") {
+
+        describe("forPath") {
+
+            describe("when the path extension matches a baked-in grammar") {
+
+                it("should resolve the kotlin grammar for a .kt file") {
+                    GrammarRegistry.forPath("src/main/kotlin/Foo.kt").id shouldBe "kotlin"
+                }
+
+                it("should resolve the python grammar for a .py file") {
+                    GrammarRegistry.forPath("scripts/build.py").id shouldBe "python"
+                }
+
+            }
+
+            describe("when the path extension is unrecognized") {
+
+                it("should fall back to the plain grammar") {
+                    GrammarRegistry.forPath("README.md").id shouldBe "plain"
+                }
+
+            }
+
+        }
+
+        describe("register") {
+
+            describe("when a caller registers a custom grammar") {
+
+                val custom = Grammar(id = "custom-lang", extensions = setOf("cstm"), keywords = setOf("FOO"))
+                GrammarRegistry.register(custom)
+
+                it("should resolve paths with the registered extension to that grammar") {
+                    GrammarRegistry.forPath("file.cstm").id shouldBe "custom-lang"
+                }
+
+            }
+
+        }
+
+    }
+
+})

--- a/src/test/kotlin/com/codymikol/highlight/GrammarRegistrySpec.kt
+++ b/src/test/kotlin/com/codymikol/highlight/GrammarRegistrySpec.kt
@@ -44,6 +44,19 @@ class GrammarRegistrySpec : DescribeSpec({
 
             }
 
+            describe("when a caller registers a grammar for an extension a baked-in grammar already owns") {
+
+                it("should let the newly registered grammar override the baked-in one") {
+                    val override = Grammar(id = "kotlin-override", extensions = setOf("kt"), keywords = setOf("FOO"))
+                    GrammarRegistry.register(override)
+
+                    GrammarRegistry.forPath("Foo.kt").id shouldBe "kotlin-override"
+
+                    GrammarRegistry.register(Grammars.KOTLIN)
+                }
+
+            }
+
         }
 
     }

--- a/src/test/kotlin/com/codymikol/highlight/GrammarRegistrySpec.kt
+++ b/src/test/kotlin/com/codymikol/highlight/GrammarRegistrySpec.kt
@@ -35,10 +35,10 @@ class GrammarRegistrySpec : DescribeSpec({
 
             describe("when a caller registers a custom grammar") {
 
-                val custom = Grammar(id = "custom-lang", extensions = setOf("cstm"), keywords = setOf("FOO"))
-                GrammarRegistry.register(custom)
-
                 it("should resolve paths with the registered extension to that grammar") {
+                    val custom = Grammar(id = "custom-lang", extensions = setOf("cstm"), keywords = setOf("FOO"))
+                    GrammarRegistry.register(custom)
+
                     GrammarRegistry.forPath("file.cstm").id shouldBe "custom-lang"
                 }
 

--- a/src/test/kotlin/com/codymikol/highlight/SyntaxHighlighterSpec.kt
+++ b/src/test/kotlin/com/codymikol/highlight/SyntaxHighlighterSpec.kt
@@ -23,6 +23,12 @@ class SyntaxHighlighterSpec : DescribeSpec({
                     SyntaxHighlighter.highlight("README.md", "hello") shouldBe listOf(Token("hello", TokenKind.PLAIN))
                 }
 
+                it("should not misinterpret digits or apostrophes as numbers or strings") {
+                    SyntaxHighlighter.highlight("README.md", "don't stop at 42") shouldBe listOf(
+                        Token("don't stop at 42", TokenKind.PLAIN)
+                    )
+                }
+
             }
 
         }

--- a/src/test/kotlin/com/codymikol/highlight/SyntaxHighlighterSpec.kt
+++ b/src/test/kotlin/com/codymikol/highlight/SyntaxHighlighterSpec.kt
@@ -1,0 +1,32 @@
+package com.codymikol.highlight
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class SyntaxHighlighterSpec : DescribeSpec({
+
+    describe("SyntaxHighlighter") {
+
+        describe("highlight") {
+
+            describe("when the path resolves to a known grammar") {
+
+                it("should tokenize the line using that grammar's keywords") {
+                    SyntaxHighlighter.highlight("Main.kt", "val") shouldBe listOf(Token("val", TokenKind.KEYWORD))
+                }
+
+            }
+
+            describe("when the path does not resolve to a known grammar") {
+
+                it("should tokenize the line as plain text") {
+                    SyntaxHighlighter.highlight("README.md", "hello") shouldBe listOf(Token("hello", TokenKind.PLAIN))
+                }
+
+            }
+
+        }
+
+    }
+
+})

--- a/src/test/kotlin/com/codymikol/highlight/TokenColorsSpec.kt
+++ b/src/test/kotlin/com/codymikol/highlight/TokenColorsSpec.kt
@@ -1,0 +1,37 @@
+package com.codymikol.highlight
+
+import androidx.compose.ui.graphics.Color
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class TokenColorsSpec : DescribeSpec({
+
+    describe("TokenColors") {
+
+        describe("colorFor") {
+
+            describe("when the token is plain") {
+
+                it("should return the supplied base color unchanged") {
+                    TokenColors.colorFor(TokenKind.PLAIN, Color.White) shouldBe Color.White
+                }
+
+            }
+
+            describe("when the token is a keyword, string, comment, or number") {
+
+                it("should return a color distinct from the base color for each") {
+                    TokenColors.colorFor(TokenKind.KEYWORD, Color.White) shouldNotBe Color.White
+                    TokenColors.colorFor(TokenKind.STRING, Color.White) shouldNotBe Color.White
+                    TokenColors.colorFor(TokenKind.COMMENT, Color.White) shouldNotBe Color.White
+                    TokenColors.colorFor(TokenKind.NUMBER, Color.White) shouldNotBe Color.White
+                }
+
+            }
+
+        }
+
+    }
+
+})

--- a/src/test/kotlin/com/codymikol/highlight/TokenizerSpec.kt
+++ b/src/test/kotlin/com/codymikol/highlight/TokenizerSpec.kt
@@ -70,6 +70,26 @@ class TokenizerSpec : DescribeSpec({
 
             }
 
+            describe("when the string contains an escaped quote") {
+
+                it("should include the escaped quote in the string token instead of ending the string early") {
+                    Tokenizer.tokenize(grammar, "\"a\\\"b\"") shouldBe listOf(
+                        Token("\"a\\\"b\"", TokenKind.STRING)
+                    )
+                }
+
+            }
+
+            describe("when a string is missing its closing quote") {
+
+                it("should classify the rest of the line as a single string token") {
+                    Tokenizer.tokenize(grammar, "\"unterminated") shouldBe listOf(
+                        Token("\"unterminated", TokenKind.STRING)
+                    )
+                }
+
+            }
+
         }
 
         describe("when the grammar has no syntax rules") {

--- a/src/test/kotlin/com/codymikol/highlight/TokenizerSpec.kt
+++ b/src/test/kotlin/com/codymikol/highlight/TokenizerSpec.kt
@@ -1,0 +1,77 @@
+package com.codymikol.highlight
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class TokenizerSpec : DescribeSpec({
+
+    describe("Tokenizer") {
+
+        describe("tokenize") {
+
+            val grammar = Grammar(
+                id = "test",
+                extensions = setOf("test"),
+                keywords = setOf("val", "fun"),
+                lineComment = "//"
+            )
+
+            describe("when a word matches a grammar keyword") {
+
+                it("should classify it as a keyword token") {
+                    Tokenizer.tokenize(grammar, "val") shouldBe listOf(Token("val", TokenKind.KEYWORD))
+                }
+
+            }
+
+            describe("when a word does not match a grammar keyword") {
+
+                it("should classify it as a plain token") {
+                    Tokenizer.tokenize(grammar, "value") shouldBe listOf(Token("value", TokenKind.PLAIN))
+                }
+
+            }
+
+            describe("when the line contains a quoted string") {
+
+                it("should classify the quoted span as a single string token") {
+                    Tokenizer.tokenize(grammar, "val a = \"hi\"") shouldBe listOf(
+                        Token("val", TokenKind.KEYWORD),
+                        Token(" ", TokenKind.PLAIN),
+                        Token("a", TokenKind.PLAIN),
+                        Token(" = ", TokenKind.PLAIN),
+                        Token("\"hi\"", TokenKind.STRING)
+                    )
+                }
+
+            }
+
+            describe("when the line contains a line comment") {
+
+                it("should classify everything from the comment marker onward as a comment token") {
+                    Tokenizer.tokenize(grammar, "1 // note") shouldBe listOf(
+                        Token("1", TokenKind.NUMBER),
+                        Token(" ", TokenKind.PLAIN),
+                        Token("// note", TokenKind.COMMENT)
+                    )
+                }
+
+            }
+
+            describe("when the line contains a numeric literal") {
+
+                it("should classify the digits as a number token") {
+                    Tokenizer.tokenize(grammar, "x = 42.5") shouldBe listOf(
+                        Token("x", TokenKind.PLAIN),
+                        Token(" = ", TokenKind.PLAIN),
+                        Token("42.5", TokenKind.NUMBER)
+                    )
+                }
+
+            }
+
+        }
+
+    }
+
+})

--- a/src/test/kotlin/com/codymikol/highlight/TokenizerSpec.kt
+++ b/src/test/kotlin/com/codymikol/highlight/TokenizerSpec.kt
@@ -72,6 +72,16 @@ class TokenizerSpec : DescribeSpec({
 
         }
 
+        describe("when the grammar has no syntax rules") {
+
+            it("should classify the whole line as a single plain token without scanning for numbers or strings") {
+                Tokenizer.tokenize(Grammars.PLAIN, "don't stop at 42") shouldBe listOf(
+                    Token("don't stop at 42", TokenKind.PLAIN)
+                )
+            }
+
+        }
+
     }
 
 })


### PR DESCRIPTION
## Summary
- Adds a pluggable syntax-highlighting layer under `com.codymikol.highlight`: a `Grammar` model, a `Tokenizer` that classifies line text into keyword/string/comment/number/plain tokens, and a `GrammarRegistry` with baked-in grammars for Kotlin, Java, JavaScript/TypeScript, and Python. Callers can `GrammarRegistry.register(...)` additional grammars at runtime, satisfying the plugin-based extensibility the issue asked for.
- Wires this into the diff view: `Diff.kt` resolves the grammar from each line's file path and renders each token in its grammar-appropriate color via an `AnnotatedString`, replacing the previous single-flat-color line rendering in `GitDownTypography.DiffContent`.

## Scope note
Full tree-sitter grammar ingestion (native bindings, prebuilt per-platform binaries) isn't practical to wire into this Gradle/JVM desktop app without network access to fetch/build native libraries, and no such bindings currently exist in the dependency graph. Instead this implements a lightweight, pure-Kotlin, per-line lexer that satisfies the issue's "plugin based solution where grammars ... baked into the project" ask without that native dependency. Known accepted tradeoffs of a line-scoped lexer (flagged and accepted during review): no block-comment/multi-line-string spanning across diff lines, and no context-aware keyword suppression (e.g. `foo.val` still colors `val` as a keyword).

## Testing
This sandbox has no JDK/Gradle toolchain available (no `java` binary; `nix develop`/`nix flake check` fail with a read-only `/nix/store` permission error, and there's no fallback baked JDK either), so `./gradlew test`/`build` could not be run locally. All new logic (`Tokenizer`, `GrammarRegistry`, `SyntaxHighlighter`, `TokenColors`) is covered by new Kotest specs and was hand-traced against those specs for correctness. CI (`actions/setup-java` + `./gradlew build`) will be the first real execution of the test suite — please watch it closely.

Closes #180