### PR TITLE
feat: select first file when opening commit view

### DIFF
--- a/src/main/kotlin/com/codymikol/state/state.kt
+++ b/src/main/kotlin/com/codymikol/state/state.kt
@@ -179,6 +179,11 @@ object GitDownState {
         if (tab == Tab.Stash) {
             selectedStash.value = stashes.value.firstOrNull()
         }
+
+        if (tab == Tab.Commit && selectedFiles.isEmpty()) {
+            val firstFile = workingDirectory.value.firstOrNull() ?: index.value.firstOrNull()
+            firstFile?.let { selectedFiles.add(it) }
+        }
     }
 
     fun selectAdjacentFile(offset: Int) {

--- a/src/test/kotlin/com/codymikol/state/GitDownStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/GitDownStateSpec.kt
@@ -770,6 +770,81 @@ class GitDownStateSpec : DescribeSpec({
 
             }
 
+            describe("when switching to the Commit tab and there are files in the working directory") {
+
+                autoClose(
+                    createTestRepository()
+                        .addFile("a.txt", "A")
+                        .addFile("b.txt", "B")
+                        .transferIntoGitDownState()
+                )
+
+                it("should select the first working directory file") {
+                    GitDownState.selectedFiles.clear()
+
+                    GitDownState.selectTab(Tab.Commit)
+
+                    GitDownState.selectedFiles.toList() shouldBe listOf(GitDownState.workingDirectory.value.toList()[0])
+                }
+
+            }
+
+            describe("when switching to the Commit tab and the working directory is empty but the index has files") {
+
+                autoClose(
+                    createTestRepository()
+                        .addFile("foo.txt", "Foo")
+                        .addFile("bar.txt", "Bar")
+                        .stageAll()
+                        .transferIntoGitDownState()
+                )
+
+                it("should select the first index file") {
+                    GitDownState.selectedFiles.clear()
+
+                    GitDownState.selectTab(Tab.Commit)
+
+                    GitDownState.selectedFiles.toList() shouldBe listOf(GitDownState.index.value.toList()[0])
+                }
+
+            }
+
+            describe("when switching to the Commit tab and there are no files at all") {
+
+                autoClose(createTestRepository().transferIntoGitDownState())
+
+                it("should leave no file selected") {
+                    GitDownState.selectedFiles.clear()
+
+                    GitDownState.selectTab(Tab.Commit)
+
+                    GitDownState.selectedFiles.toList() shouldBe emptyList()
+                }
+
+            }
+
+            describe("when switching to the Commit tab and a file is already selected") {
+
+                autoClose(
+                    createTestRepository()
+                        .addFile("a.txt", "A")
+                        .addFile("b.txt", "B")
+                        .transferIntoGitDownState()
+                )
+
+                it("should leave the existing selection untouched") {
+                    val files = GitDownState.workingDirectory.value.toList()
+
+                    GitDownState.selectedFiles.clear()
+                    GitDownState.selectedFiles.add(files[1])
+
+                    GitDownState.selectTab(Tab.Commit)
+
+                    GitDownState.selectedFiles.toList() shouldBe listOf(files[1])
+                }
+
+            }
+
         }
 
         describe("isValidGitDirectory") {


### PR DESCRIPTION
## Summary
- Auto-select the first working directory file when switching to the Commit tab.
- Fall back to the first index file when the working directory has no changes.
- Leave an existing selection untouched (no-op if selectedFiles already populated).

## Test plan
- `./gradlew test` — full suite passes, including 4 new `GitDownStateSpec` cases under `selectTab`: working-directory-first-file selection, index fallback, no files → no selection, existing selection preserved.

Closes #163