### PR TITLE
fix(diff): seed newLineNumber from the hunk's to-file start

### DIFF
--- a/src/main/kotlin/com/codymikol/components/commit/diff/Diff.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/diff/Diff.kt
@@ -176,6 +176,11 @@ private fun DiffLine(lineNode: LineNode) {
                     if (extension.isEmpty()) return@LaunchedEffect
                     highlighted = withContext(Dispatchers.IO) {
                         val grammar = resolveGrammar(extension)
+                        // highlightLine stays as the fallback deliberately: highlightLineFromFullFile
+                        // legitimately returns null for content it can't place against this diff line
+                        // (a stash entry, an implausibly large file) - see FullFileLineHighlighter's own
+                        // doc comment. #238's "always falls back" symptom was Hunk.make mis-numbering
+                        // every line after a hunk's first (fixed in Hunk.kt), not this fallback itself.
                         highlightLineFromFullFile(lineNode, displayLine, grammar.language, grammar.query)
                             ?: highlightLine(grammar.language, grammar.query, displayLine)
                     }

--- a/src/main/kotlin/com/codymikol/data/diff/Hunk.kt
+++ b/src/main/kotlin/com/codymikol/data/diff/Hunk.kt
@@ -16,8 +16,10 @@ class Hunk(
 
             val header = HunkHeader.make(delimiter)
 
+            // Removed/Unchanged lines are numbered against the from-file, Added/Unchanged
+            // against the to-file - each incrementer must seed from that same file's start.
             var originalLineNumberIncrementer = header.fromFileLineNumbersStart
-            var newLineNumberIncrementer = header.fromFileLineNumbersStart
+            var newLineNumberIncrementer = header.toFileLineNumbersStart
 
             val lines = hunkLines.drop(1).map {
 

--- a/src/test/kotlin/com/codymikol/data/diff/HunkSpec.kt
+++ b/src/test/kotlin/com/codymikol/data/diff/HunkSpec.kt
@@ -1,0 +1,60 @@
+package com.codymikol.data.diff
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class HunkSpec : DescribeSpec({
+
+    describe("Hunk") {
+
+        describe("make") {
+
+            describe("When the from and to file line number starts diverge") {
+
+                val hunkLines = listOf(
+                    "@@ -20,3 +25,3 @@",
+                    " unchanged line",
+                    "-removed line",
+                    "+added line",
+                )
+
+                val hunk = Hunk.make(hunkLines)
+
+                it("should number the unchanged line using the from and to starts") {
+                    hunk.lines[0].originalLineNumber shouldBe 20U
+                    hunk.lines[0].newLineNumber shouldBe 25U
+                }
+
+                it("should number the removed line using the from start only") {
+                    hunk.lines[1].originalLineNumber shouldBe 21U
+                    hunk.lines[1].newLineNumber shouldBe null
+                }
+
+                it("should number the added line using the to start only") {
+                    hunk.lines[2].originalLineNumber shouldBe null
+                    hunk.lines[2].newLineNumber shouldBe 26U
+                }
+
+            }
+
+            describe("When the header omits the line counts") {
+
+                val hunkLines = listOf(
+                    "@@ -20 +25 @@",
+                    " unchanged line",
+                )
+
+                val hunk = Hunk.make(hunkLines)
+
+                it("should number the unchanged line using the from and to starts") {
+                    hunk.lines[0].originalLineNumber shouldBe 20U
+                    hunk.lines[0].newLineNumber shouldBe 25U
+                }
+
+            }
+
+        }
+
+    }
+
+})

--- a/src/test/kotlin/com/codymikol/highlighting/FullFileLineHighlighterSpec.kt
+++ b/src/test/kotlin/com/codymikol/highlighting/FullFileLineHighlighterSpec.kt
@@ -15,6 +15,8 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import org.treesitter.TSQuery
 import java.nio.file.Path
 
@@ -107,6 +109,56 @@ class FullFileLineHighlighterSpec : DescribeSpec({
 
             highlighted.shouldNotBeNull()
             highlighted.spanStyles.map { it.item.color } shouldContain Color(206, 145, 120)
+        }
+
+        it("highlights a line in the second hunk of a multi-hunk diff") {
+            // Second hunk's from/to line-number starts diverge from the first hunk's, since the
+            // first hunk added one more line than it removed - this is the case Hunk.make's
+            // newLineNumberIncrementer must seed from toFileLineNumbersStart, not
+            // fromFileLineNumbersStart, or every line here gets mis-numbered and highlight()
+            // falls back to null.
+            val grammarFile = BundledJsonGrammarFixture.extract()
+            val language = GrammarLanguageLoader.load(grammarFile, BundledJsonGrammarFixture.FUNCTION_NAME)
+            requireNotNull(language) { "Expected the bundled tree-sitter-json fixture to load" }
+
+            val baseLines = listOf("[") + (1..20).mapIndexed { i, n -> if (i < 19) "  $n," else "  $n" } + listOf("]")
+            val modifiedLines = buildList {
+                add("[")
+                add("  1,")
+                add("  100,")
+                addAll((2..19).map { "  $it," })
+                add("  200,")
+                add("  20")
+                add("]")
+            }
+
+            autoClose(
+                createTestRepository()
+                    .addFile("multi.json", content(baseLines))
+                    .stageAll()
+                    .commitAll("base")
+                    .addFile("multi.json", content(modifiedLines))
+                    .transferIntoGitDownState()
+            )
+
+            val workingNode = workingDirectoryNodeFor("multi.json")
+            workingNode.hunkNodes.size shouldBe 2
+
+            val secondHunk = workingNode.hunkNodes[1]
+            secondHunk.hunk.header.fromFileLineNumbersStart shouldNotBe secondHunk.hunk.header.toFileLineNumbersStart
+
+            val addedLine = secondHunk.lineNodes.first { it.line.type == LineType.Added && it.line.value == "  200," }
+
+            val highlighted = FullFileLineHighlighter.highlight(
+                workingNode.fileDelta,
+                addedLine.line,
+                addedLine.line.value,
+                language,
+            )
+
+            highlighted.shouldNotBeNull()
+            // "200" is a bare number_literal token starting after the two-space indent.
+            highlighted.spanStyles.map { it.start to it.end } shouldContain (2 to 5)
         }
 
         it("returns null instead of parsing a file whose full content is implausibly large") {


### PR DESCRIPTION
## Summary

Root-causes and fixes the "always falls back to `highlightLine`" bug: `Hunk.make` seeded *both* the original- and new-line-number incrementers from `header.fromFileLineNumbersStart`, so `newLineNumber` was only correct when a hunk's from/to starts happened to match (typically only the first hunk in a file). Any later hunk got every `Unchanged`/`Added` line mis-numbered, which made `FullFileLineHighlighter.highlight`'s line-content check fail and silently fall back to per-line highlighting.

- `src/main/kotlin/com/codymikol/data/diff/Hunk.kt` — seed `newLineNumberIncrementer` from `header.toFileLineNumbersStart` instead.
- `src/test/kotlin/com/codymikol/data/diff/HunkSpec.kt` — new unit coverage for `Hunk.make`'s per-line numbering (previously untested; only `HunkHeaderSpec` covered header parsing), including the bare single-line header form (`@@ -20 +25 @@`).
- `src/test/kotlin/com/codymikol/highlighting/FullFileLineHighlighterSpec.kt` — new integration case with a real two-hunk diff whose from/to starts diverge, proving `highlight()` succeeds (and produces a real span) on the second hunk's line instead of returning null.
- `src/main/kotlin/com/codymikol/components/commit/diff/Diff.kt` — comment only, explaining why the `highlightLine` fallback call is kept.

Closes #238

## Note for reviewer — one open question

The issue text says the `highlightLine` fallback in `Diff.kt:180` "should be removed" and Diff.kt "should always be using `highlightLineFromFullFile`". I did **not** do that, and want a maintainer to confirm before it happens:

`FullFileLineHighlighter.highlight` legitimately returns `null` in cases that aren't bugs — a stash entry (`getFullContent` can't produce one), or an implausibly large file (the `MAX_FULL_FILE_CHARS` guard) — both of which have existing passing tests asserting `null`. The old `highlightLine` is what currently renders *any* highlighting at all for those cases (it only needs the single line's text, not full-file content). Removing it outright would silently regress the Stash view and any 2MB+ file to zero syntax highlighting, not fix a bug.

The issue's own attached root-cause research comment (marked "Verdict: recommend") diagnoses the actual defect as the `Hunk.kt` numbering bug fixed here, and prescribes that fix specifically — it does not recommend deleting the fallback. My read is the "should be removed" line in the issue body was written before that root-cause was known, on the assumption the fallback itself was the bug. Two independent review passes on this branch flagged the same tension and both concluded it needs explicit human sign-off rather than a unilateral call either way — surfacing it here rather than picking a side.

## Test plan
- [ ] CI (`./gradlew build`) — this sandbox has no local JDK/nix toolchain available (nix devShell requires `temurin-bin-21`, not present in this container's read-only, pre-baked Nix store, and no daemon/build support is available to fetch it), so tests could not be executed locally; verified by manual trace of `Hunk.make` against the new `HunkSpec` cases instead.