### PR TITLE
feat(stash): add StashService.applyStash for stash-apply delegation

### DIFF
--- a/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
+++ b/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
@@ -559,6 +559,15 @@ suspend fun Git.amendAll(message: String) = command {
         .unit()
 }
 
+suspend fun Git.applyStash(stash: StashListItem) = command {
+    this@applyStash
+        .stashApply()
+        .setStashRef(stash.sha)
+        .call()
+        .also { logger.info("Applying stash ${stash.sha}") }
+        .unit()
+}
+
 suspend fun Git.saveStash(message: String, includeUntrackedFiles: Boolean) = command {
     // stashCreate().call() returns null when there is nothing to stash (e.g. only
     // untracked files exist and includeUntrackedFiles is false), mirroring plain

--- a/src/main/kotlin/com/codymikol/services/StashService.kt
+++ b/src/main/kotlin/com/codymikol/services/StashService.kt
@@ -1,10 +1,9 @@
 package com.codymikol.services
 
 import com.codymikol.data.stash.StashListItem
+import com.codymikol.extensions.applyStash
 import com.codymikol.extensions.dropStash
 import com.codymikol.extensions.saveStash
-import com.codymikol.data.stash.StashListItem
-import com.codymikol.extensions.applyStash
 import com.codymikol.state.GitDownState
 import org.koin.core.annotation.Single
 

--- a/src/main/kotlin/com/codymikol/services/StashService.kt
+++ b/src/main/kotlin/com/codymikol/services/StashService.kt
@@ -3,6 +3,8 @@ package com.codymikol.services
 import com.codymikol.data.stash.StashListItem
 import com.codymikol.extensions.dropStash
 import com.codymikol.extensions.saveStash
+import com.codymikol.data.stash.StashListItem
+import com.codymikol.extensions.applyStash
 import com.codymikol.state.GitDownState
 import org.koin.core.annotation.Single
 
@@ -11,6 +13,10 @@ class StashService {
 
     suspend fun saveStash(message: String, includeUntrackedFiles: Boolean) {
         GitDownState.git.value.saveStash(message, includeUntrackedFiles)
+    }
+    
+    suspend fun applyStash(stash: StashListItem) {
+        GitDownState.git.value.applyStash(stash)
     }
 
     suspend fun dropStash(stash: StashListItem) {

--- a/src/test/kotlin/com/codymikol/services/StashServiceSpec.kt
+++ b/src/test/kotlin/com/codymikol/services/StashServiceSpec.kt
@@ -1,13 +1,24 @@
 package com.codymikol.services
 
+import com.codymikol.repository.TestRepository
 import com.codymikol.repository.TestRepository.Companion.createTestRepository
 import com.codymikol.state.GitDownState
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
+import java.io.File
 
 class StashServiceSpec : DescribeSpec({
+
+    suspend fun repositoryWithAStash(): TestRepository =
+    createTestRepository()
+        .addFile("foo.txt", "one\n")
+        .stageAll()
+        .commitAll("init")
+        .appendToFile("foo.txt", "two\n")
+        .stashCreate("my stash")
+        .transferIntoGitDownState()
 
     describe("StashService.saveStash") {
 
@@ -69,6 +80,30 @@ class StashServiceSpec : DescribeSpec({
             StashService().saveStash("with untracked", includeUntrackedFiles = true)
 
             GitDownState.untracked.value shouldNotContain "untracked.txt"
+        }
+
+    }
+    
+    
+    describe("StashService.applyStash") {
+
+        it("restores the stashed changes to the working directory") {
+            val repository = repositoryWithAStash()
+            autoClose(repository)
+
+            StashService().applyStash(GitDownState.stashes.value.single())
+
+            File(repository.dir.toString() + "/foo.txt").readText() shouldBe "one\ntwo\n"
+        }
+
+        it("leaves the applied stash in the stash list") {
+            val repository = repositoryWithAStash()
+            autoClose(repository)
+
+            val stash = GitDownState.stashes.value.single()
+            StashService().applyStash(stash)
+
+            GitDownState.stashes.value.single().sha shouldBe stash.sha
         }
 
     }


### PR DESCRIPTION
## Summary
- Adds `Git.applyStash(stash: StashListItem)` in `GitExtensions.kt`, wrapping JGit's `stashApply().setStashRef(...)`, following the existing `command {}` / suspend extension pattern used by other git operations.
- Adds `StashService.applyStash(stash)` (`@Single`, Koin-discovered) as the service-layer seam the stash view will delegate to.
- Covers both with `StashServiceSpec`: applying a stash restores its changes to the working directory, and the stash entry itself is left in place (JGit's `stashApply` does not drop it, unlike `stashPop`).

Per the issue, the bottom toolbar "Apply" button is intentionally **not** wired to this service yet — that's a follow-up.

## Note for reviewers
This sandbox had no JDK/Gradle toolchain available (`/nix/store` is read-only here, no baked JDK, no docker), so `./gradlew test` could not be run locally. The implementation was reviewed manually against JGit's `StashApplyCommand` API and cross-checked against the sibling `Git.saveStash`/`StashService.saveStash` pattern (unmerged `agent/issue-243` branch) for convention consistency. CI will be the first real compile/test signal for this PR.

Closes #242