### PR TITLE
fix: resolve showInFiles path against working tree

### DIFF
--- a/src/main/kotlin/com/codymikol/services/FileSystemService.kt
+++ b/src/main/kotlin/com/codymikol/services/FileSystemService.kt
@@ -1,5 +1,6 @@
 package com.codymikol.services
 
+import com.codymikol.state.GitDownState
 import org.koin.core.annotation.Single
 import java.awt.Desktop
 import java.io.File
@@ -9,11 +10,14 @@ import java.nio.file.Path
 class FileSystemService {
 
     /**
-     * Reveals [path] in the operating system's default file viewer. [reveal] is injected so
-     * the file/directory resolution can be unit tested without invoking the real AWT Desktop.
+     * Reveals [path] in the operating system's default file viewer. [path] is resolved against
+     * the repository's working tree since git status paths are repo-relative; without that
+     * resolution a repo-root-level file has no parent directory, which crashes [revealInDesktop]
+     * on platforms without BROWSE_FILE_DIR support. [reveal] is injected so the file/directory
+     * resolution can be unit tested without invoking the real AWT Desktop.
      */
     fun showInFiles(path: Path, reveal: (File) -> Unit = ::revealInDesktop) {
-        reveal(path.toFile())
+        reveal(GitDownState.repo.value.workTree.toPath().resolve(path).toFile())
     }
 
     companion object {

--- a/src/test/kotlin/com/codymikol/services/FileSystemServiceSpec.kt
+++ b/src/test/kotlin/com/codymikol/services/FileSystemServiceSpec.kt
@@ -1,5 +1,6 @@
 package com.codymikol.services
 
+import com.codymikol.repository.TestRepository.Companion.createTestRepository
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import java.io.File
@@ -11,14 +12,41 @@ class FileSystemServiceSpec : DescribeSpec({
 
         describe("showInFiles") {
 
-            it("should reveal the file at the given path") {
+            it("should resolve a repo-root-level file against the working tree") {
+                val repository = createTestRepository().addFile("README.md", "hello").transferIntoGitDownState()
+                autoClose(repository)
+
                 val service = FileSystemService()
-                val path = Path.of("/tmp/gitdown/example.txt")
                 var revealed: File? = null
 
-                service.showInFiles(path) { file -> revealed = file }
+                service.showInFiles(Path.of("README.md")) { file -> revealed = file }
 
-                revealed shouldBe path.toFile()
+                revealed shouldBe File(repository.dir.toFile(), "README.md")
+            }
+
+            it("should resolve a nested file against the working tree") {
+                val repository = createTestRepository().addFile("src/foo.txt", "hello").transferIntoGitDownState()
+                autoClose(repository)
+
+                val service = FileSystemService()
+                var revealed: File? = null
+
+                service.showInFiles(Path.of("src/foo.txt")) { file -> revealed = file }
+
+                revealed shouldBe File(repository.dir.toFile(), "src/foo.txt")
+            }
+
+            it("should pass an already-absolute path through unchanged") {
+                val repository = createTestRepository().transferIntoGitDownState()
+                autoClose(repository)
+
+                val service = FileSystemService()
+                val absolute = Path.of("/tmp/gitdown/example.txt")
+                var revealed: File? = null
+
+                service.showInFiles(absolute) { file -> revealed = file }
+
+                revealed shouldBe absolute.toFile()
             }
 
         }


### PR DESCRIPTION
## Summary
- `showInFiles` passed the repo-relative git status path straight to AWT `Desktop` without resolving it against the repository's working tree.
- On platforms without `Desktop.Action.BROWSE_FILE_DIR` support, `revealInDesktop` falls back to `desktop.open(file.parentFile)`. For a repo-root-level file (e.g. `README.md`), the unresolved relative path has no parent, so `parentFile` is `null` and `Desktop.open(null)` throws the reported NPE.
- Fix: resolve the path against `GitDownState.repo.value.workTree` first (same pattern as `Git.openFile`), so the resulting file always has a real parent directory.

## Test plan
- [x] Added/updated unit tests in `FileSystemServiceSpec` covering: repo-root-level file resolution, nested file resolution, and absolute-path passthrough.
- [ ] Could not run `./gradlew test` locally — this sandbox has no JDK and a read-only, offline nix store (`nix develop`/`nix build` fail with permission-denied). CI (`.github/workflows/ci.yml`, JDK 21 via `actions/setup-java`) is the actual test gate.

Closes #204