### PR TITLE
fix: Open File always uses OS default handler

### DIFF
--- a/src/main/kotlin/com/codymikol/extensions/EditorExtensions.kt
+++ b/src/main/kotlin/com/codymikol/extensions/EditorExtensions.kt
@@ -8,31 +8,6 @@ import java.nio.file.Path
 
 private val logger = LoggerFactory.getLogger("EditorExtensions")
 
-/**
- *  Mirrors git's own precedence for choosing an editor: the GIT_EDITOR
- *  environment variable wins over the repository's core.editor config.
- *  Returns null when neither is configured so callers can fall back to
- *  the system's default file handler.
- */
-fun Git.getConfiguredEditor(getenv: (String) -> String? = System::getenv): String? =
-    getenv("GIT_EDITOR")?.takeIf { it.isNotBlank() }
-        ?: this.repository.config.getString("core", null, "editor")?.takeIf { it.isNotBlank() }
-
-/**
- *  Splits a configured editor command (which may itself carry flags, e.g.
- *  `code --wait`, and quoted paths, e.g. `"/opt/My Editor/bin/edit" -w`)
- *  into process arguments and appends the target file, without involving a
- *  shell.
- */
-fun buildEditorCommand(editorCommand: String, file: File): List<String> {
-    val tokenPattern = Regex("""'([^']*)'|"([^"]*)"|(\S+)""")
-    val tokens = tokenPattern.findAll(editorCommand.trim()).map { match ->
-        match.groupValues.drop(1).firstOrNull { it.isNotEmpty() } ?: ""
-    }.filter { it.isNotEmpty() }.toList()
-
-    return tokens + file.absolutePath
-}
-
 private fun openWithSystemDefaultEditor(file: File) {
     if (!Desktop.isDesktopSupported() || !Desktop.getDesktop().isSupported(Desktop.Action.OPEN)) {
         logger.error("Desktop open is not supported on this platform, unable to open file: ${file.absolutePath}")
@@ -41,16 +16,15 @@ private fun openWithSystemDefaultEditor(file: File) {
     Desktop.getDesktop().open(file)
 }
 
-fun Git.openFile(path: Path): Unit = try {
-    val file = this.repository.workTree.resolve(path.toFile())
-
-    when (val editor = getConfiguredEditor()) {
-        null -> openWithSystemDefaultEditor(file)
-        else -> {
-            ProcessBuilder(buildEditorCommand(editor, file)).start()
-            Unit
-        }
-    }
+/**
+ *  Always opens via the OS's default file handler. A configured git editor
+ *  (GIT_EDITOR/core.editor) is meant for git's own short-lived, terminal-attached
+ *  edits (commit messages, rebase todo) — spawning it here detached from any
+ *  terminal silently does nothing for common terminal editors (vim, nano, ...),
+ *  which is why "Open File" must not route through it.
+ */
+fun Git.openFile(path: Path, open: (File) -> Unit = ::openWithSystemDefaultEditor): Unit = try {
+    open(File(this.repository.workTree, path.toString()))
 } catch (e: Exception) {
     logger.error("An exception was thrown while opening file $path: ${e.message}")
 }

--- a/src/test/kotlin/com/codymikol/extensions/EditorExtensionsSpec.kt
+++ b/src/test/kotlin/com/codymikol/extensions/EditorExtensionsSpec.kt
@@ -4,61 +4,39 @@ import com.codymikol.repository.TestRepository.Companion.createTestRepository
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import java.io.File
+import java.nio.file.Path
 
 class EditorExtensionsSpec : DescribeSpec({
 
-    describe("Git.getConfiguredEditor") {
+    describe("Git.openFile") {
 
-        it("prefers the GIT_EDITOR environment variable over core.editor") {
+        it("opens the file with the system default handler, ignoring a configured terminal editor") {
             val repo = createTestRepository()
-            repo.git.repository.config.setString("core", null, "editor", "configured-editor")
+            repo.addFile("foo.txt", "hello")
+            // A terminal editor (vim, nano, or CI's noop "true") launched without a
+            // controlling terminal silently does nothing, which is exactly the bug
+            // this test guards against: "Open File" must always use the OS's default
+            // file handler rather than git's commit-message editor.
+            repo.git.repository.config.setString("core", null, "editor", "true")
 
-            repo.git.getConfiguredEditor(getenv = { key -> if (key == "GIT_EDITOR") "env-editor" else null }) shouldBe "env-editor"
+            var opened: File? = null
+            repo.git.openFile(Path.of("foo.txt"), open = { opened = it })
+
+            opened shouldBe File(repo.git.repository.workTree, "foo.txt")
 
             repo.closeGitRepo()
         }
 
-        it("falls back to core.editor when GIT_EDITOR is unset") {
+        it("resolves nested paths relative to the repository's work tree") {
             val repo = createTestRepository()
-            repo.git.repository.config.setString("core", null, "editor", "configured-editor")
+            repo.addFile("nested/dir/foo.txt", "hello")
 
-            repo.git.getConfiguredEditor(getenv = { null }) shouldBe "configured-editor"
+            var opened: File? = null
+            repo.git.openFile(Path.of("nested/dir/foo.txt"), open = { opened = it })
+
+            opened shouldBe File(repo.git.repository.workTree, "nested/dir/foo.txt")
 
             repo.closeGitRepo()
-        }
-
-        it("returns null when neither is configured") {
-            val repo = createTestRepository()
-
-            repo.git.getConfiguredEditor(getenv = { null }) shouldBe null
-
-            repo.closeGitRepo()
-        }
-
-        it("treats a blank GIT_EDITOR as unset") {
-            val repo = createTestRepository()
-            repo.git.repository.config.setString("core", null, "editor", "configured-editor")
-
-            repo.git.getConfiguredEditor(getenv = { key -> if (key == "GIT_EDITOR") "" else null }) shouldBe "configured-editor"
-
-            repo.closeGitRepo()
-        }
-
-    }
-
-    describe("buildEditorCommand") {
-
-        it("appends the file path to a simple command") {
-            buildEditorCommand("vim", File("/tmp/foo.txt")) shouldBe listOf("vim", "/tmp/foo.txt")
-        }
-
-        it("splits flags from the editor command") {
-            buildEditorCommand("code --wait", File("/tmp/foo.txt")) shouldBe listOf("code", "--wait", "/tmp/foo.txt")
-        }
-
-        it("preserves quoted segments containing spaces as a single token") {
-            buildEditorCommand("\"/opt/My Editor/bin/edit\" -w", File("/tmp/foo.txt")) shouldBe
-                listOf("/opt/My Editor/bin/edit", "-w", "/tmp/foo.txt")
         }
 
     }


### PR DESCRIPTION
## Summary

- `Git.openFile` routed through a configured `GIT_EDITOR`/`core.editor` via `ProcessBuilder` before falling back to the OS default handler. Terminal editors (vim, nano, or a CI noop like `true`) launched detached from any terminal render nothing, so the "Open File" button silently did nothing for anyone with a terminal-based git editor configured — reproduced exactly by this sandbox's `GIT_EDITOR=true`. `core.editor` is meant for git's own short-lived, terminal-attached edits (commit messages, rebase todo), not for opening a file to view in a GUI.
- Dropped the editor-precedence branch entirely (`getConfiguredEditor`/`buildEditorCommand`, now unused, removed along with their tests). `openFile` always resolves the file against the repo's work tree and opens it with `Desktop.open` via an injectable `open` param (mirrors the existing `FileSystemService.showInFiles` testability pattern).
- Added `EditorExtensionsSpec` coverage for `Git.openFile`: opens via the injected handler even with a terminal editor configured, and resolves nested paths correctly.

## Note for reviewer

Local `nix develop`/`nix build`/`nix flake check` could not run in this sandbox — the Nix store is unwritable (no daemon, no root, no baked JDK fallback), confirmed as a pre-existing environment limitation reproducible on a clean `main` checkout, unrelated to this diff. Verified manually (types, imports, call sites) and via an independent reviewer subagent (verdict: APPROVE). Relying on this PR's CI run as the actual build/test gate.

Closes #205