### PR TITLE
feat: apply ReversedEllipsisText to changed file rows

### DIFF
--- a/src/main/kotlin/com/codymikol/components/commit/ChangedFile.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/ChangedFile.kt
@@ -4,20 +4,21 @@ import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.codymikol.components.ReversedEllipsisText
 import com.codymikol.data.file.FileDelta
 import com.codymikol.data.file.WorkingDirectory
 import com.codymikol.state.GitDownState
 import com.codymikol.state.Keys
 import java.nio.file.Path
 
+fun changedFileDisplayText(fileDelta: FileDelta): String = fileDelta.getPath()
 
 @Composable
 fun ChangedFile(fileDelta: FileDelta) {
@@ -37,13 +38,12 @@ fun ChangedFile(fileDelta: FileDelta) {
         .background(color), verticalAlignment = Alignment.CenterVertically) {
         Spacer(modifier = Modifier.width(12.dp))
         FileIcon(letter = fileDelta.letter, color = fileDelta.color, borderColor = fileDelta.borderColor)
-        Text(
-            fileDelta.location.toString().split("/").last(),
-            modifier = Modifier.padding(6.dp, 0.dp, 0.dp, 0.dp),
-            softWrap = false,
-            overflow = TextOverflow.Ellipsis,
+        ReversedEllipsisText(
+            text = changedFileDisplayText(fileDelta),
+            modifier = Modifier.weight(1f).padding(6.dp, 0.dp, 0.dp, 0.dp),
             color = Color.White,
-            fontSize = 12.sp
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Normal
         )
     }
 }

--- a/src/test/kotlin/com/codymikol/components/commit/ChangedFileSpec.kt
+++ b/src/test/kotlin/com/codymikol/components/commit/ChangedFileSpec.kt
@@ -1,0 +1,23 @@
+package com.codymikol.components.commit
+
+import com.codymikol.data.file.WorkingDirectory
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import java.nio.file.Path
+
+class ChangedFileSpec : DescribeSpec({
+
+    describe("changedFileDisplayText") {
+
+        it("should return the fully qualified file path, not just the file name") {
+            val path = Path.of("src", "main", "kotlin", "com", "codymikol", "Foo.kt")
+            val fileDelta = WorkingDirectory.FileModified(path)
+
+            changedFileDisplayText(fileDelta) shouldBe path.toString()
+            changedFileDisplayText(fileDelta) shouldNotBe "Foo.kt"
+        }
+
+    }
+
+})


### PR DESCRIPTION
## Summary
- Working Directory and Index rows now show the fully qualified file path instead of just the basename.
- Uses the existing `ReversedEllipsisText` component so long paths truncate from the front, keeping the filename (the most important part) visible.
- Extracted `changedFileDisplayText(fileDelta)` as a small testable seam.

Closes #206

## Test plan
- [x] `./gradlew test` passes (full suite)
- [x] New `ChangedFileSpec` asserts the display text is the full path, not just the filename