### PR TITLE
feat(highlighting): pull down and use highlights.scm with tree-sitter

### DIFF
--- a/src/main/kotlin/com/codymikol/components/commit/diff/Diff.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/diff/Diff.kt
@@ -26,6 +26,8 @@ import com.codymikol.highlighting.GrammarCache
 import com.codymikol.highlighting.GrammarExtensionRegistry
 import com.codymikol.highlighting.GrammarLanguageLoader
 import com.codymikol.highlighting.GrammarParser
+import com.codymikol.highlighting.QueryCache
+import com.codymikol.highlighting.QueryLoader
 import com.codymikol.highlighting.SyntaxHighlighter
 import com.codymikol.state.Keys
 import com.codymikol.typography.GitDownTypography
@@ -34,8 +36,10 @@ import kotlinx.coroutines.withContext
 import org.koin.java.KoinJavaComponent.inject
 import org.slf4j.LoggerFactory
 import org.treesitter.TSLanguage
+import org.treesitter.TSQuery
 
 private val grammarCache: GrammarCache by inject(GrammarCache::class.java)
+private val queryCache: QueryCache by inject(QueryCache::class.java)
 private val logger = LoggerFactory.getLogger("com.codymikol.components.commit.diff.Diff")
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -171,8 +175,9 @@ private fun DiffLine(lineNode: LineNode) {
                     val extension = lineNode.parent.parent.getPath().substringAfterLast('.', "")
                     if (extension.isEmpty()) return@LaunchedEffect
                     highlighted = withContext(Dispatchers.IO) {
-                        val language = resolveLanguage(extension)
-                        highlightLineFromFullFile(lineNode, displayLine, language) ?: highlightLine(language, displayLine)
+                        val grammar = resolveGrammar(extension)
+                        highlightLineFromFullFile(lineNode, displayLine, grammar.language, grammar.query)
+                            ?: highlightLine(grammar.language, grammar.query, displayLine)
                     }
                 } catch (e: Exception) {
                     logger.error("Failed to apply syntax highlighting for line", e)
@@ -189,23 +194,39 @@ private fun DiffLine(lineNode: LineNode) {
     }
 }
 
-private suspend fun resolveLanguage(extension: String): TSLanguage? {
-    val spec = GrammarExtensionRegistry.forExtension(extension) ?: return null
-    val grammarPath = grammarCache.ensureGrammar(spec) ?: return null
-    return GrammarLanguageLoader.load(grammarPath, spec.functionName)
+private data class ResolvedGrammar(val language: TSLanguage?, val query: TSQuery?)
+
+private val NO_GRAMMAR = ResolvedGrammar(null, null)
+
+// Resolves both the compiled grammar and (if the grammar has one, and it can be fetched/cached)
+// its highlights.scm query for an extension in one pass, since the query is only meaningful
+// once the language it's compiled against is already resolved. Either half missing propagates
+// all the way through to plain leaf-node highlighting rather than blocking it.
+private suspend fun resolveGrammar(extension: String): ResolvedGrammar {
+    val spec = GrammarExtensionRegistry.forExtension(extension) ?: return NO_GRAMMAR
+    val grammarPath = grammarCache.ensureGrammar(spec) ?: return NO_GRAMMAR
+    val language = GrammarLanguageLoader.load(grammarPath, spec.functionName) ?: return NO_GRAMMAR
+    val queriesPath = queryCache.ensureQueries(spec)
+    val query = queriesPath?.let { QueryLoader.load(language, it) }
+    return ResolvedGrammar(language, query)
 }
 
-private fun highlightLine(language: TSLanguage?, text: String): AnnotatedString {
-    val tokens = GrammarParser.parse(language, text)
+private fun highlightLine(language: TSLanguage?, query: TSQuery?, text: String): AnnotatedString {
+    val tokens = GrammarParser.parse(language, text, query)
     return SyntaxHighlighter.highlight(text, tokens)
 }
 
 // Parses the line's whole file once (so tree-sitter has cross-line context, e.g. for block
 // comments) instead of the line in isolation. Returns null - falling back to highlightLine -
 // whenever the full file's content can't be read or placed against this diff line.
-private fun highlightLineFromFullFile(lineNode: LineNode, displayLine: String, language: TSLanguage?): AnnotatedString? {
+private fun highlightLineFromFullFile(
+    lineNode: LineNode,
+    displayLine: String,
+    language: TSLanguage?,
+    query: TSQuery?,
+): AnnotatedString? {
     val fileDeltaNode = lineNode.parent.parent
-    return FullFileLineHighlighter.highlight(fileDeltaNode.fileDelta, lineNode.line, displayLine, language)
+    return FullFileLineHighlighter.highlight(fileDeltaNode.fileDelta, lineNode.line, displayLine, language, query)
 }
 
 @Composable

--- a/src/main/kotlin/com/codymikol/highlighting/FullFileLineHighlighter.kt
+++ b/src/main/kotlin/com/codymikol/highlighting/FullFileLineHighlighter.kt
@@ -5,6 +5,7 @@ import com.codymikol.data.diff.Line
 import com.codymikol.data.diff.LineType
 import com.codymikol.data.file.FileDelta
 import org.treesitter.TSLanguage
+import org.treesitter.TSQuery
 
 /**
  * Highlights a single diff line using a parse of the *whole file* it belongs to, so tree-sitter
@@ -16,15 +17,24 @@ import org.treesitter.TSLanguage
 object FullFileLineHighlighter {
 
     // Bounded, not a plain unbounded map: every distinct (path, content) version viewed in a
-    // session would otherwise be its own key that's never evicted.
+    // session would otherwise be its own key that's never evicted. Keyed on the query instance
+    // too (identity - TSQuery has no equals override) so a cached parse from before a query
+    // became available is never served back once one is - only relevant to callers that resolve
+    // a query lazily/inconsistently, since a given extension's query is otherwise stable.
     private const val MAX_CACHED_FILES = 32
-    private val cache = BoundedCache<Pair<String, String>, ParsedFile>(MAX_CACHED_FILES)
+    private val cache = BoundedCache<Triple<String, String, TSQuery?>, ParsedFile>(MAX_CACHED_FILES)
 
     // A full-file tree-sitter parse is proportional to the whole file's size, not just the
     // rendered line - an implausibly large file falls back to per-line parsing instead.
     private const val MAX_FULL_FILE_CHARS = 2_000_000
 
-    fun highlight(fileDelta: FileDelta, line: Line, displayLine: String, language: TSLanguage?): AnnotatedString? {
+    fun highlight(
+        fileDelta: FileDelta,
+        line: Line,
+        displayLine: String,
+        language: TSLanguage?,
+        query: TSQuery? = null,
+    ): AnnotatedString? {
         val lineNumber = (if (line.type == LineType.Removed) line.originalLineNumber else line.newLineNumber)
             ?: return null
         val fullContent = fileDelta.getFullContent(line) ?: return null
@@ -35,7 +45,9 @@ object FullFileLineHighlighter {
         val lineIndex = lineNumber.toInt() - 1
         if (lineIndex !in lines.indices || lines[lineIndex] != displayLine) return null
 
-        val parsedFile = cache.getOrPut(fileDelta.getPath() to tabReplaced) { FullFileTokens.parse(language, tabReplaced) }
+        val parsedFile = cache.getOrPut(Triple(fileDelta.getPath(), tabReplaced, query)) {
+            FullFileTokens.parse(language, tabReplaced, query)
+        }
         val tokens = FullFileTokens.tokensForLine(parsedFile, lineIndex)
         return SyntaxHighlighter.highlight(displayLine, tokens)
     }

--- a/src/main/kotlin/com/codymikol/highlighting/FullFileTokens.kt
+++ b/src/main/kotlin/com/codymikol/highlighting/FullFileTokens.kt
@@ -1,6 +1,7 @@
 package com.codymikol.highlighting
 
 import org.treesitter.TSLanguage
+import org.treesitter.TSQuery
 
 /**
  * The result of parsing a whole file's text once: the tokens (with byte offsets relative to the
@@ -14,8 +15,8 @@ data class ParsedFile(
 
 object FullFileTokens {
 
-    fun parse(language: TSLanguage?, text: String): ParsedFile {
-        val tokens = GrammarParser.parse(language, text)
+    fun parse(language: TSLanguage?, text: String, query: TSQuery? = null): ParsedFile {
+        val tokens = GrammarParser.parse(language, text, query)
         val lineByteRanges = mutableListOf<IntRange>()
         var byteOffset = 0
         text.split("\n").forEach { line ->

--- a/src/main/kotlin/com/codymikol/highlighting/GitHubQueryDownloader.kt
+++ b/src/main/kotlin/com/codymikol/highlighting/GitHubQueryDownloader.kt
@@ -1,0 +1,36 @@
+package com.codymikol.highlighting
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Single
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Fetches a grammar's `queries/highlights.scm` from tree-sitter-grammars, the same source
+ * [SourceCompilingGrammarDownloader] pulls each grammar's C sources from, so the captures used
+ * for highlighting come from the grammar author's own query definitions rather than a
+ * hand-rolled heuristic.
+ */
+@Single
+class GitHubQueryDownloader(
+    private val fetcher: GitHubRepositoryFetcher = HttpGitHubRepositoryFetcher(),
+) : QueryDownloader {
+
+    companion object {
+        private const val ORG = "tree-sitter-grammars"
+        private const val QUERY_FILE_NAME = "highlights.scm"
+    }
+
+    override suspend fun download(spec: GrammarSpec, destination: Path): Boolean = withContext(Dispatchers.IO) {
+        val queriesPath = spec.queriesPath ?: return@withContext false
+        val listing = fetcher.listDirectory(ORG, spec.repo, queriesPath) ?: return@withContext false
+        val entry = listing.firstOrNull { it.name == QUERY_FILE_NAME && it.type == "file" } ?: return@withContext false
+        val bytes = fetcher.fetchBytes(entry.downloadUrl ?: return@withContext false) ?: return@withContext false
+        // Destination's parent directory is [QueryCache]'s responsibility, same as
+        // SourceCompilingGrammarDownloader leaves it to GrammarCache.
+        Files.write(destination, bytes)
+        true
+    }
+
+}

--- a/src/main/kotlin/com/codymikol/highlighting/GrammarExtensionRegistry.kt
+++ b/src/main/kotlin/com/codymikol/highlighting/GrammarExtensionRegistry.kt
@@ -7,21 +7,29 @@ package com.codymikol.highlighting
 object GrammarExtensionRegistry {
 
     private val grammarsByExtension: Map<String, GrammarSpec> = mapOf(
-        "kt" to GrammarSpec("tree-sitter-kotlin", "tree_sitter_kotlin"),
-        "kts" to GrammarSpec("tree-sitter-kotlin", "tree_sitter_kotlin"),
+        // tree-sitter-kotlin ships no queries/ directory upstream at all.
+        "kt" to GrammarSpec("tree-sitter-kotlin", "tree_sitter_kotlin", queriesPath = null),
+        "kts" to GrammarSpec("tree-sitter-kotlin", "tree_sitter_kotlin", queriesPath = null),
         "toml" to GrammarSpec("tree-sitter-toml", "tree_sitter_toml"),
-        "md" to GrammarSpec("tree-sitter-markdown", "tree_sitter_markdown", sourcePath = "tree-sitter-markdown/src"),
+        "md" to GrammarSpec(
+            "tree-sitter-markdown", "tree_sitter_markdown",
+            sourcePath = "tree-sitter-markdown/src", queriesPath = "tree-sitter-markdown/queries",
+        ),
         "lua" to GrammarSpec("tree-sitter-lua", "tree_sitter_lua"),
-        "hcl" to GrammarSpec("tree-sitter-hcl", "tree_sitter_hcl"),
-        "tf" to GrammarSpec("tree-sitter-hcl", "tree_sitter_hcl"),
-        "vim" to GrammarSpec("tree-sitter-vim", "tree_sitter_vim"),
+        // tree-sitter-hcl ships no queries/ directory upstream at all.
+        "hcl" to GrammarSpec("tree-sitter-hcl", "tree_sitter_hcl", queriesPath = null),
+        "tf" to GrammarSpec("tree-sitter-hcl", "tree_sitter_hcl", queriesPath = null),
+        "vim" to GrammarSpec("tree-sitter-vim", "tree_sitter_vim", queriesPath = "queries/vim"),
         "jl" to GrammarSpec("tree-sitter-julia", "tree_sitter_julia"),
         "hs" to GrammarSpec("tree-sitter-haskell", "tree_sitter_haskell"),
         "scss" to GrammarSpec("tree-sitter-scss", "tree_sitter_scss"),
-        "csv" to GrammarSpec("tree-sitter-csv", "tree_sitter_csv", sourcePath = "csv/src"),
+        "csv" to GrammarSpec(
+            "tree-sitter-csv", "tree_sitter_csv",
+            sourcePath = "csv/src", queriesPath = "csv/queries",
+        ),
         "svelte" to GrammarSpec("tree-sitter-svelte", "tree_sitter_svelte"),
-        "vue" to GrammarSpec("tree-sitter-vue", "tree_sitter_vue"),
-        "tcl" to GrammarSpec("tree-sitter-tcl", "tree_sitter_tcl"),
+        "vue" to GrammarSpec("tree-sitter-vue", "tree_sitter_vue", queriesPath = "queries/vue"),
+        "tcl" to GrammarSpec("tree-sitter-tcl", "tree_sitter_tcl", queriesPath = "queries/tcl"),
         "thrift" to GrammarSpec("tree-sitter-thrift", "tree_sitter_thrift"),
     )
 

--- a/src/main/kotlin/com/codymikol/highlighting/GrammarParser.kt
+++ b/src/main/kotlin/com/codymikol/highlighting/GrammarParser.kt
@@ -5,23 +5,27 @@ import org.slf4j.LoggerFactory
 import org.treesitter.TSLanguage
 import org.treesitter.TSNode
 import org.treesitter.TSParser
+import org.treesitter.TSQuery
 
 /**
  * Walks the tree-sitter parse tree for a piece of text (a single diff line, or a whole file when
- * called via [FullFileTokens]) into a flat list of leaf tokens for [SyntaxHighlighter]. Parsing
- * untrusted/foreign grammar code is inherently unsafe, so every failure here is caught and turned
- * into an empty (unhighlighted) token list.
+ * called via [FullFileTokens]) into a flat list of tokens for [SyntaxHighlighter]. When a
+ * highlights.scm [query] is available, its captures (via [QueryExecutor]) are used instead of the
+ * raw leaf-node heuristic; without one, this falls back to the leaf-node types it always used.
+ * Parsing untrusted/foreign grammar code is inherently unsafe, so every failure here is caught and
+ * turned into an empty (unhighlighted) token list.
  */
 object GrammarParser {
 
     private val logger: Logger = LoggerFactory.getLogger(GrammarParser::class.java)
 
-    fun parse(language: TSLanguage?, text: String): List<SyntaxToken> {
+    fun parse(language: TSLanguage?, text: String, query: TSQuery? = null): List<SyntaxToken> {
         if (language == null) return emptyList()
         return try {
             TSParser().use { parser ->
                 parser.setLanguage(language)
                 val tree = parser.parseString(null, text) ?: return emptyList()
+                if (query != null) return QueryExecutor.execute(query, tree.rootNode, text)
                 val tokens = mutableListOf<SyntaxToken>()
                 collectLeaves(tree.rootNode, tokens)
                 tokens

--- a/src/main/kotlin/com/codymikol/highlighting/GrammarSpec.kt
+++ b/src/main/kotlin/com/codymikol/highlighting/GrammarSpec.kt
@@ -7,4 +7,8 @@ data class GrammarSpec(
     // multiple grammars in one repo (tree-sitter-markdown, tree-sitter-csv) and nest sources
     // one level deeper.
     val sourcePath: String = "src",
+    // Mirrors sourcePath's nesting for each repo's `queries/highlights.scm`. Null means the
+    // upstream repo ships no queries directory at all, so query fetching is skipped entirely
+    // rather than retried every cache cycle against a path that will never exist.
+    val queriesPath: String? = "queries",
 )

--- a/src/main/kotlin/com/codymikol/highlighting/HighlightTheme.kt
+++ b/src/main/kotlin/com/codymikol/highlighting/HighlightTheme.kt
@@ -1,0 +1,51 @@
+package com.codymikol.highlighting
+
+import androidx.compose.ui.graphics.Color
+
+/**
+ * Maps tree-sitter highlights.scm capture names (https://tree-sitter.github.io/tree-sitter/using-parsers/queries/3-predicates-and-directives.html#standard-capture-names)
+ * to colors, baked to match the app's existing diff-view aesthetic - comment/string/number/
+ * keyword reuse the exact colors [SyntaxHighlighter] already used before queries existed.
+ * Capture names not listed here (e.g. "operator", "punctuation.*") are intentionally left out so
+ * they fall back to the base text color instead of being invented.
+ */
+object HighlightTheme {
+
+    // Named so SyntaxHighlighter's node-type heuristic can reuse the exact same colors instead
+    // of duplicating the literals.
+    val comment = Color(106, 153, 85)
+    val string = Color(206, 145, 120)
+    val number = Color(181, 206, 168)
+    val keyword = Color(86, 156, 214)
+
+    val colors: Map<String, Color> = mapOf(
+        "comment" to comment,
+        "string" to string,
+        "string.escape" to Color(215, 186, 125),
+        "number" to number,
+        "keyword" to keyword,
+        "tag" to keyword,
+        "function" to Color(220, 220, 170),
+        "type" to Color(78, 201, 176),
+        "constant" to Color(79, 193, 255),
+        "property" to Color(156, 220, 254),
+        "variable.parameter" to Color(156, 220, 254),
+        "attribute" to Color(156, 220, 254),
+    )
+
+    /**
+     * Resolves a capture name to a color, trying progressively shorter dotted prefixes (e.g.
+     * "function.builtin" falls back to "function") since highlights.scm files capture with
+     * fine-grained names this baked theme doesn't need to enumerate individually.
+     */
+    fun colorFor(captureName: String): Color? {
+        var name = captureName
+        while (true) {
+            colors[name]?.let { return it }
+            val dotIndex = name.lastIndexOf('.')
+            if (dotIndex < 0) return null
+            name = name.substring(0, dotIndex)
+        }
+    }
+
+}

--- a/src/main/kotlin/com/codymikol/highlighting/QueryCache.kt
+++ b/src/main/kotlin/com/codymikol/highlighting/QueryCache.kt
@@ -1,0 +1,76 @@
+package com.codymikol.highlighting
+
+import com.codymikol.repositories.UserDirectoryRepository
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.koin.core.annotation.Single
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.attribute.FileTime
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Lazily fetches and caches each grammar's `highlights.scm` under git-down's managed data
+ * directory, keyed by grammar repo - mirrors [GrammarCache]'s staleness/locking behavior for the
+ * compiled grammar itself. Any failure here is caught and logged so a broken/missing query file
+ * can never take down the diff view - callers just get null back and fall back to the
+ * heuristic-only highlighting [GrammarParser] already provides.
+ */
+@Single
+class QueryCache(
+    private val userDirectoryRepository: UserDirectoryRepository,
+    private val downloader: QueryDownloader,
+    private val now: () -> Instant = Instant::now,
+) {
+
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(QueryCache::class.java)
+        private val staleAfter: Duration = Duration.ofDays(7)
+    }
+
+    private val locksByRepo = ConcurrentHashMap<String, Mutex>()
+
+    suspend fun ensureQueries(spec: GrammarSpec): Path? {
+        if (spec.queriesPath == null) return null
+        val lock = locksByRepo.computeIfAbsent(spec.repo) { Mutex() }
+        return lock.withLock {
+            try {
+                val path = queriesPath(spec)
+                if (Files.exists(path) && !isStale(path)) return@withLock path
+                if (attemptDownload(spec, path)) path
+                else if (Files.exists(path)) path
+                else null
+            } catch (e: Exception) {
+                logger.error("Failed to ensure highlight queries for '${spec.repo}'", e)
+                null
+            }
+        }
+    }
+
+    private fun isStale(path: Path): Boolean {
+        val modifiedAt = Files.getLastModifiedTime(path).toInstant()
+        return Duration.between(modifiedAt, now()) > staleAfter
+    }
+
+    private suspend fun attemptDownload(spec: GrammarSpec, destination: Path): Boolean = try {
+        Files.createDirectories(destination.parent)
+        val succeeded = downloader.download(spec, destination)
+        if (succeeded) Files.setLastModifiedTime(destination, FileTime.from(now()))
+        succeeded
+    } catch (e: Exception) {
+        logger.error("Failed to download highlight queries for '${spec.repo}'", e)
+        false
+    }
+
+    private fun queriesPath(spec: GrammarSpec): Path = Paths.get(
+        requireNotNull(userDirectoryRepository.getUserDataDir()),
+        "queries",
+        "${spec.repo}.scm",
+    )
+
+}

--- a/src/main/kotlin/com/codymikol/highlighting/QueryDownloader.kt
+++ b/src/main/kotlin/com/codymikol/highlighting/QueryDownloader.kt
@@ -1,0 +1,7 @@
+package com.codymikol.highlighting
+
+import java.nio.file.Path
+
+interface QueryDownloader {
+    suspend fun download(spec: GrammarSpec, destination: Path): Boolean
+}

--- a/src/main/kotlin/com/codymikol/highlighting/QueryExecutor.kt
+++ b/src/main/kotlin/com/codymikol/highlighting/QueryExecutor.kt
@@ -1,0 +1,43 @@
+package com.codymikol.highlighting
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.treesitter.TSNode
+import org.treesitter.TSQuery
+import org.treesitter.TSQueryCursor
+
+/**
+ * Runs a compiled highlights.scm [TSQuery] over a parsed tree, turning each capture into a
+ * [SyntaxToken] carrying its capture name (e.g. "string", "function.builtin") for
+ * [SyntaxHighlighter] to theme. Executing a query against untrusted/foreign grammar output is
+ * inherently unsafe, so every failure here is caught and turned into an empty (unhighlighted)
+ * capture list, same as [GrammarParser]'s leaf-collection fallback.
+ */
+object QueryExecutor {
+
+    private val logger: Logger = LoggerFactory.getLogger(QueryExecutor::class.java)
+
+    fun execute(query: TSQuery, root: TSNode, text: String): List<SyntaxToken> = try {
+        TSQueryCursor().use { cursor ->
+            cursor.exec(query, root, text)
+            val tokens = mutableListOf<SyntaxToken>()
+            for (match in cursor.captures) {
+                val capture = match.captures[match.captureIndex]
+                tokens.add(
+                    SyntaxToken(
+                        type = capture.node.type,
+                        startByte = capture.node.startByte,
+                        endByte = capture.node.endByte,
+                        isNamed = capture.node.isNamed,
+                        captureName = query.getCaptureNameForId(capture.index),
+                    ),
+                )
+            }
+            tokens
+        }
+    } catch (e: Throwable) {
+        logger.error("Failed to execute highlight query", e)
+        emptyList()
+    }
+
+}

--- a/src/main/kotlin/com/codymikol/highlighting/QueryLoader.kt
+++ b/src/main/kotlin/com/codymikol/highlighting/QueryLoader.kt
@@ -1,0 +1,39 @@
+package com.codymikol.highlighting
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.treesitter.TSLanguage
+import org.treesitter.TSQuery
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Compiles a cached `highlights.scm` file into a [TSQuery] for a grammar's [TSLanguage].
+ * Compiling untrusted/foreign query text is inherently unsafe (syntax errors, capture names the
+ * binding rejects), so every failure mode here is caught and turned into a null rather than a
+ * crash - mirrors [GrammarLanguageLoader]'s handling of the compiled grammar itself.
+ *
+ * Compiled queries are cached by (path, mtime): a diff view re-renders the same grammar for every
+ * visible line, and re-parsing the same query text on each one would be wasteful.
+ */
+object QueryLoader {
+
+    private val logger: Logger = LoggerFactory.getLogger(QueryLoader::class.java)
+    private val cache = ConcurrentHashMap<String, TSQuery>()
+
+    fun load(language: TSLanguage, path: Path): TSQuery? {
+        if (!Files.exists(path)) return null
+        val mtime = try { Files.getLastModifiedTime(path).toMillis() } catch (e: Exception) { 0L }
+        val key = "$path|$mtime"
+        cache[key]?.let { return it }
+        return try {
+            val text = Files.readString(path)
+            TSQuery(language, text).also { cache[key] = it }
+        } catch (e: Throwable) {
+            logger.error("Failed to compile highlight query from $path", e)
+            null
+        }
+    }
+
+}

--- a/src/main/kotlin/com/codymikol/highlighting/SyntaxHighlighter.kt
+++ b/src/main/kotlin/com/codymikol/highlighting/SyntaxHighlighter.kt
@@ -47,11 +47,18 @@ object SyntaxHighlighter {
     private fun charIndexFor(byteToCharIndexMap: IntArray, byteOffset: Int): Int =
         byteToCharIndexMap[byteOffset.coerceIn(0, byteToCharIndexMap.size - 1)]
 
-    private fun colorFor(token: SyntaxToken): Color? = when {
-        "comment" in token.type -> Color(106, 153, 85)
-        "string" in token.type || "char" in token.type -> Color(206, 145, 120)
-        "number" in token.type || "integer" in token.type || "float" in token.type -> Color(181, 206, 168)
-        !token.isNamed && keywordPattern.matches(token.type) -> Color(86, 156, 214)
+    private fun colorFor(token: SyntaxToken): Color? {
+        token.captureName?.let { HighlightTheme.colorFor(it)?.let { color -> return color } }
+        return heuristicColorFor(token)
+    }
+
+    // Falls back to matching the raw grammar node type when a token has no capture name (no
+    // highlights.scm was available for the grammar) or the capture name isn't in the baked theme.
+    private fun heuristicColorFor(token: SyntaxToken): Color? = when {
+        "comment" in token.type -> HighlightTheme.comment
+        "string" in token.type || "char" in token.type -> HighlightTheme.string
+        "number" in token.type || "integer" in token.type || "float" in token.type -> HighlightTheme.number
+        !token.isNamed && keywordPattern.matches(token.type) -> HighlightTheme.keyword
         else -> null
     }
 

--- a/src/main/kotlin/com/codymikol/highlighting/SyntaxToken.kt
+++ b/src/main/kotlin/com/codymikol/highlighting/SyntaxToken.kt
@@ -5,4 +5,7 @@ data class SyntaxToken(
     val startByte: Int,
     val endByte: Int,
     val isNamed: Boolean,
+    // Set when this token came from executing a highlights.scm query capture (e.g. "string",
+    // "function.builtin") rather than the leaf-node heuristic; null keeps the old fallback path.
+    val captureName: String? = null,
 )

--- a/src/test/kotlin/com/codymikol/highlighting/FullFileLineHighlighterSpec.kt
+++ b/src/test/kotlin/com/codymikol/highlighting/FullFileLineHighlighterSpec.kt
@@ -15,6 +15,7 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
+import org.treesitter.TSQuery
 import java.nio.file.Path
 
 private fun content(lines: List<String>) = lines.joinToString("\n", postfix = "\n")
@@ -72,6 +73,40 @@ class FullFileLineHighlighterSpec : DescribeSpec({
             // "2" is a bare number_literal token; tree-sitter-json reports its byte range
             // relative to the diff line's own text once sliced from the full-file parse.
             highlighted.spanStyles.map { it.start to it.end } shouldContain (2 to 3)
+        }
+
+        it("forwards a given highlights.scm query so its captures drive the line's coloring") {
+            val grammarFile = BundledJsonGrammarFixture.extract()
+            val language = GrammarLanguageLoader.load(grammarFile, BundledJsonGrammarFixture.FUNCTION_NAME)
+            requireNotNull(language) { "Expected the bundled tree-sitter-json fixture to load" }
+            // Deliberately captures the number node as @string: the heuristic would color a
+            // "number" node type as a number, so only seeing the string color proves this
+            // came from the query's capture, not a heuristic fallback that happens to agree.
+            val query = TSQuery(language, "(number) @string")
+
+            autoClose(
+                createTestRepository()
+                    .addFile("bar.json", content(listOf("[", "  1", "]")))
+                    .stageAll()
+                    .commitAll("base")
+                    .addFile("bar.json", content(listOf("[", "  1,", "  2", "]")))
+                    .transferIntoGitDownState()
+            )
+
+            val workingNode = workingDirectoryNodeFor("bar.json")
+            val addedLine = workingNode.hunkNodes.flatMap { it.lineNodes }
+                .first { it.line.type == LineType.Added && it.line.value == "  2" }
+
+            val highlighted = FullFileLineHighlighter.highlight(
+                workingNode.fileDelta,
+                addedLine.line,
+                addedLine.line.value,
+                language,
+                query,
+            )
+
+            highlighted.shouldNotBeNull()
+            highlighted.spanStyles.map { it.item.color } shouldContain Color(206, 145, 120)
         }
 
         it("returns null instead of parsing a file whose full content is implausibly large") {

--- a/src/test/kotlin/com/codymikol/highlighting/FullFileTokensSpec.kt
+++ b/src/test/kotlin/com/codymikol/highlighting/FullFileTokensSpec.kt
@@ -2,6 +2,7 @@ package com.codymikol.highlighting
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
+import org.treesitter.TSQuery
 
 class FullFileTokensSpec : DescribeSpec({
 
@@ -55,6 +56,18 @@ class FullFileTokensSpec : DescribeSpec({
             val parsedFile = FullFileTokens.parse(null, "é=1\nb")
 
             parsedFile.lineByteRanges shouldBe listOf(0 until 4, 5 until 6)
+        }
+
+        it("forwards a given highlights.scm query to the parse, so its captures come back on the tokens") {
+            val language = GrammarLanguageLoader.load(
+                BundledJsonGrammarFixture.extract(),
+                BundledJsonGrammarFixture.FUNCTION_NAME,
+            )!!
+            val query = TSQuery(language, "(number) @number")
+
+            val parsedFile = FullFileTokens.parse(language, "{\"key\": 1}", query)
+
+            parsedFile.tokens.single().captureName shouldBe "number"
         }
 
     }

--- a/src/test/kotlin/com/codymikol/highlighting/GitHubQueryDownloaderSpec.kt
+++ b/src/test/kotlin/com/codymikol/highlighting/GitHubQueryDownloaderSpec.kt
@@ -1,0 +1,95 @@
+package com.codymikol.highlighting
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.runBlocking
+import java.nio.file.Files
+import kotlin.io.path.createTempDirectory
+
+private class FakeGitHubRepositoryFetcher(
+    private val filesByPath: Map<String, ByteArray>,
+    private val listingsByPath: Map<String, List<GitHubEntry>>,
+) : GitHubRepositoryFetcher {
+
+    override fun listDirectory(org: String, repo: String, path: String): List<GitHubEntry>? = listingsByPath[path]
+
+    override fun fetchBytes(url: String): ByteArray? = filesByPath[url]
+}
+
+class GitHubQueryDownloaderSpec : DescribeSpec({
+
+    describe("GitHubQueryDownloader") {
+
+        val spec = GrammarSpec(repo = "tree-sitter-fake", functionName = "tree_sitter_fake", queriesPath = "queries")
+
+        it("fetches queries/highlights.scm and writes it to destination") {
+            val fetcher = FakeGitHubRepositoryFetcher(
+                filesByPath = mapOf("https://example.com/highlights.scm" to "(comment) @comment".toByteArray()),
+                listingsByPath = mapOf(
+                    "queries" to listOf(
+                        GitHubEntry("highlights.scm", "file", "https://example.com/highlights.scm"),
+                    ),
+                ),
+            )
+            val downloader = GitHubQueryDownloader(fetcher)
+            val destination = createTempDirectory("git-down-query-downloader-test-").resolve("out.scm")
+
+            val result = runBlocking { downloader.download(spec, destination) }
+
+            result shouldBe true
+            Files.readString(destination) shouldBe "(comment) @comment"
+        }
+
+        it("returns false when the spec has no queriesPath") {
+            val fetcher = FakeGitHubRepositoryFetcher(emptyMap(), emptyMap())
+            val downloader = GitHubQueryDownloader(fetcher)
+            val destination = createTempDirectory("git-down-query-downloader-test-").resolve("out.scm")
+
+            val result = runBlocking {
+                downloader.download(spec.copy(queriesPath = null), destination)
+            }
+
+            result shouldBe false
+        }
+
+        it("returns false when the queries directory listing fails") {
+            val fetcher = FakeGitHubRepositoryFetcher(emptyMap(), emptyMap())
+            val downloader = GitHubQueryDownloader(fetcher)
+            val destination = createTempDirectory("git-down-query-downloader-test-").resolve("out.scm")
+
+            val result = runBlocking { downloader.download(spec, destination) }
+
+            result shouldBe false
+        }
+
+        it("returns false when the listing has no highlights.scm entry") {
+            val fetcher = FakeGitHubRepositoryFetcher(
+                filesByPath = emptyMap(),
+                listingsByPath = mapOf("queries" to listOf(GitHubEntry("injections.scm", "file", "https://example.com/injections.scm"))),
+            )
+            val downloader = GitHubQueryDownloader(fetcher)
+            val destination = createTempDirectory("git-down-query-downloader-test-").resolve("out.scm")
+
+            val result = runBlocking { downloader.download(spec, destination) }
+
+            result shouldBe false
+        }
+
+        it("returns false when fetching the file's bytes fails") {
+            val fetcher = FakeGitHubRepositoryFetcher(
+                filesByPath = emptyMap(),
+                listingsByPath = mapOf(
+                    "queries" to listOf(GitHubEntry("highlights.scm", "file", "https://example.com/highlights.scm")),
+                ),
+            )
+            val downloader = GitHubQueryDownloader(fetcher)
+            val destination = createTempDirectory("git-down-query-downloader-test-").resolve("out.scm")
+
+            val result = runBlocking { downloader.download(spec, destination) }
+
+            result shouldBe false
+        }
+
+    }
+
+})

--- a/src/test/kotlin/com/codymikol/highlighting/GrammarCacheSpec.kt
+++ b/src/test/kotlin/com/codymikol/highlighting/GrammarCacheSpec.kt
@@ -14,7 +14,7 @@ import java.time.Instant
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.io.path.createTempDirectory
 
-private class TestUserDirectoryRepository(private val dir: String) : UserDirectoryRepository() {
+private class GrammarCacheUserDirectoryRepository(private val dir: String) : UserDirectoryRepository() {
     override fun getUserDataDir(): String = dir
 }
 
@@ -41,7 +41,7 @@ class GrammarCacheSpec : DescribeSpec({
         val kotlinSpec = GrammarSpec(repo = "tree-sitter-kotlin", functionName = "tree_sitter_kotlin")
 
         fun createCache(downloader: GrammarDownloader) = GrammarCache(
-            TestUserDirectoryRepository(createTempDirectory("git-down-grammar-cache-test-").toString()),
+            GrammarCacheUserDirectoryRepository(createTempDirectory("git-down-grammar-cache-test-").toString()),
             downloader,
         )
 
@@ -71,7 +71,7 @@ class GrammarCacheSpec : DescribeSpec({
             val dir = createTempDirectory("git-down-grammar-cache-test-")
             var clock = Instant.parse("2026-01-01T00:00:00Z")
             val downloader = FakeGrammarDownloader()
-            val cache = GrammarCache(TestUserDirectoryRepository(dir.toString()), downloader) { clock }
+            val cache = GrammarCache(GrammarCacheUserDirectoryRepository(dir.toString()), downloader) { clock }
 
             runBlocking { cache.ensureGrammar(kotlinSpec) }
             downloader.callCount shouldBe 1
@@ -91,7 +91,7 @@ class GrammarCacheSpec : DescribeSpec({
                 override suspend fun download(spec: GrammarSpec, destination: Path): Boolean =
                     if (succeed) downloader.download(spec, destination) else false
             }
-            val cache = GrammarCache(TestUserDirectoryRepository(dir.toString()), flakyDownloader) { clock }
+            val cache = GrammarCache(GrammarCacheUserDirectoryRepository(dir.toString()), flakyDownloader) { clock }
 
             runBlocking { cache.ensureGrammar(kotlinSpec) }
             clock = clock.plus(Duration.ofDays(8))

--- a/src/test/kotlin/com/codymikol/highlighting/GrammarExtensionRegistrySpec.kt
+++ b/src/test/kotlin/com/codymikol/highlighting/GrammarExtensionRegistrySpec.kt
@@ -11,6 +11,7 @@ class GrammarExtensionRegistrySpec : DescribeSpec({
             GrammarExtensionRegistry.forExtension("kt") shouldBe GrammarSpec(
                 repo = "tree-sitter-kotlin",
                 functionName = "tree_sitter_kotlin",
+                queriesPath = null,
             )
         }
 
@@ -24,6 +25,29 @@ class GrammarExtensionRegistrySpec : DescribeSpec({
 
         it("points csv at its nested source directory, since the repo bundles csv/tsv/psv") {
             GrammarExtensionRegistry.forExtension("csv")?.sourcePath shouldBe "csv/src"
+        }
+
+        it("defaults queriesPath to the repo's top-level queries directory") {
+            GrammarExtensionRegistry.forExtension("toml")?.queriesPath shouldBe "queries"
+        }
+
+        it("points markdown's queries at its nested directory, matching its nested source") {
+            GrammarExtensionRegistry.forExtension("md")?.queriesPath shouldBe "tree-sitter-markdown/queries"
+        }
+
+        it("points csv's queries at its nested directory, matching its nested source") {
+            GrammarExtensionRegistry.forExtension("csv")?.queriesPath shouldBe "csv/queries"
+        }
+
+        it("points vim/vue/tcl's queries at their per-language nested directory") {
+            GrammarExtensionRegistry.forExtension("vim")?.queriesPath shouldBe "queries/vim"
+            GrammarExtensionRegistry.forExtension("vue")?.queriesPath shouldBe "queries/vue"
+            GrammarExtensionRegistry.forExtension("tcl")?.queriesPath shouldBe "queries/tcl"
+        }
+
+        it("has no queriesPath for grammars whose upstream repo ships no queries directory") {
+            GrammarExtensionRegistry.forExtension("kt")?.queriesPath shouldBe null
+            GrammarExtensionRegistry.forExtension("hcl")?.queriesPath shouldBe null
         }
 
     }

--- a/src/test/kotlin/com/codymikol/highlighting/GrammarParserIntegrationSpec.kt
+++ b/src/test/kotlin/com/codymikol/highlighting/GrammarParserIntegrationSpec.kt
@@ -2,6 +2,8 @@ package com.codymikol.highlighting
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import org.treesitter.TSQuery
 
 class GrammarParserIntegrationSpec : DescribeSpec({
 
@@ -20,6 +22,19 @@ class GrammarParserIntegrationSpec : DescribeSpec({
             val highlighted = SyntaxHighlighter.highlight(text, tokens)
             highlighted.spanStyles.map { it.start to it.end } shouldContain
                 (stringContentToken.startByte to stringContentToken.endByte)
+        }
+
+        it("runs a highlights.scm query against the parsed tree when one is given, producing captured tokens") {
+            val grammarFile = BundledJsonGrammarFixture.extract()
+            val language = GrammarLanguageLoader.load(grammarFile, BundledJsonGrammarFixture.FUNCTION_NAME)
+            requireNotNull(language) { "Expected the bundled tree-sitter-json fixture to load" }
+
+            val text = "{\"key\": 1}"
+            val query = TSQuery(language, "(number) @number")
+
+            val tokens = GrammarParser.parse(language, text, query)
+
+            tokens.single().captureName shouldBe "number"
         }
 
     }

--- a/src/test/kotlin/com/codymikol/highlighting/QueryCacheSpec.kt
+++ b/src/test/kotlin/com/codymikol/highlighting/QueryCacheSpec.kt
@@ -1,0 +1,115 @@
+package com.codymikol.highlighting
+
+import com.codymikol.repositories.UserDirectoryRepository
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.nulls.shouldBeNull
+import kotlinx.coroutines.runBlocking
+import java.nio.file.Path
+import java.time.Duration
+import java.time.Instant
+import kotlin.io.path.createTempDirectory
+
+private class TestUserDirectoryRepository(private val dir: String) : UserDirectoryRepository() {
+    override fun getUserDataDir(): String = dir
+}
+
+private class FakeQueryDownloader(
+    private val result: Boolean = true,
+    private val onDownload: (GrammarSpec, Path) -> Unit = { _, destination ->
+        destination.toFile().apply { parentFile.mkdirs() }.writeText("(comment) @comment")
+    },
+) : QueryDownloader {
+    var callCount = 0
+        private set
+
+    override suspend fun download(spec: GrammarSpec, destination: Path): Boolean {
+        callCount++
+        if (result) onDownload(spec, destination)
+        return result
+    }
+}
+
+class QueryCacheSpec : DescribeSpec({
+
+    describe("QueryCache") {
+
+        val tomlSpec = GrammarSpec(repo = "tree-sitter-toml", functionName = "tree_sitter_toml")
+
+        fun createCache(downloader: QueryDownloader) = QueryCache(
+            TestUserDirectoryRepository(createTempDirectory("git-down-query-cache-test-").toString()),
+            downloader,
+        )
+
+        it("downloads the queries on first request when nothing is cached") {
+            val downloader = FakeQueryDownloader()
+
+            val cache = createCache(downloader)
+            val result = runBlocking { cache.ensureQueries(tomlSpec) }
+
+            result?.toFile()?.readText() shouldBe "(comment) @comment"
+            downloader.callCount shouldBe 1
+        }
+
+        it("returns the cached path without downloading again when the file is fresh") {
+            val downloader = FakeQueryDownloader()
+            val cache = createCache(downloader)
+            val firstResult = runBlocking { cache.ensureQueries(tomlSpec) }
+            downloader.callCount shouldBe 1
+
+            val secondResult = runBlocking { cache.ensureQueries(tomlSpec) }
+
+            secondResult shouldBe firstResult
+            downloader.callCount shouldBe 1
+        }
+
+        it("re-downloads when the cached queries file is older than a week") {
+            val dir = createTempDirectory("git-down-query-cache-test-")
+            var clock = Instant.parse("2026-01-01T00:00:00Z")
+            val downloader = FakeQueryDownloader()
+            val cache = QueryCache(TestUserDirectoryRepository(dir.toString()), downloader) { clock }
+
+            runBlocking { cache.ensureQueries(tomlSpec) }
+            downloader.callCount shouldBe 1
+
+            clock = clock.plus(Duration.ofDays(8))
+            runBlocking { cache.ensureQueries(tomlSpec) }
+
+            downloader.callCount shouldBe 2
+        }
+
+        it("returns null without downloading when the spec has no queriesPath") {
+            val downloader = FakeQueryDownloader()
+            val cache = createCache(downloader)
+
+            val result = runBlocking { cache.ensureQueries(tomlSpec.copy(queriesPath = null)) }
+
+            result.shouldBeNull()
+            downloader.callCount shouldBe 0
+        }
+
+        it("returns null when downloading fails and nothing was ever cached") {
+            val downloader = FakeQueryDownloader(result = false)
+
+            val cache = createCache(downloader)
+            val result = runBlocking { cache.ensureQueries(tomlSpec) }
+
+            result.shouldBeNull()
+        }
+
+        it("returns null instead of throwing when the downloader throws") {
+            val downloader = object : QueryDownloader {
+                override suspend fun download(spec: GrammarSpec, destination: Path): Boolean {
+                    throw RuntimeException("network is on fire")
+                }
+            }
+
+            val cache = createCache(downloader)
+            val result = runBlocking { cache.ensureQueries(tomlSpec) }
+
+            result.shouldBeNull()
+        }
+
+    }
+
+})

--- a/src/test/kotlin/com/codymikol/highlighting/QueryExecutorSpec.kt
+++ b/src/test/kotlin/com/codymikol/highlighting/QueryExecutorSpec.kt
@@ -1,0 +1,57 @@
+package com.codymikol.highlighting
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import org.treesitter.TSParser
+import org.treesitter.TSQuery
+
+class QueryExecutorSpec : DescribeSpec({
+
+    describe("QueryExecutor.execute") {
+
+        val language = GrammarLanguageLoader.load(
+            BundledJsonGrammarFixture.extract(),
+            BundledJsonGrammarFixture.FUNCTION_NAME,
+        )!!
+
+        fun parse(text: String) = TSParser().use { parser ->
+            parser.setLanguage(language)
+            parser.parseString(null, text)!!
+        }
+
+        it("returns a token per capture, with the capture's name and the node's byte range") {
+            val text = "{\"key\": 1}"
+            val tree = parse(text)
+            val query = TSQuery(language, "(number) @number")
+
+            val tokens = QueryExecutor.execute(query, tree.rootNode, text)
+
+            tokens shouldContain SyntaxToken(type = "number", startByte = 8, endByte = 9, isNamed = true, captureName = "number")
+        }
+
+        it("returns a token for every pattern in the query that matches") {
+            val text = "{\"key\": 1}"
+            val tree = parse(text)
+            val query = TSQuery(language, "(string) @string (number) @number")
+
+            val tokens = QueryExecutor.execute(query, tree.rootNode, text)
+
+            tokens.map { it.captureName } shouldContain "string"
+            tokens.map { it.captureName } shouldContain "number"
+        }
+
+        it("returns an empty list when the query matches nothing") {
+            val text = "{\"key\": 1}"
+            val tree = parse(text)
+            val query = TSQuery(language, "(comment) @comment")
+
+            val tokens = QueryExecutor.execute(query, tree.rootNode, text)
+
+            tokens shouldHaveSize 0
+        }
+
+    }
+
+})

--- a/src/test/kotlin/com/codymikol/highlighting/QueryLoaderSpec.kt
+++ b/src/test/kotlin/com/codymikol/highlighting/QueryLoaderSpec.kt
@@ -1,0 +1,57 @@
+package com.codymikol.highlighting
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import java.nio.file.Paths
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.writeText
+
+class QueryLoaderSpec : DescribeSpec({
+
+    describe("QueryLoader") {
+
+        fun jsonLanguage() = GrammarLanguageLoader.load(
+            BundledJsonGrammarFixture.extract(),
+            BundledJsonGrammarFixture.FUNCTION_NAME,
+        )!!
+
+        it("returns null instead of throwing when the query file does not exist") {
+            val result = QueryLoader.load(jsonLanguage(), Paths.get("/does/not/exist.scm"))
+
+            result shouldBe null
+        }
+
+        it("compiles a valid highlights.scm against the grammar's language") {
+            val queryFile = createTempDirectory("git-down-query-loader-test-").resolve("highlights.scm")
+            queryFile.writeText("(string) @string")
+
+            val result = QueryLoader.load(jsonLanguage(), queryFile)
+
+            result.shouldNotBeNull()
+        }
+
+        it("returns null instead of throwing when the query text is malformed") {
+            val queryFile = createTempDirectory("git-down-query-loader-test-").resolve("highlights.scm")
+            queryFile.writeText("(this is not valid tree-sitter query syntax")
+
+            val result = QueryLoader.load(jsonLanguage(), queryFile)
+
+            result.shouldBeNull()
+        }
+
+        it("reuses the same compiled query instance for the same file, so it isn't recompiled on every diff line") {
+            val queryFile = createTempDirectory("git-down-query-loader-test-").resolve("highlights.scm")
+            queryFile.writeText("(string) @string")
+            val language = jsonLanguage()
+
+            val first = QueryLoader.load(language, queryFile)
+            val second = QueryLoader.load(language, queryFile)
+
+            first shouldBe second
+        }
+
+    }
+
+})

--- a/src/test/kotlin/com/codymikol/highlighting/SourceCompilingGrammarDownloaderSpec.kt
+++ b/src/test/kotlin/com/codymikol/highlighting/SourceCompilingGrammarDownloaderSpec.kt
@@ -8,7 +8,7 @@ import java.nio.file.Path
 import kotlin.io.path.createTempDirectory
 import kotlin.io.path.name
 
-private class FakeGitHubRepositoryFetcher(
+private class FakeCountingGitHubRepositoryFetcher(
     private val filesByPath: Map<String, ByteArray>,
     private val listingsByPath: Map<String, List<GitHubEntry>>,
 ) : GitHubRepositoryFetcher {
@@ -31,7 +31,7 @@ class SourceCompilingGrammarDownloaderSpec : DescribeSpec({
         val spec = GrammarSpec(repo = "tree-sitter-fake", functionName = "tree_sitter_fake")
 
         it("fetches the src/ tree, compiles it, and writes the result to destination") {
-            val fetcher = FakeGitHubRepositoryFetcher(
+            val fetcher = FakeCountingGitHubRepositoryFetcher(
                 filesByPath = mapOf(
                     "https://example.com/parser.c" to "// parser".toByteArray(),
                     "https://example.com/parser.h" to "// header".toByteArray(),
@@ -62,7 +62,7 @@ class SourceCompilingGrammarDownloaderSpec : DescribeSpec({
         }
 
         it("returns false when the top-level directory listing fails") {
-            val fetcher = FakeGitHubRepositoryFetcher(emptyMap(), emptyMap())
+            val fetcher = FakeCountingGitHubRepositoryFetcher(emptyMap(), emptyMap())
             val downloader = SourceCompilingGrammarDownloader(fetcher, compile = { _, _, _ -> true })
 
             val result = runBlocking {
@@ -73,7 +73,7 @@ class SourceCompilingGrammarDownloaderSpec : DescribeSpec({
         }
 
         it("returns false without compiling when no .c/.cc/.cpp sources are found") {
-            val fetcher = FakeGitHubRepositoryFetcher(
+            val fetcher = FakeCountingGitHubRepositoryFetcher(
                 filesByPath = emptyMap(),
                 listingsByPath = mapOf("src" to listOf(GitHubEntry("README.md", "file", null))),
             )
@@ -89,7 +89,7 @@ class SourceCompilingGrammarDownloaderSpec : DescribeSpec({
         }
 
         it("returns false when fetching a file's bytes fails partway through") {
-            val fetcher = FakeGitHubRepositoryFetcher(
+            val fetcher = FakeCountingGitHubRepositoryFetcher(
                 filesByPath = emptyMap(), // parser.c has a download URL but no bytes registered -> fetchBytes returns null
                 listingsByPath = mapOf(
                     "src" to listOf(GitHubEntry("parser.c", "file", "https://example.com/parser.c")),
@@ -105,7 +105,7 @@ class SourceCompilingGrammarDownloaderSpec : DescribeSpec({
         }
 
         it("skips a file entry with a suspicious path-escaping name") {
-            val fetcher = FakeGitHubRepositoryFetcher(
+            val fetcher = FakeCountingGitHubRepositoryFetcher(
                 filesByPath = mapOf("https://example.com/parser.c" to "// parser".toByteArray()),
                 listingsByPath = mapOf(
                     "src" to listOf(
@@ -135,7 +135,7 @@ class SourceCompilingGrammarDownloaderSpec : DescribeSpec({
                 functionName = "tree_sitter_markdown",
                 sourcePath = "tree-sitter-markdown/src",
             )
-            val fetcher = FakeGitHubRepositoryFetcher(
+            val fetcher = FakeCountingGitHubRepositoryFetcher(
                 filesByPath = mapOf("https://example.com/parser.c" to "// parser".toByteArray()),
                 listingsByPath = mapOf(
                     "tree-sitter-markdown/src" to listOf(

--- a/src/test/kotlin/com/codymikol/highlighting/SyntaxHighlighterSpec.kt
+++ b/src/test/kotlin/com/codymikol/highlighting/SyntaxHighlighterSpec.kt
@@ -73,6 +73,40 @@ class SyntaxHighlighterSpec : DescribeSpec({
             result.spanStyles shouldBe emptyList()
         }
 
+        it("colors a token by its capture name using the baked highlight theme") {
+            val tokens = listOf(SyntaxToken(type = "identifier", startByte = 0, endByte = 3, isNamed = true, captureName = "keyword"))
+
+            val result = SyntaxHighlighter.highlight("fun", tokens)
+
+            result.spanStyles.single().item.color shouldBe Color(86, 156, 214)
+        }
+
+        it("prefers the capture name over the node type heuristic when both are present") {
+            // type would heuristically read as a keyword (unnamed, alphabetic), but the capture
+            // name says otherwise and must win.
+            val tokens = listOf(SyntaxToken(type = "val", startByte = 0, endByte = 3, isNamed = false, captureName = "comment"))
+
+            val result = SyntaxHighlighter.highlight("val", tokens)
+
+            result.spanStyles.single().item.color shouldBe Color(106, 153, 85)
+        }
+
+        it("resolves a dotted capture name by trying progressively shorter prefixes") {
+            val tokens = listOf(SyntaxToken(type = "identifier", startByte = 0, endByte = 3, isNamed = true, captureName = "function.builtin"))
+
+            val result = SyntaxHighlighter.highlight("abc", tokens)
+
+            result.spanStyles.single().item.color shouldBe Color(220, 220, 170)
+        }
+
+        it("falls back to the node type heuristic when the capture name has no theme entry") {
+            val tokens = listOf(SyntaxToken(type = "line_comment", startByte = 0, endByte = 8, isNamed = true, captureName = "totally.unknown"))
+
+            val result = SyntaxHighlighter.highlight("// hello", tokens)
+
+            result.spanStyles.single().item.color shouldBe Color(106, 153, 85)
+        }
+
         it("maps UTF-8 byte offsets from a multi-byte character onto the correct UTF-16 char range") {
             // "é" is 1 UTF-16 char but 2 UTF-8 bytes, so "1"'s tree-sitter byte range (3..4)
             // must map to char range (2..3), not be read as literal char indices.


### PR DESCRIPTION
## Summary
- Fetches each grammar's upstream `queries/highlights.scm` from tree-sitter-grammars (`GitHubQueryDownloader`) and caches it on disk (`QueryCache`), mirroring `GrammarCache`'s staleness/locking behavior for the compiled grammar itself.
- Compiles the cached query text into a `TSQuery` against the grammar's `TSLanguage` (`QueryLoader`) and executes it via `TSQueryCursor` (`QueryExecutor`), turning each capture into a `SyntaxToken` carrying its capture name.
- Adds a baked default theme (`HighlightTheme`) mapping standard capture names (`@comment`, `@string`, `@keyword`, `@function`, `@type`, ...) to colors matching the app's existing diff aesthetic - the comment/string/number/keyword colors are exactly what `SyntaxHighlighter` already used.
- `SyntaxHighlighter.colorFor` now prefers a capture-name theme lookup (trying progressively shorter dotted prefixes, e.g. `function.builtin` -> `function`) before falling back to the existing node-type heuristic, so grammars without a usable query keep working exactly as before.
- Threads an optional `TSQuery` through `GrammarParser` -> `FullFileTokens` -> `FullFileLineHighlighter` -> `Diff.kt`, all defaulting to null to preserve current behavior when no query is available.
- `GrammarSpec` gains a `queriesPath` field mirroring `sourcePath`'s per-repo nesting; verified against the live tree-sitter-grammars repos (`gh api`) for markdown/csv (nested), vim/vue/tcl (per-language nested), and kotlin/hcl (no queries directory upstream at all, so query fetching is skipped for those two rather than always failing).

Closes #233

## Notes for reviewers
- Sandbox note: this PR was authored without a working JDK/nix in the dev sandbox (nix store is read-only there), so nothing was compiled or test-run locally - it was reviewed carefully by inspection instead, including verifying the exact `io.github.bonede:tree-sitter` 0.26.6 query API (`TSQuery`, `TSQueryCursor`, capture iteration) against the binding's source on GitHub. CI (`./gradlew build`) is the first real compile/test of this change - please watch it closely.
- Follow-up worth a separate issue if desired: overlapping/nested query captures currently render in the order `TSQueryCursor` yields them (later capture's span wins where it overlaps an earlier one in Compose's `AnnotatedString`), which doesn't implement tree-sitter's own first-match/priority convention for nested captures. This degrades gracefully (a capture still gets colored, just not always the "most specific" one), and none of the currently-wired grammars exercise heavily nested captures, so it wasn't blocking - but a real solution (priority-ordered span resolution) is out of scope for this issue.