### PR TITLE
chore: default sizing

### DIFF
--- a/src/main/kotlin/com/codymikol/services/WindowSizeService.kt
+++ b/src/main/kotlin/com/codymikol/services/WindowSizeService.kt
@@ -1,0 +1,33 @@
+package com.codymikol.services
+
+import org.koin.core.annotation.Single
+import java.awt.Dimension
+import java.awt.Toolkit
+
+@Single
+class WindowSizeService {
+
+    internal var screenSizeProvider: () -> Dimension = ::primaryScreenSize
+
+    /**
+     * Sizes the window relative to the current display so it comfortably fits its
+     * contents on both small laptop screens and large monitors, never shrinking
+     * below the app's minimum usable size.
+     */
+    fun getDefaultWindowSize(): Dimension {
+        val screenSize = screenSizeProvider()
+        val width = (screenSize.width * SIZE_RATIO).toInt().coerceAtLeast(MIN_WIDTH)
+        val height = (screenSize.height * SIZE_RATIO).toInt().coerceAtLeast(MIN_HEIGHT)
+        return Dimension(width, height)
+    }
+
+    companion object {
+        private const val SIZE_RATIO = 0.8
+
+        const val MIN_WIDTH = 800
+        const val MIN_HEIGHT = 500
+
+        private fun primaryScreenSize(): Dimension = Toolkit.getDefaultToolkit().screenSize
+    }
+
+}

--- a/src/main/kotlin/com/codymikol/windows/GitDown.kt
+++ b/src/main/kotlin/com/codymikol/windows/GitDown.kt
@@ -40,6 +40,7 @@ import com.codymikol.gitdown.generated.resources.map
 import com.codymikol.gitdown.generated.resources.map_white
 import com.codymikol.gitdown.generated.resources.stash
 import com.codymikol.gitdown.generated.resources.stash_white
+import com.codymikol.services.WindowSizeService
 import com.codymikol.state.GitDownState
 import com.codymikol.state.Keys
 import com.codymikol.tabs.Tab
@@ -48,11 +49,16 @@ import com.codymikol.views.isCommitMessageFocused
 import com.codymikol.views.MapView
 import com.codymikol.views.StashView
 import org.jetbrains.compose.resources.painterResource
+import org.koin.java.KoinJavaComponent.inject
 import java.awt.Dimension
+
+private val windowSizeService: WindowSizeService by inject(WindowSizeService::class.java)
 
 @Preview
 @Composable
 fun GitDown(applicationScope: ApplicationScope) {
+
+    val defaultWindowSize = windowSizeService.getDefaultWindowSize()
 
     Window(
         onKeyEvent = {
@@ -79,8 +85,8 @@ fun GitDown(applicationScope: ApplicationScope) {
         icon = painterResource(Res.drawable.icon),
         undecorated = true,
         state = rememberWindowState(
-            width = windowWidth.dp,
-            height = windowHeight.dp,
+            width = defaultWindowSize.width.dp,
+            height = defaultWindowSize.height.dp,
             placement = WindowPlacement.Floating,
             position = WindowPosition(alignment = Alignment.Center)
         )
@@ -91,7 +97,7 @@ fun GitDown(applicationScope: ApplicationScope) {
             GitDownState.git.value.scanForChanges()
         }
 
-        this.window.minimumSize = Dimension(800, 500)
+        this.window.minimumSize = Dimension(WindowSizeService.MIN_WIDTH, WindowSizeService.MIN_HEIGHT)
 
         CompositionLocalProvider(
             LocalScrollbarStyle provides ScrollbarStyle(

--- a/src/test/kotlin/com/codymikol/services/WindowSizeServiceSpec.kt
+++ b/src/test/kotlin/com/codymikol/services/WindowSizeServiceSpec.kt
@@ -1,0 +1,34 @@
+package com.codymikol.services
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.awt.Dimension
+
+class WindowSizeServiceSpec : DescribeSpec({
+
+    describe("WindowSizeService.getDefaultWindowSize") {
+
+        it("sizes the window to 80% of a large screen") {
+            val service = WindowSizeService()
+            service.screenSizeProvider = { Dimension(1920, 1080) }
+
+            service.getDefaultWindowSize() shouldBe Dimension(1536, 864)
+        }
+
+        it("scales down for a smaller screen while staying above the minimum") {
+            val service = WindowSizeService()
+            service.screenSizeProvider = { Dimension(1024, 768) }
+
+            service.getDefaultWindowSize() shouldBe Dimension(819, 614)
+        }
+
+        it("clamps to the minimum usable size when the screen is smaller than it") {
+            val service = WindowSizeService()
+            service.screenSizeProvider = { Dimension(640, 480) }
+
+            service.getDefaultWindowSize() shouldBe Dimension(WindowSizeService.MIN_WIDTH, WindowSizeService.MIN_HEIGHT)
+        }
+
+    }
+
+})


### PR DESCRIPTION
## Summary
- Add `WindowSizeService`, a standalone unit-tested service that computes a default window size from the current display's screen size (80% of screen width/height), clamped to the app's minimum usable size.
- Wire it into `GitDown.kt`'s main window creation, replacing the reused `windowWidth`/`windowHeight` constants (310x385) borrowed from `DirectorySelector`'s small picker popup — that default was smaller than the app's own 800x500 minimum, so the main window opened far too small regardless of monitor size.
- `DirectorySelector`'s own small picker window is untouched; it should stay fixed-size.

Closes #200

## Test plan
- [x] `./gradlew test` — full suite green, including new `WindowSizeServiceSpec` (large screen, small screen above minimum, screen below minimum)