### PR TITLE
fix(map): sync all lane scroll positions to one plane

### DIFF
--- a/src/main/kotlin/com/codymikol/state/MapState.kt
+++ b/src/main/kotlin/com/codymikol/state/MapState.kt
@@ -16,6 +16,7 @@ import org.eclipse.jgit.lib.Ref
 object MapState {
 
     const val PAGE_SIZE = 30
+    const val LOAD_MORE_THRESHOLD = 5
 
     private val walkers = mutableMapOf<String, CommitHistoryWalker>()
 
@@ -27,6 +28,17 @@ object MapState {
         GitDownState.git.value.listLocalBranches().sortedBy { it.name }
     }
 
+    /**
+     * Every lane's LazyColumn renders exactly this many rows (padding shorter branches
+     * with blank rows past their own commits) so all lanes share the same item count.
+     * That's what makes it safe for every lane to render against one shared
+     * LazyListState (see MapView) - a shared state clamps to whichever lane's item
+     * count last measured, so mismatched counts would fight over the scroll position.
+     */
+    val maxLoadedRowCount = derivedStateOf {
+        commitsByBranch.values.maxOfOrNull { it.size } ?: 0
+    }
+
     fun loadMore(branch: Ref) {
         if (hasMoreByBranch[branch.name] == false) return
 
@@ -35,6 +47,19 @@ object MapState {
 
         commitsByBranch.getOrPut(branch.name) { mutableStateListOf() }.addAll(page)
         hasMoreByBranch[branch.name] = walker.hasMore
+    }
+
+    /**
+     * Branches share a single vertical scroll position (see MapView), so a branch's own
+     * loaded-commit count is checked against that shared position rather than a lane-local
+     * one. lastVisibleIndex must be the last (bottom-most) visible row, not the first - the
+     * first visible index stays well short of loadedCount whenever more than
+     * LOAD_MORE_THRESHOLD rows fit in the viewport, so it would never trigger paging.
+     */
+    fun shouldLoadMore(branchName: String, lastVisibleIndex: Int): Boolean {
+        if (hasMoreByBranch[branchName] == false) return false
+        val loadedCount = commitsByBranch[branchName]?.size ?: 0
+        return lastVisibleIndex >= loadedCount - LOAD_MORE_THRESHOLD
     }
 
     fun reset() {

--- a/src/main/kotlin/com/codymikol/views/MapView.kt
+++ b/src/main/kotlin/com/codymikol/views/MapView.kt
@@ -6,14 +6,15 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.Text
@@ -39,7 +40,7 @@ import org.eclipse.jgit.lib.Ref
 private val LaneWidth = 260.dp
 private val NodeRadius = 5.dp
 private val GutterX = 20.dp
-private const val LoadMoreThreshold = 5
+private val RowHeight = 48.dp
 
 @Composable
 @Preview
@@ -50,6 +51,13 @@ fun MapView() {
     }
 
     val branches = MapState.branches.value
+    val rowCount = MapState.maxLoadedRowCount.value
+
+    // All lanes render against this one vertical LazyListState, rather than each owning
+    // its own, so scrolling any lane scrolls every lane's commit nodes in lock-step. Every
+    // lane also renders the same rowCount (see BranchLane), which is what makes sharing
+    // this state safe across lanes with different numbers of loaded commits.
+    val verticalScrollState = rememberLazyListState()
 
     when (branches.isEmpty()) {
         true -> MapEmptyState()
@@ -57,7 +65,7 @@ fun MapView() {
             state = rememberLazyListState(),
             modifier = Modifier.fillMaxWidth().fillMaxHeight().background(Colors.DarkGrayBackground)
         ) {
-            items(branches, key = { it.name }) { branch -> BranchLane(branch) }
+            items(branches, key = { it.name }) { branch -> BranchLane(branch, verticalScrollState, rowCount) }
         }
     }
 }
@@ -78,11 +86,10 @@ private fun MapEmptyState() {
 }
 
 @Composable
-private fun BranchLane(branch: Ref) {
+private fun BranchLane(branch: Ref, verticalScrollState: LazyListState, rowCount: Int) {
     val branchName = branch.name.removePrefix("refs/heads/")
     val commits = MapState.commitsByBranch[branch.name] ?: emptyList()
     val hasMore = MapState.hasMoreByBranch[branch.name] ?: true
-    val listState = rememberLazyListState()
 
     // Loading this lane's first page only happens once it's actually composed,
     // which LazyRow only does once the lane scrolls into view - this is what
@@ -94,10 +101,9 @@ private fun BranchLane(branch: Ref) {
     }
 
     LaunchedEffect(branch.name, commits.size, hasMore) {
-        snapshotFlow { listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index }
+        snapshotFlow { verticalScrollState.layoutInfo.visibleItemsInfo.lastOrNull()?.index }
             .collect { lastVisibleIndex ->
-                val nearBottom = lastVisibleIndex != null && lastVisibleIndex >= commits.size - LoadMoreThreshold
-                if (hasMore && nearBottom) {
+                if (lastVisibleIndex != null && MapState.shouldLoadMore(branch.name, lastVisibleIndex)) {
                     MapState.loadMore(branch)
                 }
             }
@@ -110,13 +116,17 @@ private fun BranchLane(branch: Ref) {
             .border(width = 1.dp, color = Color.Black)
     ) {
         Subheader(branchName)
-        LazyColumn(state = listState, modifier = Modifier.fillMaxWidth().fillMaxHeight()) {
-            itemsIndexed(commits, key = { _, commit -> commit.sha }) { index, commit ->
-                CommitNode(
-                    commit = commit,
-                    showLeadingGuideline = index != 0,
-                    showTrailingGuideline = index != commits.lastIndex || hasMore,
-                )
+        LazyColumn(state = verticalScrollState, modifier = Modifier.fillMaxWidth().fillMaxHeight()) {
+            items(rowCount, key = { index -> commits.getOrNull(index)?.sha ?: "blank-$index" }) { index ->
+                val commit = commits.getOrNull(index)
+                when (commit) {
+                    null -> Spacer(modifier = Modifier.fillMaxWidth().height(RowHeight))
+                    else -> CommitNode(
+                        commit = commit,
+                        showLeadingGuideline = index != 0,
+                        showTrailingGuideline = index != commits.lastIndex || hasMore,
+                    )
+                }
             }
         }
     }
@@ -127,7 +137,7 @@ private fun CommitNode(commit: CommitGraphNode, showLeadingGuideline: Boolean, s
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .height(48.dp)
+            .height(RowHeight)
             .drawBehind { drawCommitNode(commit, showLeadingGuideline, showTrailingGuideline) }
             .padding(start = 40.dp, top = 4.dp, end = 8.dp, bottom = 4.dp)
     ) {

--- a/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
@@ -1,9 +1,11 @@
 package com.codymikol.state
 
+import com.codymikol.data.map.CommitGraphNode
 import com.codymikol.repository.TestRepository.Companion.createTestRepository
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import java.util.Date
 
 class MapStateSpec : DescribeSpec({
 
@@ -65,5 +67,74 @@ class MapStateSpec : DescribeSpec({
                 MapState.hasMoreByBranch.isEmpty() shouldBe true
             }
         }
+
+        describe("shouldLoadMore") {
+
+            it("should return false once the branch has no more commits to load") {
+                MapState.reset()
+                MapState.commitsByBranch["refs/heads/main"] = dummyCommits(4)
+                MapState.hasMoreByBranch["refs/heads/main"] = false
+
+                MapState.shouldLoadMore("refs/heads/main", 3) shouldBe false
+            }
+
+            it("should return false when the shared last-visible index is far from this branch's loaded end") {
+                MapState.reset()
+                MapState.commitsByBranch["refs/heads/main"] = dummyCommits(30)
+                MapState.hasMoreByBranch["refs/heads/main"] = true
+
+                MapState.shouldLoadMore("refs/heads/main", 0) shouldBe false
+            }
+
+            it("should return true when the shared last-visible index nears this branch's loaded end and more remain") {
+                MapState.reset()
+                MapState.commitsByBranch["refs/heads/main"] = dummyCommits(30)
+                MapState.hasMoreByBranch["refs/heads/main"] = true
+
+                MapState.shouldLoadMore("refs/heads/main", 28) shouldBe true
+            }
+
+            it("should return true exactly at the load-more threshold boundary") {
+                MapState.reset()
+                MapState.commitsByBranch["refs/heads/main"] = dummyCommits(30)
+                MapState.hasMoreByBranch["refs/heads/main"] = true
+
+                MapState.shouldLoadMore("refs/heads/main", 30 - MapState.LOAD_MORE_THRESHOLD) shouldBe true
+            }
+
+            it("should return true when nothing has loaded yet for the branch and more is assumed available") {
+                MapState.reset()
+
+                MapState.shouldLoadMore("refs/heads/main", 0) shouldBe true
+            }
+        }
+
+        describe("maxLoadedRowCount") {
+
+            it("should return zero when nothing has loaded") {
+                MapState.reset()
+
+                MapState.maxLoadedRowCount.value shouldBe 0
+            }
+
+            it("should return the largest loaded commit count across branches") {
+                MapState.reset()
+                MapState.commitsByBranch["refs/heads/main"] = dummyCommits(4)
+                MapState.commitsByBranch["refs/heads/feature"] = dummyCommits(30)
+
+                MapState.maxLoadedRowCount.value shouldBe 30
+            }
+        }
     }
 })
+
+private fun dummyCommits(count: Int) = (1..count).map {
+    CommitGraphNode(
+        sha = "sha$it",
+        shortSha = "sha$it",
+        shortMessage = "commit $it",
+        authorName = "author",
+        date = Date(),
+        parentShas = emptyList(),
+    )
+}.toMutableList()


### PR DESCRIPTION
## Summary

Fixes the follow-up noted in #192: Map view branch lanes each owned an independent vertical `LazyListState`, so scrolling one lane left every other lane's commit nodes at their own position instead of on a shared plane.

- `MapView` now creates a single vertical `LazyListState` shared by every `BranchLane`, so scrolling any lane scrolls every lane's commits in lock-step.
- Sharing one `LazyListState` across lanes is only safe when every lane reports the same item count to it - otherwise each lane's own measurement clamps the shared scroll position to its own bounds and lanes fight each other. So every lane now pads its `LazyColumn` out to `MapState.maxLoadedRowCount` (the tallest currently-loaded lane), rendering blank spacer rows past its own loaded commits.
- The per-lane load-more trigger moved to `MapState.shouldLoadMore()` (unit tested), driven by the shared `layoutInfo.visibleItemsInfo.lastOrNull()?.index` rather than each lane's own `LazyListState`.

Cross-lane connector lines for a merge commit's non-primary parents remain out of scope, same as noted in #192.

### Notes for reviewer
- **Could not run `./gradlew build`/`test` locally** - this sandbox has no JDK and no working `nix develop` (root-owned `/nix/store`, no daemon reachable), same limitation noted in #192. Changes were reviewed carefully by hand and by a fresh independent review pass; CI (JDK 21 via `actions/setup-java`) is the first real compile/test signal - please keep an eye on it.
- Sharing one `LazyListState` across sibling `LazyColumn`s (safe here because row counts/heights are now kept uniform across lanes) is an unusual Compose pattern worth a close look/runtime sanity-check.

Closes #195