### PR TITLE
feat(services): add StashService.dropStash for stash toolbar delete

### DIFF
--- a/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
+++ b/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
@@ -7,6 +7,7 @@ import com.codymikol.data.diff.LineType
 import com.codymikol.data.file.FileDelta
 import com.codymikol.data.file.Stash
 import com.codymikol.data.file.WorkingDirectory
+import com.codymikol.data.stash.StashListItem
 import com.codymikol.state.GitDownState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -572,6 +573,23 @@ suspend fun Git.saveStash(message: String, includeUntrackedFiles: Boolean) = com
         .setIncludeUntracked(includeUntrackedFiles)
         .call()
         ?.also { logger.info("Saving stash") }
+}
+
+suspend fun Git.dropStash(stash: StashListItem) = command {
+    // StashDropCommand.setStashRef() takes the 0-based position of the stash within
+    // the reflog (stash@{0} = most recent), not a sha or ref string, so the stash's
+    // position must be resolved from the current stash list first.
+    this@dropStash
+        .getStashes()
+        .indexOfFirst { it.name == stash.sha }
+        .takeIf { it >= 0 }
+        ?.let { index ->
+            logger.info("Dropping stash ${stash.sha}")
+            // stashDrop().call() returns null when the dropped entry was the last
+            // stash, so logging must happen before the call rather than chained
+            // off its result.
+            this@dropStash.stashDrop().setStashRef(index).call()
+        }
 }
 
 private fun <C> MutableState<Set<C>>.assignWhenDifferent(new: Set<C>) {

--- a/src/main/kotlin/com/codymikol/services/StashService.kt
+++ b/src/main/kotlin/com/codymikol/services/StashService.kt
@@ -1,5 +1,7 @@
 package com.codymikol.services
 
+import com.codymikol.data.stash.StashListItem
+import com.codymikol.extensions.dropStash
 import com.codymikol.extensions.saveStash
 import com.codymikol.state.GitDownState
 import org.koin.core.annotation.Single
@@ -9,6 +11,14 @@ class StashService {
 
     suspend fun saveStash(message: String, includeUntrackedFiles: Boolean) {
         GitDownState.git.value.saveStash(message, includeUntrackedFiles)
+    }
+
+    suspend fun dropStash(stash: StashListItem) {
+        GitDownState.git.value.dropStash(stash)
+
+        if (GitDownState.selectedStash.value?.sha == stash.sha) {
+            GitDownState.selectedStash.value = null
+        }
     }
 
 }

--- a/src/test/kotlin/com/codymikol/services/StashServiceSpec.kt
+++ b/src/test/kotlin/com/codymikol/services/StashServiceSpec.kt
@@ -73,4 +73,88 @@ class StashServiceSpec : DescribeSpec({
 
     }
 
+    describe("StashService.dropStash") {
+
+        it("removes the given stash from GitDownState") {
+            autoClose(
+                createTestRepository()
+                    .addFile("foo.txt", "one\n")
+                    .stageAll()
+                    .commitAll("init")
+                    .appendToFile("foo.txt", "two\n")
+                    .transferIntoGitDownState()
+            )
+
+            StashService().saveStash("to drop", includeUntrackedFiles = false)
+            val stash = GitDownState.stashes.value.single()
+
+            StashService().dropStash(stash)
+
+            GitDownState.stashes.value shouldBe emptyList()
+        }
+
+        it("clears selectedStash when the dropped stash was selected") {
+            autoClose(
+                createTestRepository()
+                    .addFile("foo.txt", "one\n")
+                    .stageAll()
+                    .commitAll("init")
+                    .appendToFile("foo.txt", "two\n")
+                    .transferIntoGitDownState()
+            )
+
+            StashService().saveStash("to drop", includeUntrackedFiles = false)
+            val stash = GitDownState.stashes.value.single()
+            GitDownState.selectedStash.value = stash
+
+            StashService().dropStash(stash)
+
+            GitDownState.selectedStash.value shouldBe null
+        }
+
+        it("leaves selectedStash untouched when a different stash is dropped") {
+            val repo = createTestRepository()
+                .addFile("foo.txt", "one\n")
+                .stageAll()
+                .commitAll("init")
+
+            autoClose(repo)
+
+            repo.appendToFile("foo.txt", "two\n").transferIntoGitDownState()
+            StashService().saveStash("first", includeUntrackedFiles = false)
+
+            repo.appendToFile("foo.txt", "three\n")
+            StashService().saveStash("second", includeUntrackedFiles = false)
+
+            val keptStash = GitDownState.stashes.value.single { it.description == "second" }
+            val droppedStash = GitDownState.stashes.value.single { it.description == "first" }
+            GitDownState.selectedStash.value = keptStash
+
+            StashService().dropStash(droppedStash)
+
+            GitDownState.stashes.value.single().description shouldBe "second"
+            GitDownState.selectedStash.value shouldBe keptStash
+        }
+
+        it("does nothing when the given stash is no longer in the stash list") {
+            autoClose(
+                createTestRepository()
+                    .addFile("foo.txt", "one\n")
+                    .stageAll()
+                    .commitAll("init")
+                    .appendToFile("foo.txt", "two\n")
+                    .transferIntoGitDownState()
+            )
+
+            StashService().saveStash("only stash", includeUntrackedFiles = false)
+            val stash = GitDownState.stashes.value.single()
+            StashService().dropStash(stash)
+
+            StashService().dropStash(stash)
+
+            GitDownState.stashes.value shouldBe emptyList()
+        }
+
+    }
+
 })


### PR DESCRIPTION
## Summary
- Add `Git.dropStash(stash: StashListItem)` jgit extension wrapper. `StashDropCommand.setStashRef()` takes a 0-based reflog index rather than a sha/ref string, so the wrapper resolves the given stash's position from the current stash list before dropping it.
- Add `StashService.dropStash(stash)` delegating to it, and clear `GitDownState.selectedStash` when the dropped stash was the one currently selected, so no stale reference lingers in local state. The stash list itself (`GitDownState.stashes`) is a `derivedStateOf` that recomputes automatically after the underlying `command {}` wrapper bumps `lastRequestedUpdateTimestamp`, matching the existing `saveStash` pattern.
- Cover with tests in `StashServiceSpec` (drop removes it from `GitDownState.stashes`, clears `selectedStash` only when it matches, leaves a different selection untouched, and is a safe no-op if the stash is no longer present).

Per the issue, this PR intentionally does **not** wire the toolbar "-" button to this service — that's a follow-up.

## Note on verification
This sandbox has no JDK and `/nix/store` is mounted read-only for this user, so `nix develop`/`./gradlew` could not be run locally (confirmed: no `java` binary anywhere, `nix-daemon` started but store writes still denied). The jgit `StashDropCommand` API (int index, nullable return on last-stash-drop) was verified against the actual 7.0.0.202409031743-r source. CI (`./gradlew build` under a real JDK 21) is the first real build/test gate for this change.

Closes #241