### PR TITLE
fix: hide Delete File for tracked working dir changes

### DIFF
--- a/src/main/kotlin/com/codymikol/components/commit/diff/file/header/action/buttons/FileHeaderCogButtonWorkingDirectory.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/diff/file/header/action/buttons/FileHeaderCogButtonWorkingDirectory.kt
@@ -11,11 +11,15 @@ import com.codymikol.components.commit.ConfirmDialog
 import com.codymikol.components.menu.MenuColors
 import com.codymikol.components.menu.ThemedDropdownMenuItem
 import com.codymikol.data.diff.FileDeltaNode
+import com.codymikol.data.file.FileDelta
+import com.codymikol.data.file.WorkingDirectory
 import com.codymikol.extensions.deleteFile
 import com.codymikol.extensions.discardFile
 import com.codymikol.extensions.openFile
 import com.codymikol.state.GitDownState
 import kotlinx.coroutines.launch
+
+fun isNewUntrackedFile(fileDelta: FileDelta): Boolean = fileDelta is WorkingDirectory.FileAdded
 
 @Composable
 fun FileHeaderCogButtonWorkingDirectory(fileDeltaNode: FileDeltaNode) {
@@ -30,8 +34,11 @@ fun FileHeaderCogButtonWorkingDirectory(fileDeltaNode: FileDeltaNode) {
         FileActionMenuItem("Open File", dismiss) { GitDownState.git.value.openFile(fileDeltaNode.fileDelta.location) }
         FileActionMenuItem("Show In Files", dismiss) { fileSystemService.showInFiles(fileDeltaNode.fileDelta.location) }
         Divider(color = MenuColors.Divider)
-        ThemedDropdownMenuItem(label = "Discard Changes", onClick = { isConfirmingDiscard = true; dismiss() })
-        ThemedDropdownMenuItem(label = "Delete File", onClick = { isConfirmingDelete = true; dismiss() })
+        if (isNewUntrackedFile(fileDeltaNode.fileDelta)) {
+            ThemedDropdownMenuItem(label = "Delete File", onClick = { isConfirmingDelete = true; dismiss() })
+        } else {
+            ThemedDropdownMenuItem(label = "Discard Changes", onClick = { isConfirmingDiscard = true; dismiss() })
+        }
     }
 
     if (isConfirmingDiscard) {

--- a/src/test/kotlin/com/codymikol/components/commit/diff/file/header/action/buttons/FileHeaderCogButtonWorkingDirectorySpec.kt
+++ b/src/test/kotlin/com/codymikol/components/commit/diff/file/header/action/buttons/FileHeaderCogButtonWorkingDirectorySpec.kt
@@ -1,0 +1,38 @@
+package com.codymikol.components.commit.diff.file.header.action.buttons
+
+import com.codymikol.data.file.WorkingDirectory
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.nio.file.Path
+
+class FileHeaderCogButtonWorkingDirectorySpec : DescribeSpec({
+
+    describe("isNewUntrackedFile") {
+
+        describe("when the file is newly added and untracked") {
+
+            it("should return true") {
+                isNewUntrackedFile(WorkingDirectory.FileAdded(Path.of("new-file.txt"))) shouldBe true
+            }
+
+        }
+
+        describe("when the file is a tracked modification") {
+
+            it("should return false") {
+                isNewUntrackedFile(WorkingDirectory.FileModified(Path.of("existing.txt"))) shouldBe false
+            }
+
+        }
+
+        describe("when the file is a tracked deletion") {
+
+            it("should return false") {
+                isNewUntrackedFile(WorkingDirectory.FileDeleted(Path.of("existing.txt"))) shouldBe false
+            }
+
+        }
+
+    }
+
+})


### PR DESCRIPTION
## Summary
- Working Directory cog dropdown showed both "Discard Changes" and "Delete File" unconditionally.
- "Delete File" now only renders for new, untracked files (`WorkingDirectory.FileAdded`); "Discard Changes" renders otherwise (tracked modifications/deletions), so the two are mutually exclusive.

## Test plan
- [x] Added `FileHeaderCogButtonWorkingDirectorySpec` covering `isNewUntrackedFile` for FileAdded/FileModified/FileDeleted.
- [x] `./gradlew build` (full suite, matches CI) green.

Closes #203