### PR TITLE
feat: configurable UI and text size

### DIFF
--- a/src/main/kotlin/com/codymikol/Main.kt
+++ b/src/main/kotlin/com/codymikol/Main.kt
@@ -3,8 +3,11 @@ import androidx.compose.ui.window.application
 import com.codymikol.config.BeansModule
 import com.codymikol.config.RepositoriesModule
 import com.codymikol.config.ServicesModule
+import com.codymikol.repositories.SettingsRepository
+import com.codymikol.state.GitDownState
 import com.codymikol.windows.handleDirectorySelection
 import org.koin.core.context.startKoin
+import org.koin.java.KoinJavaComponent.inject
 import org.koin.ksp.generated.module
 
 fun main(args: Array<String>) = application {
@@ -16,6 +19,11 @@ fun main(args: Array<String>) = application {
             ServicesModule().module,
         )
     }
+
+    val settingsRepository: SettingsRepository by inject(SettingsRepository::class.java)
+    val settings = settingsRepository.getSettings()
+    GitDownState.headerTextSize.value = settings.headerTextSize
+    GitDownState.bodyTextSize.value = settings.bodyTextSize
 
     // todo(mikol): we should move this into a load directory service and make it more robust eventually...
     if (args.size == 1) {

--- a/src/main/kotlin/com/codymikol/components/Subheader.kt
+++ b/src/main/kotlin/com/codymikol/components/Subheader.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.codymikol.data.Colors
+import com.codymikol.state.GitDownState
 
 @Composable
 fun Subheader(title: String) {
@@ -25,7 +26,7 @@ fun Subheader(title: String) {
             .requiredHeight(32.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Text(style = TextStyle(fontWeight = FontWeight.Bold, fontSize = 12.sp), modifier = Modifier.padding(8.dp).fillMaxWidth(), color = Color.White, text = title)
+        Text(style = TextStyle(fontWeight = FontWeight.Bold, fontSize = GitDownState.headerTextSize.value.sp), modifier = Modifier.padding(8.dp).fillMaxWidth(), color = Color.White, text = title)
     }
 }
 

--- a/src/main/kotlin/com/codymikol/data/settings/AppSettings.kt
+++ b/src/main/kotlin/com/codymikol/data/settings/AppSettings.kt
@@ -1,0 +1,15 @@
+package com.codymikol.data.settings
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class AppSettings(
+    @JsonProperty("headerTextSize")
+    val headerTextSize: Int = DEFAULT_HEADER_TEXT_SIZE,
+    @JsonProperty("bodyTextSize")
+    val bodyTextSize: Int = DEFAULT_BODY_TEXT_SIZE,
+) {
+    companion object {
+        const val DEFAULT_HEADER_TEXT_SIZE = 20
+        const val DEFAULT_BODY_TEXT_SIZE = 12
+    }
+}

--- a/src/main/kotlin/com/codymikol/repositories/SettingsRepository.kt
+++ b/src/main/kotlin/com/codymikol/repositories/SettingsRepository.kt
@@ -1,0 +1,59 @@
+package com.codymikol.repositories
+
+import com.codymikol.beans.ObjectMapperBean
+import com.codymikol.data.settings.AppSettings
+import org.koin.core.annotation.Single
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Paths
+
+@Single
+class SettingsRepository(
+    private val objectMapperBean: ObjectMapperBean,
+    private val userDirectoryRepository: UserDirectoryRepository,
+) {
+
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(SettingsRepository::class.java)
+    }
+
+    private var cachedSettings: AppSettings? = null
+    private val settingsFilename: String = "appSettings.json"
+
+    fun getSettings(): AppSettings {
+        return cachedSettings ?: initializeSettings()
+    }
+
+    fun setSettings(newSettings: AppSettings) {
+        try {
+            Files.createDirectories(Paths.get(userDirectoryRepository.getUserDataDir()))
+            val file = getFile()
+            if (!file.exists()) file.createNewFile()
+            objectMapperBean.value.writeValue(getFile(), newSettings)
+            cachedSettings = newSettings
+        } catch (e: IOException) {
+            logger.error("Failed to save app settings.")
+        }
+    }
+
+    private fun getFile() = File("${requireNotNull(userDirectoryRepository.getUserDataDir())}/$settingsFilename")
+
+    private fun initializeSettings(): AppSettings {
+        val file = getFile()
+        return when (file.exists()) {
+            true -> getSettingsFromFile(file)
+            false -> AppSettings()
+        }
+    }
+
+    private fun getSettingsFromFile(file: File): AppSettings = try {
+        objectMapperBean.value.readValue(file, AppSettings::class.java)
+    } catch (e: IOException) {
+        logger.error("There was an error reading app settings, using defaults")
+        AppSettings()
+    }
+
+}

--- a/src/main/kotlin/com/codymikol/state/TextSizeShortcut.kt
+++ b/src/main/kotlin/com/codymikol/state/TextSizeShortcut.kt
@@ -1,0 +1,19 @@
+package com.codymikol.state
+
+import androidx.compose.ui.input.key.Key
+
+object TextSizeShortcut {
+
+    fun isShortcutModifierPressed(
+        isCtrlPressed: Boolean,
+        isMetaPressed: Boolean,
+        osName: String = System.getProperty("os.name") ?: "",
+    ): Boolean = if (osName.contains("Mac", ignoreCase = true)) isMetaPressed else isCtrlPressed
+
+    fun isIncrease(key: Key, isShortcutModifierPressed: Boolean): Boolean =
+        isShortcutModifierPressed && (key == Key.Equals || key == Key.NumPadAdd)
+
+    fun isDecrease(key: Key, isShortcutModifierPressed: Boolean): Boolean =
+        isShortcutModifierPressed && (key == Key.Minus || key == Key.NumPadSubtract)
+
+}

--- a/src/main/kotlin/com/codymikol/state/state.kt
+++ b/src/main/kotlin/com/codymikol/state/state.kt
@@ -1,6 +1,7 @@
 package com.codymikol.state
 
 import androidx.compose.runtime.*
+import com.codymikol.data.settings.AppSettings
 import com.codymikol.data.diff.DiffTree
 import com.codymikol.data.file.FileDelta
 import com.codymikol.data.file.Index
@@ -19,7 +20,15 @@ import java.nio.file.Path
 
 object GitDownState {
 
+    const val TEXT_SIZE_STEP = 2
+    const val MIN_TEXT_SIZE = 8
+    const val MAX_TEXT_SIZE = 40
+
     val currentTab: MutableState<Tab> = mutableStateOf(Tab.Commit)
+
+    val headerTextSize = mutableStateOf(AppSettings.DEFAULT_HEADER_TEXT_SIZE)
+
+    val bodyTextSize = mutableStateOf(AppSettings.DEFAULT_BODY_TEXT_SIZE)
 
     val gitDirectory = mutableStateOf("")
 
@@ -172,6 +181,15 @@ object GitDownState {
 
     //todo(mikol): this is not ideal, work out a better way to manage this...
     val lastRequestedUpdateTimestamp = mutableStateOf(System.currentTimeMillis())
+
+    fun increaseTextSize() = adjustTextSize(TEXT_SIZE_STEP)
+
+    fun decreaseTextSize() = adjustTextSize(-TEXT_SIZE_STEP)
+
+    private fun adjustTextSize(delta: Int) {
+        headerTextSize.value = (headerTextSize.value + delta).coerceIn(MIN_TEXT_SIZE, MAX_TEXT_SIZE)
+        bodyTextSize.value = (bodyTextSize.value + delta).coerceIn(MIN_TEXT_SIZE, MAX_TEXT_SIZE)
+    }
 
     fun selectTab(tab: Tab) {
         currentTab.value = tab

--- a/src/main/kotlin/com/codymikol/typography/GitDownTypography.kt
+++ b/src/main/kotlin/com/codymikol/typography/GitDownTypography.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.sp
 import com.codymikol.gitdown.generated.resources.*
+import com.codymikol.state.GitDownState
 import org.jetbrains.compose.resources.Font
 
 
@@ -48,7 +49,7 @@ object GitDownTypography {
             value,
             modifier = Modifier.fillMaxWidth(),
             color = Color(whiteLevel, whiteLevel, whiteLevel),
-            fontSize = 10.sp,
+            fontSize = GitDownState.headerTextSize.value.sp,
             fontWeight = FontWeight.Bold,
             fontFamily = jetbrainsMono(),
         )
@@ -93,7 +94,7 @@ object GitDownTypography {
             },
             color = color,
             fontFamily = jetbrainsMono(),
-            fontSize = 12.sp
+            fontSize = GitDownState.bodyTextSize.value.sp
         )
     }
 

--- a/src/main/kotlin/com/codymikol/windows/GitDown.kt
+++ b/src/main/kotlin/com/codymikol/windows/GitDown.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
@@ -40,9 +41,12 @@ import com.codymikol.gitdown.generated.resources.map
 import com.codymikol.gitdown.generated.resources.map_white
 import com.codymikol.gitdown.generated.resources.stash
 import com.codymikol.gitdown.generated.resources.stash_white
+import com.codymikol.data.settings.AppSettings
+import com.codymikol.repositories.SettingsRepository
 import com.codymikol.services.WindowSizeService
 import com.codymikol.state.GitDownState
 import com.codymikol.state.Keys
+import com.codymikol.state.TextSizeShortcut
 import com.codymikol.tabs.Tab
 import com.codymikol.views.CommitView
 import com.codymikol.views.isCommitMessageFocused
@@ -53,6 +57,16 @@ import org.koin.java.KoinJavaComponent.inject
 import java.awt.Dimension
 
 private val windowSizeService: WindowSizeService by inject(WindowSizeService::class.java)
+private val settingsRepository: SettingsRepository by inject(SettingsRepository::class.java)
+
+private fun persistTextSize() {
+    settingsRepository.setSettings(
+        AppSettings(
+            headerTextSize = GitDownState.headerTextSize.value,
+            bodyTextSize = GitDownState.bodyTextSize.value,
+        )
+    )
+}
 
 @Preview
 @Composable
@@ -71,11 +85,28 @@ fun GitDown(applicationScope: ApplicationScope) {
                 !isCommitMessageFocused.value &&
                 GitDownState.selectedFiles.size == 1
 
-            if (isFileSelectionArrow) {
-                GitDownState.selectAdjacentFile(if (it.key == Key.DirectionUp) -1 else 1)
-                true
-            } else {
-                false
+            val isShortcutModifierPressed = TextSizeShortcut.isShortcutModifierPressed(it.isCtrlPressed, it.isMetaPressed)
+            val isTextSizeIncrease = it.type == KeyEventType.KeyDown &&
+                TextSizeShortcut.isIncrease(it.key, isShortcutModifierPressed)
+            val isTextSizeDecrease = it.type == KeyEventType.KeyDown &&
+                TextSizeShortcut.isDecrease(it.key, isShortcutModifierPressed)
+
+            when {
+                isFileSelectionArrow -> {
+                    GitDownState.selectAdjacentFile(if (it.key == Key.DirectionUp) -1 else 1)
+                    true
+                }
+                isTextSizeIncrease -> {
+                    GitDownState.increaseTextSize()
+                    persistTextSize()
+                    true
+                }
+                isTextSizeDecrease -> {
+                    GitDownState.decreaseTextSize()
+                    persistTextSize()
+                    true
+                }
+                else -> false
             }
         },
         onCloseRequest = {

--- a/src/test/kotlin/com/codymikol/repositories/SettingsRepositorySpec.kt
+++ b/src/test/kotlin/com/codymikol/repositories/SettingsRepositorySpec.kt
@@ -1,0 +1,36 @@
+package com.codymikol.repositories
+
+import com.codymikol.beans.ObjectMapperBean
+import com.codymikol.data.settings.AppSettings
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import kotlin.io.path.createTempDirectory
+
+private class SettingsTestUserDirectoryRepository(private val dir: String) : UserDirectoryRepository() {
+    override fun getUserDataDir(): String = dir
+}
+
+class SettingsRepositorySpec : DescribeSpec({
+
+    describe("SettingsRepository") {
+
+        fun createRepository() = SettingsRepository(
+            ObjectMapperBean(),
+            SettingsTestUserDirectoryRepository(createTempDirectory("git-down-settings-test-").toString())
+        )
+
+        it("starts with the default settings") {
+            createRepository().getSettings() shouldBe AppSettings()
+        }
+
+        it("returns the settings that were saved") {
+            val repository = createRepository()
+
+            repository.setSettings(AppSettings(headerTextSize = 24, bodyTextSize = 16))
+
+            repository.getSettings() shouldBe AppSettings(headerTextSize = 24, bodyTextSize = 16)
+        }
+
+    }
+
+})

--- a/src/test/kotlin/com/codymikol/state/TextSizeShortcutSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/TextSizeShortcutSpec.kt
@@ -1,0 +1,77 @@
+package com.codymikol.state
+
+import androidx.compose.ui.input.key.Key
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class TextSizeShortcutSpec : DescribeSpec({
+
+    describe("TextSizeShortcut.isShortcutModifierPressed") {
+
+        it("requires the Meta key on macOS") {
+            TextSizeShortcut.isShortcutModifierPressed(
+                isCtrlPressed = false,
+                isMetaPressed = true,
+                osName = "Mac OS X"
+            ) shouldBe true
+        }
+
+        it("ignores Ctrl on macOS") {
+            TextSizeShortcut.isShortcutModifierPressed(
+                isCtrlPressed = true,
+                isMetaPressed = false,
+                osName = "Mac OS X"
+            ) shouldBe false
+        }
+
+        it("requires the Ctrl key on Linux") {
+            TextSizeShortcut.isShortcutModifierPressed(
+                isCtrlPressed = true,
+                isMetaPressed = false,
+                osName = "Linux"
+            ) shouldBe true
+        }
+
+        it("ignores Meta on Linux") {
+            TextSizeShortcut.isShortcutModifierPressed(
+                isCtrlPressed = false,
+                isMetaPressed = true,
+                osName = "Linux"
+            ) shouldBe false
+        }
+
+    }
+
+    describe("TextSizeShortcut.isIncrease") {
+
+        it("is true for the '=' key when the shortcut modifier is pressed") {
+            TextSizeShortcut.isIncrease(Key.Equals, isShortcutModifierPressed = true) shouldBe true
+        }
+
+        it("is false for the '=' key when the shortcut modifier is not pressed") {
+            TextSizeShortcut.isIncrease(Key.Equals, isShortcutModifierPressed = false) shouldBe false
+        }
+
+        it("is false for an unrelated key") {
+            TextSizeShortcut.isIncrease(Key.A, isShortcutModifierPressed = true) shouldBe false
+        }
+
+    }
+
+    describe("TextSizeShortcut.isDecrease") {
+
+        it("is true for the '-' key when the shortcut modifier is pressed") {
+            TextSizeShortcut.isDecrease(Key.Minus, isShortcutModifierPressed = true) shouldBe true
+        }
+
+        it("is false for the '-' key when the shortcut modifier is not pressed") {
+            TextSizeShortcut.isDecrease(Key.Minus, isShortcutModifierPressed = false) shouldBe false
+        }
+
+        it("is false for an unrelated key") {
+            TextSizeShortcut.isDecrease(Key.A, isShortcutModifierPressed = true) shouldBe false
+        }
+
+    }
+
+})

--- a/src/test/kotlin/com/codymikol/state/TextSizeStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/TextSizeStateSpec.kt
@@ -1,0 +1,64 @@
+package com.codymikol.state
+
+import com.codymikol.data.settings.AppSettings
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class TextSizeStateSpec : DescribeSpec({
+
+    beforeTest {
+        GitDownState.headerTextSize.value = AppSettings.DEFAULT_HEADER_TEXT_SIZE
+        GitDownState.bodyTextSize.value = AppSettings.DEFAULT_BODY_TEXT_SIZE
+    }
+
+    describe("GitDownState text size") {
+
+        it("starts with a header text size of 20") {
+            GitDownState.headerTextSize.value shouldBe 20
+        }
+
+        it("starts with a body text size of 12") {
+            GitDownState.bodyTextSize.value shouldBe 12
+        }
+
+        it("increases both header and body text size by 2px") {
+            GitDownState.headerTextSize.value = 20
+            GitDownState.bodyTextSize.value = 12
+
+            GitDownState.increaseTextSize()
+
+            GitDownState.headerTextSize.value shouldBe 22
+            GitDownState.bodyTextSize.value shouldBe 14
+        }
+
+        it("decreases both header and body text size by 2px") {
+            GitDownState.headerTextSize.value = 20
+            GitDownState.bodyTextSize.value = 12
+
+            GitDownState.decreaseTextSize()
+
+            GitDownState.headerTextSize.value shouldBe 18
+            GitDownState.bodyTextSize.value shouldBe 10
+        }
+
+        it("does not decrease body text size below the minimum of 8px") {
+            GitDownState.headerTextSize.value = 20
+            GitDownState.bodyTextSize.value = 8
+
+            GitDownState.decreaseTextSize()
+
+            GitDownState.bodyTextSize.value shouldBe 8
+        }
+
+        it("does not increase header text size above the maximum of 40px") {
+            GitDownState.headerTextSize.value = 40
+            GitDownState.bodyTextSize.value = 12
+
+            GitDownState.increaseTextSize()
+
+            GitDownState.headerTextSize.value shouldBe 40
+        }
+
+    }
+
+})


### PR DESCRIPTION
## Summary
- Adds `GitDownState.headerTextSize` (default 20px) and `bodyTextSize` (default 12px), adjustable in 2px steps and clamped to a sane range.
- Adds `TextSizeShortcut` to detect the industry-standard scale shortcut: Cmd +/- on macOS, Ctrl +/- on Linux/Windows.
- Wires the shortcut into `GitDown`'s `onKeyEvent` handler to increase/decrease text size and persist the change.
- Adds `SettingsRepository`, mirroring `RecentProjectRepository`, to persist `AppSettings` (header/body text size) as JSON in the user data dir, loaded on startup in `Main.kt`.
- Applies header size to `Subheader` and `GitDownTypography.DiffHunkHeader`, and body size to `GitDownTypography.DiffContent`.

Closes #228

## Test plan
- [x] `./gradlew build` (test + check) green
- [x] New unit tests for text size defaults/clamping, shortcut key detection, and settings persistence