### PR TITLE
fix: clip themed dropdown menu to rounded corners

### DIFF
--- a/src/main/kotlin/com/codymikol/components/menu/ThemedDropdownMenu.kt
+++ b/src/main/kotlin/com/codymikol/components/menu/ThemedDropdownMenu.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Text
@@ -12,8 +13,18 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+
+// Must match Material's default MenuDefaults.shape radius, or the
+// underlying DropdownMenu Card's corners will still show past this clip.
+private val CornerRadius = 4.dp
+
+internal fun themedDropdownMenuModifier(base: Modifier): Modifier = base
+    .clip(RoundedCornerShape(CornerRadius))
+    .background(MenuColors.Background)
+    .border(1.dp, MenuColors.Divider, RoundedCornerShape(CornerRadius))
 
 @Composable
 fun ThemedDropdownMenu(
@@ -24,9 +35,7 @@ fun ThemedDropdownMenu(
 ) = DropdownMenu(
     expanded = expanded,
     onDismissRequest = onDismissRequest,
-    modifier = modifier
-        .background(MenuColors.Background)
-        .border(1.dp, MenuColors.Divider),
+    modifier = themedDropdownMenuModifier(modifier),
     content = content
 )
 

--- a/src/test/kotlin/com/codymikol/components/menu/ThemedDropdownMenuSpec.kt
+++ b/src/test/kotlin/com/codymikol/components/menu/ThemedDropdownMenuSpec.kt
@@ -1,0 +1,26 @@
+package com.codymikol.components.menu
+
+import androidx.compose.ui.Modifier
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.ints.shouldBeLessThan
+import io.kotest.matchers.shouldNotBe
+
+class ThemedDropdownMenuSpec : DescribeSpec({
+
+    describe("themedDropdownMenuModifier") {
+
+        it("clips before painting the background, so corners stay rounded") {
+            val elements = themedDropdownMenuModifier(Modifier)
+                .foldIn(mutableListOf<String>()) { acc, element -> acc.apply { add(element.toString()) } }
+
+            val clipIndex = elements.indexOfFirst { it.contains("clip", ignoreCase = true) }
+            val backgroundIndex = elements.indexOfFirst { it.contains("background", ignoreCase = true) }
+
+            clipIndex shouldNotBe -1
+            backgroundIndex shouldNotBe -1
+            clipIndex shouldBeLessThan backgroundIndex
+        }
+
+    }
+
+})


### PR DESCRIPTION
## Summary
- The custom "Recently Opened" dropdown (`ThemedDropdownMenu`) wraps Material's `DropdownMenu`, which renders its own white `Card` surface. Our themed background/border was painted before that internal surface, so its unclipped rounded fill peeked out past our rounded corners, showing a white box under the border radius.
- Clip the menu's own modifier chain (clip → background → border) before it's handed to `DropdownMenu`, so our themed fill stays within the rounded shape and nothing white shows through the corners.
- Extracted the modifier construction into a small, non-composable `themedDropdownMenuModifier` function so it's unit-testable without Compose UI test infra (none exists in this repo).

Closes #199

## Test plan
- [x] `./gradlew test` — full suite green, including new `ThemedDropdownMenuSpec` regression test asserting clip precedes background in the modifier chain