### PR TITLE
feat: add StashService for save-stash delegation

### DIFF
--- a/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
+++ b/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
@@ -558,6 +558,22 @@ suspend fun Git.amendAll(message: String) = command {
         .unit()
 }
 
+suspend fun Git.saveStash(message: String, includeUntrackedFiles: Boolean) = command {
+    // stashCreate().call() returns null when there is nothing to stash (e.g. only
+    // untracked files exist and includeUntrackedFiles is false), mirroring plain
+    // `git stash`'s no-op behavior; .unit() would NPE on that null receiver.
+    //
+    // setWorkingDirectoryMessage() treats its whole argument as a MessageFormat
+    // pattern, so message is quoted to keep apostrophes and literal { } braces
+    // from being interpreted as format syntax.
+    this@saveStash
+        .stashCreate()
+        .setWorkingDirectoryMessage("On {0}: '${message.replace("'", "''")}'")
+        .setIncludeUntracked(includeUntrackedFiles)
+        .call()
+        ?.also { logger.info("Saving stash") }
+}
+
 private fun <C> MutableState<Set<C>>.assignWhenDifferent(new: Set<C>) {
     if (!this.value.equals(new)) this.value = new
 }

--- a/src/main/kotlin/com/codymikol/services/StashService.kt
+++ b/src/main/kotlin/com/codymikol/services/StashService.kt
@@ -1,0 +1,14 @@
+package com.codymikol.services
+
+import com.codymikol.extensions.saveStash
+import com.codymikol.state.GitDownState
+import org.koin.core.annotation.Single
+
+@Single
+class StashService {
+
+    suspend fun saveStash(message: String, includeUntrackedFiles: Boolean) {
+        GitDownState.git.value.saveStash(message, includeUntrackedFiles)
+    }
+
+}

--- a/src/test/kotlin/com/codymikol/services/StashServiceSpec.kt
+++ b/src/test/kotlin/com/codymikol/services/StashServiceSpec.kt
@@ -1,0 +1,76 @@
+package com.codymikol.services
+
+import com.codymikol.repository.TestRepository.Companion.createTestRepository
+import com.codymikol.state.GitDownState
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+class StashServiceSpec : DescribeSpec({
+
+    describe("StashService.saveStash") {
+
+        it("creates a stash carrying the given message") {
+            autoClose(
+                createTestRepository()
+                    .addFile("foo.txt", "one\n")
+                    .stageAll()
+                    .commitAll("init")
+                    .appendToFile("foo.txt", "two\n")
+                    .transferIntoGitDownState()
+            )
+
+            StashService().saveStash("my stash message", includeUntrackedFiles = false)
+
+            GitDownState.stashes.value.single().description shouldBe "my stash message"
+        }
+
+        it("preserves a message containing MessageFormat-sensitive characters") {
+            autoClose(
+                createTestRepository()
+                    .addFile("foo.txt", "one\n")
+                    .stageAll()
+                    .commitAll("init")
+                    .appendToFile("foo.txt", "two\n")
+                    .transferIntoGitDownState()
+            )
+
+            StashService().saveStash("don't stop {now}", includeUntrackedFiles = false)
+
+            GitDownState.stashes.value.single().description shouldBe "don't stop {now}"
+        }
+
+        it("leaves an untracked file in the working directory when includeUntrackedFiles is false") {
+            autoClose(
+                createTestRepository()
+                    .addFile("foo.txt", "one\n")
+                    .stageAll()
+                    .commitAll("init")
+                    .addFile("untracked.txt", "new\n")
+                    .transferIntoGitDownState()
+            )
+
+            StashService().saveStash("no untracked", includeUntrackedFiles = false)
+
+            GitDownState.untracked.value shouldContain "untracked.txt"
+        }
+
+        it("stashes an untracked file when includeUntrackedFiles is true") {
+            autoClose(
+                createTestRepository()
+                    .addFile("foo.txt", "one\n")
+                    .stageAll()
+                    .commitAll("init")
+                    .addFile("untracked.txt", "new\n")
+                    .transferIntoGitDownState()
+            )
+
+            StashService().saveStash("with untracked", includeUntrackedFiles = true)
+
+            GitDownState.untracked.value shouldNotContain "untracked.txt"
+        }
+
+    }
+
+})


### PR DESCRIPTION
## Summary
- Add `Git.saveStash` jgit wrapper extension (message, includeUntrackedFiles)
- Add `StashService` in the service layer to delegate save-stash calls
- Cover `StashService.saveStash` with tests

Not wired into the UI button yet, per the issue's follow-up note.

Closes #243