### PR TITLE
fix: expand branch name to fill toolbar and ellipsis-truncate

### DIFF
--- a/src/main/kotlin/com/codymikol/components/commit/CommitBottomToolbar.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/CommitBottomToolbar.kt
@@ -41,14 +41,9 @@ fun BoldText(_text: String, modifier: Modifier = Modifier) = Text(
 )
 
 
-const val MAX_BRANCH_NAME_LENGTH = 40
-
-fun truncateBranchName(branchName: String, maxLength: Int = MAX_BRANCH_NAME_LENGTH): String =
-    if (branchName.length > maxLength) branchName.take(maxLength) + "..." else branchName
-
 fun getObjectName(isDetatchedHead: Boolean, branchName: String): String = when (isDetatchedHead) {
     true -> "HEAD"
-    false -> truncateBranchName(branchName)
+    false -> branchName
 }
 
 fun getObjectNamePrefix(isDetatchedHead: Boolean): String = "on " + when (isDetatchedHead) {

--- a/src/main/kotlin/com/codymikol/components/commit/CommitBottomToolbar.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/CommitBottomToolbar.kt
@@ -35,6 +35,7 @@ fun BoldText(_text: String, modifier: Modifier = Modifier) = Text(
     fontWeight = FontWeight.Bold,
     color = Colors.LightGrayText,
     fontSize = 12.sp,
+    softWrap = false,
     overflow = TextOverflow.Ellipsis,
     modifier = modifier,
 )
@@ -113,7 +114,7 @@ fun CommitBottomToolbar(
         modifier = Modifier.background(color = Colors.LightGrayBackground).fillMaxWidth().requiredHeight(48.dp)
             .padding(10.dp)
     ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
+        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.weight(1f)) {
             SlimButton("Unstage All", modifier = Modifier.padding(end = 12.dp), onClick = {
                 scope.launch {
                     GitDownState.git.value.unstageAll()
@@ -128,7 +129,7 @@ fun CommitBottomToolbar(
                 BoldText("$committingAsEmail ")
             }
             if(showOnBranch) RegularText(getObjectNamePrefix(isDetachedHead))
-            BoldText(getObjectName(isDetachedHead, branchName), modifier = Modifier.widthIn(max = 100.dp, min = 100.dp))
+            BoldText(getObjectName(isDetachedHead, branchName), modifier = Modifier.weight(1f))
         }
 
         Row(verticalAlignment = Alignment.CenterVertically) {

--- a/src/test/kotlin/com/codymikol/components/commit/CommitBottomToolbarSpec.kt
+++ b/src/test/kotlin/com/codymikol/components/commit/CommitBottomToolbarSpec.kt
@@ -5,32 +5,6 @@ import io.kotest.matchers.shouldBe
 
 class CommitBottomToolbarSpec : DescribeSpec({
 
-    describe("truncateBranchName") {
-
-        describe("when the branch name is within the limit") {
-
-            it("should return the branch name unchanged") {
-                truncateBranchName("main") shouldBe "main"
-            }
-
-            it("should return a 40 character branch name unchanged") {
-                val branchName = "a".repeat(40)
-                truncateBranchName(branchName) shouldBe branchName
-            }
-
-        }
-
-        describe("when the branch name exceeds the limit") {
-
-            it("should truncate to 40 characters and append an ellipsis") {
-                val branchName = "a".repeat(50)
-                truncateBranchName(branchName) shouldBe ("a".repeat(40) + "...")
-            }
-
-        }
-
-    }
-
     describe("getObjectName") {
 
         describe("when the head is detached") {
@@ -43,13 +17,13 @@ class CommitBottomToolbarSpec : DescribeSpec({
 
         describe("when the head is not detached") {
 
-            it("should return the branch name unchanged when within the limit") {
+            it("should return the branch name unchanged when short") {
                 getObjectName(false, "main") shouldBe "main"
             }
 
-            it("should return the truncated branch name when it exceeds the limit") {
+            it("should return the branch name unchanged even when long, leaving truncation to the UI") {
                 val branchName = "a".repeat(50)
-                getObjectName(false, branchName) shouldBe ("a".repeat(40) + "...")
+                getObjectName(false, branchName) shouldBe branchName
             }
 
         }


### PR DESCRIPTION
## Summary
- The bottom commit toolbar's branch name label was pinned to a fixed 100dp width and its shared `BoldText` helper lacked `softWrap = false`, so `overflow = TextOverflow.Ellipsis` never took effect — long names wrapped instead of truncating.
- Gave the label's containing `Row` `weight(1f)` so it claims the space to its right instead of leaving it blank, and gave the label itself `weight(1f)` so it grows into that space and shrinks with the ellipsis when squeezed against the right-justified commit controls.
- Removed the now-redundant `truncateBranchName`/`MAX_BRANCH_NAME_LENGTH` 40-char hard cap, which otherwise still shortened long names even on wide windows where they'd fit — that was a prior workaround for the same wrapping bug and is superseded by the pixel-based ellipsis.

Closes #197

## Note
Local sandbox has no writable nix store / JDK available in this session (confirmed even on a clean, unmodified `main` checkout), so `./gradlew test`/`build` could not be run locally. Diff was hand-verified for Kotlin/Compose correctness; CI (`./gradlew build` via `actions/setup-java`) will provide the real gate.

## Test plan
- [x] Updated `CommitBottomToolbarSpec` for `getObjectName` no longer truncating
- [ ] CI: `./gradlew build`