### PR TITLE
feat: stash bottom toolbar

### DIFF
--- a/src/main/kotlin/com/codymikol/components/stash/StashBottomToolbar.kt
+++ b/src/main/kotlin/com/codymikol/components/stash/StashBottomToolbar.kt
@@ -1,0 +1,38 @@
+package com.codymikol.components.stash
+
+import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.codymikol.components.SlimButton
+import com.codymikol.data.Colors
+
+fun stashToolbarButtonClicked(buttonText: String) = println(buttonText)
+
+@Composable
+@Preview
+fun StashBottomToolbar() {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+        modifier = Modifier
+            .fillMaxWidth()
+            .requiredHeight(48.dp)
+            .background(Colors.MediumGrayBackground)
+            .padding(horizontal = 8.dp)
+    ) {
+        SlimButton("Apply", onClick = { stashToolbarButtonClicked("Apply") })
+
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            SlimButton("+", modifier = Modifier.padding(end = 8.dp), onClick = { stashToolbarButtonClicked("+") })
+            SlimButton("-", onClick = { stashToolbarButtonClicked("-") })
+        }
+    }
+}

--- a/src/main/kotlin/com/codymikol/views/StashView.kt
+++ b/src/main/kotlin/com/codymikol/views/StashView.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.codymikol.components.Subheader
 import com.codymikol.components.commit.diff.Diff
+import com.codymikol.components.stash.StashBottomToolbar
 import com.codymikol.components.stash.StashRow
 import com.codymikol.data.Colors
 import com.codymikol.state.GitDownState
@@ -68,6 +69,7 @@ private fun ColumnScope.StashList() {
         }
         false -> StashEmptyState("No stashes")
     }
+    StashBottomToolbar()
 }
 
 @Composable

--- a/src/test/kotlin/com/codymikol/components/stash/StashBottomToolbarSpec.kt
+++ b/src/test/kotlin/com/codymikol/components/stash/StashBottomToolbarSpec.kt
@@ -1,0 +1,26 @@
+package com.codymikol.components.stash
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+
+class StashBottomToolbarSpec : DescribeSpec({
+
+    describe("stashToolbarButtonClicked") {
+
+        it("prints the button text to the console") {
+            val originalOut = System.out
+            val captured = ByteArrayOutputStream()
+            try {
+                System.setOut(PrintStream(captured))
+                stashToolbarButtonClicked("Apply")
+            } finally {
+                System.setOut(originalOut)
+            }
+            captured.toString().trim() shouldBe "Apply"
+        }
+
+    }
+
+})


### PR DESCRIPTION
## Summary
- Adds a fixed bottom toolbar to the stash list viewport with `+` / `-` buttons justified right and an `Apply` button justified left, mirroring the layout pattern used by `CommitBottomToolbar`.
- Each button currently logs its own label to the console via `stashToolbarButtonClicked`; real stash operations are deferred to a future item per the issue.

Closes #202

## Test plan
- [x] `./gradlew test` — full suite green (171 tests)
- [x] New unit test covers `stashToolbarButtonClicked` printing its argument to stdout