### PR TITLE
fix(stash): flip bottom toolbar button alignment

### DIFF
--- a/src/main/kotlin/com/codymikol/components/stash/StashBottomToolbar.kt
+++ b/src/main/kotlin/com/codymikol/components/stash/StashBottomToolbar.kt
@@ -28,11 +28,11 @@ fun StashBottomToolbar() {
             .background(Colors.MediumGrayBackground)
             .padding(horizontal = 8.dp)
     ) {
-        SlimButton("Apply", onClick = { stashToolbarButtonClicked("Apply") })
-
         Row(verticalAlignment = Alignment.CenterVertically) {
             SlimButton("+", modifier = Modifier.padding(end = 8.dp), onClick = { stashToolbarButtonClicked("+") })
             SlimButton("-", onClick = { stashToolbarButtonClicked("-") })
         }
+
+        SlimButton("Apply", onClick = { stashToolbarButtonClicked("Apply") })
     }
 }


### PR DESCRIPTION
## Summary
- The stash view's bottom toolbar declared the Apply button before the +/- buttons in a `SpaceBetween` row, so Apply rendered on the left and +/- on the right — backwards from the intended layout.
- Swap the declaration order so +/- render on the left and Apply renders on the right.

## Notes for reviewer
- Repo has no Compose UI-test infrastructure (only pure-function unit tests exist for this composable), so this fix was verified by manual code inspection rather than an automated layout test — flagged and accepted in code review.
- Local Gradle build/test could not be run in this sandbox: no JDK is installed and `nix develop` fails (`NIX_STORE_WRITABLE=false`, no writable Nix store to realize the pinned temurin toolchain). CI (`./gradlew build` via GitHub Actions with JDK 21) is the authoritative gate for this change.

Closes #240