### PR TITLE
fix(highlighting): parse whole files for per-line diff highlighting

### DIFF
--- a/src/main/kotlin/com/codymikol/components/commit/diff/Diff.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/diff/Diff.kt
@@ -21,6 +21,7 @@ import com.codymikol.data.diff.FileDeltaNode
 import com.codymikol.data.diff.Hunk
 import com.codymikol.data.diff.LineNode
 import com.codymikol.extensions.*
+import com.codymikol.highlighting.FullFileLineHighlighter
 import com.codymikol.highlighting.GrammarCache
 import com.codymikol.highlighting.GrammarExtensionRegistry
 import com.codymikol.highlighting.GrammarLanguageLoader
@@ -168,7 +169,9 @@ private fun DiffLine(lineNode: LineNode) {
                 try {
                     val extension = lineNode.parent.parent.getPath().substringAfterLast('.', "")
                     if (extension.isEmpty()) return@LaunchedEffect
-                    highlighted = withContext(Dispatchers.IO) { highlightLine(extension, displayLine) }
+                    highlighted = withContext(Dispatchers.IO) {
+                        highlightLineFromFullFile(lineNode, extension, displayLine) ?: highlightLine(extension, displayLine)
+                    }
                 } catch (e: Exception) {
                     logger.error("Failed to apply syntax highlighting for line", e)
                 }
@@ -190,6 +193,17 @@ private suspend fun highlightLine(extension: String, text: String): AnnotatedStr
     val language = GrammarLanguageLoader.load(grammarPath, spec.functionName) ?: return null
     val tokens = GrammarParser.parse(language, text)
     return SyntaxHighlighter.highlight(text, tokens)
+}
+
+// Parses the line's whole file once (so tree-sitter has cross-line context, e.g. for block
+// comments) instead of the line in isolation. Returns null - falling back to highlightLine -
+// whenever the full file's content can't be read or placed against this diff line.
+private suspend fun highlightLineFromFullFile(lineNode: LineNode, extension: String, displayLine: String): AnnotatedString? {
+    val spec = GrammarExtensionRegistry.forExtension(extension) ?: return null
+    val grammarPath = grammarCache.ensureGrammar(spec) ?: return null
+    val language = GrammarLanguageLoader.load(grammarPath, spec.functionName) ?: return null
+    val fileDeltaNode = lineNode.parent.parent
+    return FullFileLineHighlighter.highlight(fileDeltaNode.fileDelta, lineNode.line, displayLine, language)
 }
 
 @Composable

--- a/src/main/kotlin/com/codymikol/components/commit/diff/Diff.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/diff/Diff.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.koin.java.KoinJavaComponent.inject
 import org.slf4j.LoggerFactory
+import org.treesitter.TSLanguage
 
 private val grammarCache: GrammarCache by inject(GrammarCache::class.java)
 private val logger = LoggerFactory.getLogger("com.codymikol.components.commit.diff.Diff")
@@ -170,7 +171,8 @@ private fun DiffLine(lineNode: LineNode) {
                     val extension = lineNode.parent.parent.getPath().substringAfterLast('.', "")
                     if (extension.isEmpty()) return@LaunchedEffect
                     highlighted = withContext(Dispatchers.IO) {
-                        highlightLineFromFullFile(lineNode, extension, displayLine) ?: highlightLine(extension, displayLine)
+                        val language = resolveLanguage(extension)
+                        highlightLineFromFullFile(lineNode, displayLine, language) ?: highlightLine(language, displayLine)
                     }
                 } catch (e: Exception) {
                     logger.error("Failed to apply syntax highlighting for line", e)
@@ -187,10 +189,13 @@ private fun DiffLine(lineNode: LineNode) {
     }
 }
 
-private suspend fun highlightLine(extension: String, text: String): AnnotatedString? {
+private suspend fun resolveLanguage(extension: String): TSLanguage? {
     val spec = GrammarExtensionRegistry.forExtension(extension) ?: return null
     val grammarPath = grammarCache.ensureGrammar(spec) ?: return null
-    val language = GrammarLanguageLoader.load(grammarPath, spec.functionName) ?: return null
+    return GrammarLanguageLoader.load(grammarPath, spec.functionName)
+}
+
+private fun highlightLine(language: TSLanguage?, text: String): AnnotatedString {
     val tokens = GrammarParser.parse(language, text)
     return SyntaxHighlighter.highlight(text, tokens)
 }
@@ -198,10 +203,7 @@ private suspend fun highlightLine(extension: String, text: String): AnnotatedStr
 // Parses the line's whole file once (so tree-sitter has cross-line context, e.g. for block
 // comments) instead of the line in isolation. Returns null - falling back to highlightLine -
 // whenever the full file's content can't be read or placed against this diff line.
-private suspend fun highlightLineFromFullFile(lineNode: LineNode, extension: String, displayLine: String): AnnotatedString? {
-    val spec = GrammarExtensionRegistry.forExtension(extension) ?: return null
-    val grammarPath = grammarCache.ensureGrammar(spec) ?: return null
-    val language = GrammarLanguageLoader.load(grammarPath, spec.functionName) ?: return null
+private fun highlightLineFromFullFile(lineNode: LineNode, displayLine: String, language: TSLanguage?): AnnotatedString? {
     val fileDeltaNode = lineNode.parent.parent
     return FullFileLineHighlighter.highlight(fileDeltaNode.fileDelta, lineNode.line, displayLine, language)
 }

--- a/src/main/kotlin/com/codymikol/data/file/FileDelta.kt
+++ b/src/main/kotlin/com/codymikol/data/file/FileDelta.kt
@@ -3,14 +3,20 @@ package com.codymikol.data.file
 import androidx.compose.ui.graphics.Color
 import com.codymikol.data.diff.Line
 import com.codymikol.data.diff.LineType
+import com.codymikol.extensions.readHeadBlobText
+import com.codymikol.extensions.readIndexBlobText
 import com.codymikol.state.GitDownState
-import org.eclipse.jgit.treewalk.TreeWalk
 import org.eclipse.jgit.treewalk.filter.PathFilter
+import org.slf4j.LoggerFactory
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.nio.file.Path
 
 interface FileDelta {
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(FileDelta::class.java)
+    }
 
     val letter: String
     val color: Color
@@ -25,24 +31,6 @@ interface FileDelta {
         return if (file.isFile) file.readText() else null
     }
 
-    private fun readIndexContent(): String? {
-        val repo = GitDownState.repo.value
-        val entry = repo.readDirCache().getEntry(getPath()) ?: return null
-        return repo.open(entry.objectId).bytes.toString(Charsets.UTF_8)
-    }
-
-    private fun readHeadContent(): String? {
-        val repo = GitDownState.repo.value
-        val headTree = repo.resolve("HEAD^{tree}") ?: return null
-        return TreeWalk(repo).use { treeWalk ->
-            treeWalk.addTree(headTree)
-            treeWalk.isRecursive = true
-            treeWalk.filter = PathFilter.create(getPath())
-            if (!treeWalk.next()) null
-            else repo.open(treeWalk.getObjectId(0)).bytes.toString(Charsets.UTF_8)
-        }
-    }
-
     /**
      * The full available content of the side of the diff [line] belongs to (working tree/index
      * for unstaged changes, index/HEAD for staged changes), for parsing with cross-line grammar
@@ -50,12 +38,16 @@ interface FileDelta {
      * callers can fall back to per-line parsing.
      */
     fun getFullContent(line: Line): String? = try {
+        val repo = GitDownState.repo.value
         when (this.type) {
-            Status.WORKING_DIRECTORY -> if (line.type == LineType.Removed) readIndexContent() else readWorkingTreeContent()
-            Status.INDEX -> if (line.type == LineType.Removed) readHeadContent() else readIndexContent()
+            Status.WORKING_DIRECTORY ->
+                if (line.type == LineType.Removed) readIndexBlobText(repo, getPath()) else readWorkingTreeContent()
+            Status.INDEX ->
+                if (line.type == LineType.Removed) readHeadBlobText(repo, getPath()) else readIndexBlobText(repo, getPath())
             Status.STASH -> null
         }
     } catch (e: Exception) {
+        logger.error("Failed to read full content for ${getPath()}", e)
         null
     }
     private fun loadWorkingDirectoryDiff(stream: ByteArrayOutputStream) = GitDownState

--- a/src/main/kotlin/com/codymikol/data/file/FileDelta.kt
+++ b/src/main/kotlin/com/codymikol/data/file/FileDelta.kt
@@ -1,9 +1,13 @@
 package com.codymikol.data.file
 
 import androidx.compose.ui.graphics.Color
+import com.codymikol.data.diff.Line
+import com.codymikol.data.diff.LineType
 import com.codymikol.state.GitDownState
+import org.eclipse.jgit.treewalk.TreeWalk
 import org.eclipse.jgit.treewalk.filter.PathFilter
 import java.io.ByteArrayOutputStream
+import java.io.File
 import java.nio.file.Path
 
 interface FileDelta {
@@ -15,6 +19,45 @@ interface FileDelta {
     val type: Status
 
     fun getPath() = location.toString()
+
+    private fun readWorkingTreeContent(): String? {
+        val file = File(GitDownState.repo.value.workTree, getPath())
+        return if (file.isFile) file.readText() else null
+    }
+
+    private fun readIndexContent(): String? {
+        val repo = GitDownState.repo.value
+        val entry = repo.readDirCache().getEntry(getPath()) ?: return null
+        return repo.open(entry.objectId).bytes.toString(Charsets.UTF_8)
+    }
+
+    private fun readHeadContent(): String? {
+        val repo = GitDownState.repo.value
+        val headTree = repo.resolve("HEAD^{tree}") ?: return null
+        return TreeWalk(repo).use { treeWalk ->
+            treeWalk.addTree(headTree)
+            treeWalk.isRecursive = true
+            treeWalk.filter = PathFilter.create(getPath())
+            if (!treeWalk.next()) null
+            else repo.open(treeWalk.getObjectId(0)).bytes.toString(Charsets.UTF_8)
+        }
+    }
+
+    /**
+     * The full available content of the side of the diff [line] belongs to (working tree/index
+     * for unstaged changes, index/HEAD for staged changes), for parsing with cross-line grammar
+     * context. Returns null when that content can't be read (deleted file, stash, I/O error), so
+     * callers can fall back to per-line parsing.
+     */
+    fun getFullContent(line: Line): String? = try {
+        when (this.type) {
+            Status.WORKING_DIRECTORY -> if (line.type == LineType.Removed) readIndexContent() else readWorkingTreeContent()
+            Status.INDEX -> if (line.type == LineType.Removed) readHeadContent() else readIndexContent()
+            Status.STASH -> null
+        }
+    } catch (e: Exception) {
+        null
+    }
     private fun loadWorkingDirectoryDiff(stream: ByteArrayOutputStream) = GitDownState
         .git
         .value

--- a/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
+++ b/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
@@ -216,37 +216,43 @@ private data class FileContent(
     val endsWithNewline: Boolean,
 )
 
-private fun readIndexFileContent(repo: Repository, path: String): FileContent? {
+/**
+ * Reads a path's raw blob text from the index (staged content). Shared with
+ * [com.codymikol.data.file.FileDelta.getFullContent], which needs the same blob but as a whole
+ * string rather than split into lines.
+ */
+internal fun readIndexBlobText(repo: Repository, path: String): String? {
     val entry = repo.readDirCache().getEntry(path) ?: return null
-    val loader = repo.open(entry.objectId)
-    val text = loader.bytes.toString(Charsets.UTF_8)
-    val endsWithNewline = text.endsWith("\n")
+    return repo.open(entry.objectId).bytes.toString(Charsets.UTF_8)
+}
+
+/** Reads a path's raw blob text from HEAD. See [readIndexBlobText] for why this is shared. */
+internal fun readHeadBlobText(repo: Repository, path: String): String? {
+    val headTree = repo.resolve("HEAD^{tree}") ?: return null
+    return TreeWalk(repo).use { treeWalk ->
+        treeWalk.addTree(headTree)
+        treeWalk.isRecursive = true
+        treeWalk.filter = PathFilter.create(path)
+        if (!treeWalk.next()) null
+        else repo.open(treeWalk.getObjectId(0)).bytes.toString(Charsets.UTF_8)
+    }
+}
+
+private fun String.toFileContent(): FileContent {
+    val endsWithNewline = this.endsWith("\n")
     val lines = when {
-        text.isEmpty() -> emptyList()
-        endsWithNewline -> text.dropLast(1).split("\n")
-        else -> text.split("\n")
+        this.isEmpty() -> emptyList()
+        endsWithNewline -> this.dropLast(1).split("\n")
+        else -> this.split("\n")
     }
     return FileContent(lines, endsWithNewline)
 }
 
-private fun readHeadFileContent(repo: Repository, path: String): FileContent {
-    val headTree = repo.resolve("HEAD^{tree}") ?: return FileContent(emptyList(), false)
-    TreeWalk(repo).use { treeWalk ->
-        treeWalk.addTree(headTree)
-        treeWalk.isRecursive = true
-        treeWalk.filter = PathFilter.create(path)
-        if (!treeWalk.next()) return FileContent(emptyList(), false)
-        val loader = repo.open(treeWalk.getObjectId(0))
-        val text = loader.bytes.toString(Charsets.UTF_8)
-        val endsWithNewline = text.endsWith("\n")
-        val lines = when {
-            text.isEmpty() -> emptyList()
-            endsWithNewline -> text.dropLast(1).split("\n")
-            else -> text.split("\n")
-        }
-        return FileContent(lines, endsWithNewline)
-    }
-}
+private fun readIndexFileContent(repo: Repository, path: String): FileContent? =
+    readIndexBlobText(repo, path)?.toFileContent()
+
+private fun readHeadFileContent(repo: Repository, path: String): FileContent =
+    readHeadBlobText(repo, path)?.toFileContent() ?: FileContent(emptyList(), false)
 
 private fun buildPatchedLines(
     fileDeltaNode: FileDeltaNode,

--- a/src/main/kotlin/com/codymikol/highlighting/BoundedCache.kt
+++ b/src/main/kotlin/com/codymikol/highlighting/BoundedCache.kt
@@ -1,0 +1,23 @@
+package com.codymikol.highlighting
+
+/**
+ * A fixed-capacity, thread-safe LRU cache. Plain unbounded caches keyed by file content (as
+ * [FullFileLineHighlighter]'s is) would otherwise grow forever across a long-running session as a
+ * user edits and reviews diffs, since every distinct version of every file viewed becomes its own
+ * key that's never removed.
+ */
+class BoundedCache<K, V>(private val maxSize: Int) {
+
+    private val map = object : LinkedHashMap<K, V>(16, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<K, V>?): Boolean = size > maxSize
+    }
+
+    @Synchronized
+    fun getOrPut(key: K, compute: () -> V): V {
+        map[key]?.let { return it }
+        val value = compute()
+        map[key] = value
+        return value
+    }
+
+}

--- a/src/main/kotlin/com/codymikol/highlighting/FullFileLineHighlighter.kt
+++ b/src/main/kotlin/com/codymikol/highlighting/FullFileLineHighlighter.kt
@@ -5,7 +5,6 @@ import com.codymikol.data.diff.Line
 import com.codymikol.data.diff.LineType
 import com.codymikol.data.file.FileDelta
 import org.treesitter.TSLanguage
-import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Highlights a single diff line using a parse of the *whole file* it belongs to, so tree-sitter
@@ -16,7 +15,10 @@ import java.util.concurrent.ConcurrentHashMap
  */
 object FullFileLineHighlighter {
 
-    private val cache = ConcurrentHashMap<Pair<String, String>, ParsedFile>()
+    // Bounded, not a plain unbounded map: every distinct (path, content) version viewed in a
+    // session would otherwise be its own key that's never evicted.
+    private const val MAX_CACHED_FILES = 32
+    private val cache = BoundedCache<Pair<String, String>, ParsedFile>(MAX_CACHED_FILES)
 
     fun highlight(fileDelta: FileDelta, line: Line, displayLine: String, language: TSLanguage?): AnnotatedString? {
         val lineNumber = (if (line.type == LineType.Removed) line.originalLineNumber else line.newLineNumber)

--- a/src/main/kotlin/com/codymikol/highlighting/FullFileLineHighlighter.kt
+++ b/src/main/kotlin/com/codymikol/highlighting/FullFileLineHighlighter.kt
@@ -20,10 +20,15 @@ object FullFileLineHighlighter {
     private const val MAX_CACHED_FILES = 32
     private val cache = BoundedCache<Pair<String, String>, ParsedFile>(MAX_CACHED_FILES)
 
+    // A full-file tree-sitter parse is proportional to the whole file's size, not just the
+    // rendered line - an implausibly large file falls back to per-line parsing instead.
+    private const val MAX_FULL_FILE_CHARS = 2_000_000
+
     fun highlight(fileDelta: FileDelta, line: Line, displayLine: String, language: TSLanguage?): AnnotatedString? {
         val lineNumber = (if (line.type == LineType.Removed) line.originalLineNumber else line.newLineNumber)
             ?: return null
         val fullContent = fileDelta.getFullContent(line) ?: return null
+        if (fullContent.length > MAX_FULL_FILE_CHARS) return null
 
         val tabReplaced = fullContent.replace("\t", "  ")
         val lines = tabReplaced.split("\n")

--- a/src/main/kotlin/com/codymikol/highlighting/FullFileLineHighlighter.kt
+++ b/src/main/kotlin/com/codymikol/highlighting/FullFileLineHighlighter.kt
@@ -1,0 +1,36 @@
+package com.codymikol.highlighting
+
+import androidx.compose.ui.text.AnnotatedString
+import com.codymikol.data.diff.Line
+import com.codymikol.data.diff.LineType
+import com.codymikol.data.file.FileDelta
+import org.treesitter.TSLanguage
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Highlights a single diff line using a parse of the *whole file* it belongs to, so tree-sitter
+ * has the cross-line context per-line parsing lacks (multi-line comments, strings, etc). Returns
+ * null on anything that prevents this - unreadable content, a line the diff model can't place
+ * within the file, or a mismatch between the diff line and the file's own line - so the caller can
+ * fall back to per-line highlighting instead.
+ */
+object FullFileLineHighlighter {
+
+    private val cache = ConcurrentHashMap<Pair<String, String>, ParsedFile>()
+
+    fun highlight(fileDelta: FileDelta, line: Line, displayLine: String, language: TSLanguage?): AnnotatedString? {
+        val lineNumber = (if (line.type == LineType.Removed) line.originalLineNumber else line.newLineNumber)
+            ?: return null
+        val fullContent = fileDelta.getFullContent(line) ?: return null
+
+        val tabReplaced = fullContent.replace("\t", "  ")
+        val lines = tabReplaced.split("\n")
+        val lineIndex = lineNumber.toInt() - 1
+        if (lineIndex !in lines.indices || lines[lineIndex] != displayLine) return null
+
+        val parsedFile = cache.getOrPut(fileDelta.getPath() to tabReplaced) { FullFileTokens.parse(language, tabReplaced) }
+        val tokens = FullFileTokens.tokensForLine(parsedFile, lineIndex)
+        return SyntaxHighlighter.highlight(displayLine, tokens)
+    }
+
+}

--- a/src/main/kotlin/com/codymikol/highlighting/FullFileTokens.kt
+++ b/src/main/kotlin/com/codymikol/highlighting/FullFileTokens.kt
@@ -1,0 +1,48 @@
+package com.codymikol.highlighting
+
+import org.treesitter.TSLanguage
+
+/**
+ * The result of parsing a whole file's text once: the tokens (with byte offsets relative to the
+ * full text) alongside the byte range each line occupies within that text, so a token that spans
+ * multiple lines (e.g. a block comment) can be sliced onto each line it touches.
+ */
+data class ParsedFile(
+    val lineByteRanges: List<IntRange>,
+    val tokens: List<SyntaxToken>,
+)
+
+object FullFileTokens {
+
+    fun parse(language: TSLanguage?, text: String): ParsedFile {
+        val tokens = GrammarParser.parse(language, text)
+        val lineByteRanges = mutableListOf<IntRange>()
+        var byteOffset = 0
+        text.split("\n").forEach { line ->
+            val lineByteLength = line.toByteArray(Charsets.UTF_8).size
+            lineByteRanges.add(byteOffset until byteOffset + lineByteLength)
+            byteOffset += lineByteLength + 1 // +1 for the '\n' separator
+        }
+        return ParsedFile(lineByteRanges, tokens)
+    }
+
+    /**
+     * Slices [parsedFile]'s tokens down to those overlapping the given line, re-basing each
+     * token's byte offsets to be relative to that line's own start (as required by
+     * [SyntaxHighlighter.highlight]). A token spanning multiple lines is clipped to the portion
+     * that falls on this line.
+     */
+    fun tokensForLine(parsedFile: ParsedFile, lineIndex: Int): List<SyntaxToken> {
+        val lineRange = parsedFile.lineByteRanges.getOrNull(lineIndex) ?: return emptyList()
+        val lineStart = lineRange.first
+        val lineEnd = lineRange.last + 1
+
+        return parsedFile.tokens.mapNotNull { token ->
+            val clippedStart = token.startByte.coerceIn(lineStart, lineEnd)
+            val clippedEnd = token.endByte.coerceIn(lineStart, lineEnd)
+            if (clippedStart >= clippedEnd) null
+            else token.copy(startByte = clippedStart - lineStart, endByte = clippedEnd - lineStart)
+        }
+    }
+
+}

--- a/src/main/kotlin/com/codymikol/highlighting/GrammarParser.kt
+++ b/src/main/kotlin/com/codymikol/highlighting/GrammarParser.kt
@@ -7,9 +7,10 @@ import org.treesitter.TSNode
 import org.treesitter.TSParser
 
 /**
- * Walks the tree-sitter parse tree for a single line of text into a flat list of leaf tokens
- * for [SyntaxHighlighter]. Parsing untrusted/foreign grammar code is inherently unsafe, so every
- * failure here is caught and turned into an empty (unhighlighted) token list.
+ * Walks the tree-sitter parse tree for a piece of text (a single diff line, or a whole file when
+ * called via [FullFileTokens]) into a flat list of leaf tokens for [SyntaxHighlighter]. Parsing
+ * untrusted/foreign grammar code is inherently unsafe, so every failure here is caught and turned
+ * into an empty (unhighlighted) token list.
  */
 object GrammarParser {
 

--- a/src/test/kotlin/com/codymikol/data/file/FileDeltaGetFullContentSpec.kt
+++ b/src/test/kotlin/com/codymikol/data/file/FileDeltaGetFullContentSpec.kt
@@ -1,0 +1,121 @@
+package com.codymikol.data.file
+
+import com.codymikol.data.diff.FileDeltaNode
+import com.codymikol.data.diff.LineType
+import com.codymikol.extensions.commitAll
+import com.codymikol.extensions.stageAll
+import com.codymikol.repository.TestRepository.Companion.createTestRepository
+import com.codymikol.state.GitDownState
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+private fun content(lines: List<String>) = lines.joinToString("\n", postfix = "\n")
+
+private fun fileDeltaNodeFor(path: String, status: Status): FileDeltaNode {
+    val fileDelta = when (status) {
+        Status.WORKING_DIRECTORY -> GitDownState.workingDirectory.value.firstOrNull { it.getPath() == path }
+        Status.INDEX -> GitDownState.index.value.firstOrNull { it.getPath() == path }
+        Status.STASH -> null
+    }
+    requireNotNull(fileDelta)
+    GitDownState.selectedFiles.clear()
+    GitDownState.selectedFiles.add(fileDelta)
+    return GitDownState.diffTree.value.fileDeltaNodes.single()
+}
+
+class FileDeltaGetFullContentSpec : DescribeSpec({
+
+    describe("FileDelta.getFullContent") {
+
+        describe("an unstaged addition in the working directory") {
+
+            autoClose(
+                createTestRepository()
+                    .addFile("foo.txt", content(listOf("one", "two", "three")))
+                    .stageAll()
+                    .commitAll("base")
+                    .addFile("foo.txt", content(listOf("one", "two", "three", "four")))
+                    .transferIntoGitDownState()
+            )
+
+            val workingNode = fileDeltaNodeFor("foo.txt", Status.WORKING_DIRECTORY)
+            val addedLine = workingNode.hunkNodes.flatMap { it.lineNodes }.first { it.line.type == LineType.Added }
+
+            it("returns the working tree's full content for an added line") {
+                workingNode.fileDelta.getFullContent(addedLine.line) shouldBe
+                    content(listOf("one", "two", "three", "four"))
+            }
+
+        }
+
+        describe("an unstaged removal, with a separate staged change already in the index") {
+
+            autoClose(
+                createTestRepository()
+                    .addFile("foo.txt", content(listOf("a", "b", "c")))
+                    .stageAll()
+                    .commitAll("base")
+                    .addFile("foo.txt", content(listOf("a", "b", "c", "d")))
+                    .stageAll()
+                    .addFile("foo.txt", content(listOf("a", "c", "d")))
+                    .transferIntoGitDownState()
+            )
+
+            val workingNode = fileDeltaNodeFor("foo.txt", Status.WORKING_DIRECTORY)
+            val removedLine = workingNode.hunkNodes.flatMap { it.lineNodes }.first { it.line.type == LineType.Removed }
+
+            it("returns the index's content, not HEAD's, for a removed line") {
+                // If this read HEAD instead of the index it would be missing "d".
+                workingNode.fileDelta.getFullContent(removedLine.line) shouldBe
+                    content(listOf("a", "b", "c", "d"))
+            }
+
+        }
+
+        describe("a staged addition in the index") {
+
+            autoClose(
+                createTestRepository()
+                    .addFile("foo.txt", content(listOf("one", "two", "three")))
+                    .stageAll()
+                    .commitAll("base")
+                    .addFile("foo.txt", content(listOf("one", "two", "three", "four")))
+                    .stageAll()
+                    .transferIntoGitDownState()
+            )
+
+            val indexNode = fileDeltaNodeFor("foo.txt", Status.INDEX)
+            val addedLine = indexNode.hunkNodes.flatMap { it.lineNodes }.first { it.line.type == LineType.Added }
+
+            it("returns the index's full content for an added line") {
+                indexNode.fileDelta.getFullContent(addedLine.line) shouldBe
+                    content(listOf("one", "two", "three", "four"))
+            }
+
+        }
+
+        describe("a staged removal") {
+
+            autoClose(
+                createTestRepository()
+                    .addFile("foo.txt", content(listOf("a", "b", "c")))
+                    .stageAll()
+                    .commitAll("base")
+                    .addFile("foo.txt", content(listOf("a", "c")))
+                    .stageAll()
+                    .transferIntoGitDownState()
+            )
+
+            val indexNode = fileDeltaNodeFor("foo.txt", Status.INDEX)
+            val removedLine = indexNode.hunkNodes.flatMap { it.lineNodes }.first { it.line.type == LineType.Removed }
+
+            it("returns HEAD's full content for a removed line") {
+                indexNode.fileDelta.getFullContent(removedLine.line) shouldBe
+                    content(listOf("a", "b", "c"))
+            }
+
+        }
+
+    }
+
+})

--- a/src/test/kotlin/com/codymikol/highlighting/BoundedCacheSpec.kt
+++ b/src/test/kotlin/com/codymikol/highlighting/BoundedCacheSpec.kt
@@ -1,0 +1,35 @@
+package com.codymikol.highlighting
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class BoundedCacheSpec : DescribeSpec({
+
+    describe("BoundedCache.getOrPut") {
+
+        it("returns the cached value without recomputing it on a repeat key") {
+            val cache = BoundedCache<String, Int>(maxSize = 2)
+            var calls = 0
+
+            cache.getOrPut("a") { calls++; 1 }
+            cache.getOrPut("a") { calls++; 1 }
+
+            calls shouldBe 1
+        }
+
+        it("evicts the least recently used entry once capacity is exceeded") {
+            val cache = BoundedCache<String, Int>(maxSize = 2)
+            cache.getOrPut("a") { 1 }
+            cache.getOrPut("b") { 2 }
+            cache.getOrPut("a") { 1 } // touch "a" so "b" is now the least-recently-used entry
+            cache.getOrPut("c") { 3 } // exceeds capacity, evicts "b"
+
+            var recomputed = false
+            cache.getOrPut("b") { recomputed = true; 2 }
+
+            recomputed shouldBe true
+        }
+
+    }
+
+})

--- a/src/test/kotlin/com/codymikol/highlighting/FullFileLineHighlighterSpec.kt
+++ b/src/test/kotlin/com/codymikol/highlighting/FullFileLineHighlighterSpec.kt
@@ -1,9 +1,12 @@
 package com.codymikol.highlighting
 
+import androidx.compose.ui.graphics.Color
 import com.codymikol.data.diff.FileDeltaNode
 import com.codymikol.data.diff.Line
 import com.codymikol.data.diff.LineType
+import com.codymikol.data.file.FileDelta
 import com.codymikol.data.file.Stash
+import com.codymikol.data.file.Status
 import com.codymikol.extensions.commitAll
 import com.codymikol.extensions.stageAll
 import com.codymikol.repository.TestRepository.Companion.createTestRepository
@@ -69,6 +72,29 @@ class FullFileLineHighlighterSpec : DescribeSpec({
             // "2" is a bare number_literal token; tree-sitter-json reports its byte range
             // relative to the diff line's own text once sliced from the full-file parse.
             highlighted.spanStyles.map { it.start to it.end } shouldContain (2 to 3)
+        }
+
+        it("returns null instead of parsing a file whose full content is implausibly large") {
+            // The line the diff points at genuinely matches the full content's first line, so
+            // this exercises the size guard specifically, not the line-mismatch fallback.
+            val hugeContent = "a\n" + "b".repeat(10_000_000)
+            val fileDelta = object : FileDelta {
+                override val letter = "M"
+                override val color = Color.White
+                override val borderColor = Color.White
+                override val location = Path.of("huge.json")
+                override val type = Status.WORKING_DIRECTORY
+                override fun getFullContent(line: Line): String = hugeContent
+            }
+            val line = Line(
+                type = LineType.Added,
+                value = "a",
+                symbol = "+",
+                originalLineNumber = null,
+                newLineNumber = 1u,
+            )
+
+            FullFileLineHighlighter.highlight(fileDelta, line, "a", null).shouldBeNull()
         }
 
     }

--- a/src/test/kotlin/com/codymikol/highlighting/FullFileLineHighlighterSpec.kt
+++ b/src/test/kotlin/com/codymikol/highlighting/FullFileLineHighlighterSpec.kt
@@ -1,0 +1,76 @@
+package com.codymikol.highlighting
+
+import com.codymikol.data.diff.FileDeltaNode
+import com.codymikol.data.diff.Line
+import com.codymikol.data.diff.LineType
+import com.codymikol.data.file.Stash
+import com.codymikol.extensions.commitAll
+import com.codymikol.extensions.stageAll
+import com.codymikol.repository.TestRepository.Companion.createTestRepository
+import com.codymikol.state.GitDownState
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import java.nio.file.Path
+
+private fun content(lines: List<String>) = lines.joinToString("\n", postfix = "\n")
+
+private fun workingDirectoryNodeFor(path: String): FileDeltaNode {
+    val fileDelta = GitDownState.workingDirectory.value.first { it.getPath() == path }
+    GitDownState.selectedFiles.clear()
+    GitDownState.selectedFiles.add(fileDelta)
+    return GitDownState.diffTree.value.fileDeltaNodes.single()
+}
+
+class FullFileLineHighlighterSpec : DescribeSpec({
+
+    describe("FullFileLineHighlighter.highlight") {
+
+        it("returns null when the file delta's full content can't be read (e.g. a stash entry)") {
+            val fileDelta = Stash.FileModified(Path.of("foo.json"), "")
+            val line = Line(
+                type = LineType.Added,
+                value = "1",
+                symbol = "+",
+                originalLineNumber = null,
+                newLineNumber = 1u,
+            )
+
+            FullFileLineHighlighter.highlight(fileDelta, line, "1", null).shouldBeNull()
+        }
+
+        it("highlights an added diff line using a parse of the file's full contents") {
+            val grammarFile = BundledJsonGrammarFixture.extract()
+            val language = GrammarLanguageLoader.load(grammarFile, BundledJsonGrammarFixture.FUNCTION_NAME)
+            requireNotNull(language) { "Expected the bundled tree-sitter-json fixture to load" }
+
+            autoClose(
+                createTestRepository()
+                    .addFile("foo.json", content(listOf("[", "  1", "]")))
+                    .stageAll()
+                    .commitAll("base")
+                    .addFile("foo.json", content(listOf("[", "  1,", "  2", "]")))
+                    .transferIntoGitDownState()
+            )
+
+            val workingNode = workingDirectoryNodeFor("foo.json")
+            val addedLine = workingNode.hunkNodes.flatMap { it.lineNodes }
+                .first { it.line.type == LineType.Added && it.line.value == "  2" }
+
+            val highlighted = FullFileLineHighlighter.highlight(
+                workingNode.fileDelta,
+                addedLine.line,
+                addedLine.line.value,
+                language,
+            )
+
+            highlighted.shouldNotBeNull()
+            // "2" is a bare number_literal token; tree-sitter-json reports its byte range
+            // relative to the diff line's own text once sliced from the full-file parse.
+            highlighted.spanStyles.map { it.start to it.end } shouldContain (2 to 3)
+        }
+
+    }
+
+})

--- a/src/test/kotlin/com/codymikol/highlighting/FullFileTokensSpec.kt
+++ b/src/test/kotlin/com/codymikol/highlighting/FullFileTokensSpec.kt
@@ -1,0 +1,62 @@
+package com.codymikol.highlighting
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class FullFileTokensSpec : DescribeSpec({
+
+    describe("FullFileTokens.tokensForLine") {
+
+        it("rebases a token fully contained within the target line to be relative to that line's start") {
+            // "foo\nbar\n" -> line 0 is "foo" (bytes 0..3), line 1 is "bar" (bytes 4..7)
+            val parsedFile = ParsedFile(
+                lineByteRanges = listOf(0 until 3, 4 until 7),
+                tokens = listOf(SyntaxToken("identifier", 4, 7, true)),
+            )
+
+            val tokens = FullFileTokens.tokensForLine(parsedFile, 1)
+
+            tokens shouldBe listOf(SyntaxToken("identifier", 0, 3, true))
+        }
+
+        it("splits a token spanning multiple lines into a clipped fragment per line") {
+            // "/*\nfoo\n*/" -> a block comment token spanning bytes 0..9 across all 3 lines
+            val parsedFile = ParsedFile(
+                lineByteRanges = listOf(0 until 2, 3 until 6, 7 until 9),
+                tokens = listOf(SyntaxToken("comment", 0, 9, true)),
+            )
+
+            FullFileTokens.tokensForLine(parsedFile, 0) shouldBe listOf(SyntaxToken("comment", 0, 2, true))
+            FullFileTokens.tokensForLine(parsedFile, 1) shouldBe listOf(SyntaxToken("comment", 0, 3, true))
+            FullFileTokens.tokensForLine(parsedFile, 2) shouldBe listOf(SyntaxToken("comment", 0, 2, true))
+        }
+
+        it("drops a token that does not overlap the target line at all") {
+            val parsedFile = ParsedFile(
+                lineByteRanges = listOf(0 until 3, 4 until 7),
+                tokens = listOf(SyntaxToken("identifier", 4, 7, true)),
+            )
+
+            FullFileTokens.tokensForLine(parsedFile, 0) shouldBe emptyList()
+        }
+
+        it("returns an empty list for a line index outside the file") {
+            val parsedFile = ParsedFile(lineByteRanges = listOf(0 until 3), tokens = emptyList())
+
+            FullFileTokens.tokensForLine(parsedFile, 5) shouldBe emptyList()
+        }
+
+    }
+
+    describe("FullFileTokens.parse") {
+
+        it("computes byte ranges per line accounting for multi-byte UTF-8 characters") {
+            // "é=1\nb" -> line 0 is "é=1" (2-byte é + '=' + '1' = 4 bytes), line 1 is "b" (1 byte)
+            val parsedFile = FullFileTokens.parse(null, "é=1\nb")
+
+            parsedFile.lineByteRanges shouldBe listOf(0 until 4, 5 until 6)
+        }
+
+    }
+
+})


### PR DESCRIPTION
## Summary

Fixes the per-line syntax highlighting limitation from #231: each diff line was parsed by tree-sitter in isolation, so multi-line constructs (block comments, multi-line strings) never highlighted correctly across line boundaries because the diff model never had full-file content.

- `FileDelta.getFullContent(line)` reads the whole file for the side of the diff a line belongs to (working tree/index for unstaged changes, index/HEAD for staged changes), sharing its JGit blob-read logic with `GitExtensions`.
- `FullFileTokens` parses a file once and slices/re-bases its byte-offset tokens onto an individual line's range — a token spanning multiple lines (e.g. a block comment) becomes a clipped fragment per line instead of being lost.
- `FullFileLineHighlighter` ties these together, with a bounded LRU cache (`BoundedCache`, 32 entries) so parses aren't repeated per line and don't grow memory unbounded over a long session, plus a size guard that skips full-file parsing for implausibly large files.
- `Diff.kt`'s `DiffLine` now tries this full-file path first and falls back to the existing per-line `highlightLine` whenever the full content can't be read or placed against the diff line (deleted file, stash, binary, mismatch, oversized file) — the existing per-line behavior is preserved as a safety net.

All new logic is covered by unit/integration tests (`FullFileTokensSpec`, `FileDeltaGetFullContentSpec`, `FullFileLineHighlighterSpec`, `BoundedCacheSpec`), including a real bundled tree-sitter-json grammar exercising the full pipeline end-to-end via `TestRepository`-backed diffs.

Closes #231

## Reviewer notes / follow-ups considered but not fixed here

A `reviewer` subagent pass blocked once (unbounded cache — fixed via `BoundedCache`) then approved. Remaining non-blocking items intentionally left as follow-ups rather than folded in, since fixing them safely is a bigger design lift than this slice:

- `getFullContent` re-reads the file from disk/git for every rendered line (only the parse result is cached). A content-level cache would need a staleness-safe key (e.g. JGit object ID / mtime) to avoid reintroducing the exact "stale content" bug class this issue is about — didn't want to rush that.
- `BoundedCache.getOrPut` holds a single global lock across the parse call, serializing highlighting across unrelated files. Fixing this well needs per-key locking, not a quick patch.
- Multi-line token slicing is proven at the unit level (`FullFileTokensSpec`, synthetic tokens) but not via a real bundled grammar with actual block comments/multi-line strings, since the only bundled test grammar (tree-sitter-json) has no such constructs.

## Test plan

- [x] `./gradlew test` — all 224 tests pass
- [x] Fresh `reviewer` subagent pass: APPROVE (after fixing the one blocking finding)