### PR TITLE
fix: round outer window corners on map/commit/stash view

### DIFF
--- a/src/main/kotlin/com/codymikol/windows/GitDown.kt
+++ b/src/main/kotlin/com/codymikol/windows/GitDown.kt
@@ -4,7 +4,9 @@ import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.LocalScrollbarStyle
 import androidx.compose.foundation.ScrollbarStyle
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.window.WindowDraggableArea
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -12,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
@@ -54,6 +57,8 @@ import java.awt.Dimension
 
 private val windowSizeService: WindowSizeService by inject(WindowSizeService::class.java)
 
+val WindowCornerRadius = 8.dp
+
 @Preview
 @Composable
 fun GitDown(applicationScope: ApplicationScope) {
@@ -84,6 +89,7 @@ fun GitDown(applicationScope: ApplicationScope) {
         title = GitDownState.projectName.value,
         icon = painterResource(Res.drawable.icon),
         undecorated = true,
+        transparent = true,
         state = rememberWindowState(
             width = defaultWindowSize.width.dp,
             height = defaultWindowSize.height.dp,
@@ -109,7 +115,13 @@ fun GitDown(applicationScope: ApplicationScope) {
                 hoverColor = MaterialTheme.colors.onSurface.copy(alpha = 0.50f)
             )
         ) {
-            Column(modifier = Modifier.fillMaxSize().background(color = Colors.DarkGrayBackground)) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .border(width = 1.dp, color = Color.Black, shape = RoundedCornerShape(WindowCornerRadius))
+                    .clip(RoundedCornerShape(WindowCornerRadius))
+                    .background(color = Colors.DarkGrayBackground)
+            ) {
                 Row(
                     modifier = Modifier.requiredHeight(48.dp).fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween

--- a/src/test/kotlin/com/codymikol/windows/GitDownSpec.kt
+++ b/src/test/kotlin/com/codymikol/windows/GitDownSpec.kt
@@ -1,0 +1,17 @@
+package com.codymikol.windows
+
+import androidx.compose.ui.unit.dp
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class GitDownSpec : DescribeSpec({
+
+    describe("WindowCornerRadius") {
+
+        it("is a subtle radius applied to the outermost application window") {
+            WindowCornerRadius shouldBe 8.dp
+        }
+
+    }
+
+})


### PR DESCRIPTION
## Summary
- The undecorated `GitDown` `Window` was opaque, so simply clipping its content to rounded corners would have left square window edges showing outside the clip (this is why a previous attempt, #201/#210, rounded the inner viewport panels instead — the wrong element per this issue).
- Make the window `transparent = true` and clip/border the root `Column` to a subtle 8dp radius, following the same `border + clip` pattern already used for the `DirectorySelector` window frame.

## Test plan
- Added `GitDownSpec.kt` asserting the new `WindowCornerRadius` constant, following the existing `WindowSizeServiceSpec` convention for testable style/config constants — this repo has no Composable-level UI test harness, so the visual clip/border itself isn't independently testable.
- Could not run `./gradlew test` locally — no JVM and no usable `nix develop` in this sandbox (nix store is read-only, `nix develop` fails with a lock-file permission error). CI will compile and run the full test suite.

Closes #214