### PR TITLE
feat: wire stash bottom toolbar to StashService

### DIFF
--- a/src/main/kotlin/com/codymikol/components/stash/SaveStashDialog.kt
+++ b/src/main/kotlin/com/codymikol/components/stash/SaveStashDialog.kt
@@ -1,0 +1,94 @@
+package com.codymikol.components.stash
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.Checkbox
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.codymikol.components.SlimButton
+import com.codymikol.data.Colors
+import com.codymikol.typography.jetbrainsMono
+
+fun canSaveStash(message: String): Boolean = message.isNotBlank()
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun SaveStashDialog(onDismiss: () -> Unit, onConfirm: (message: String, includeUntrackedFiles: Boolean) -> Unit) {
+    var message by remember { mutableStateOf("") }
+    var includeUntrackedFiles by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        modifier = Modifier.fillMaxWidth().border(1.dp, Color.Black, RoundedCornerShape(4.dp)).padding(bottom = 8.dp),
+        onDismissRequest = { onDismiss() },
+        backgroundColor = Colors.LightGrayBackground,
+        contentColor = Color.White,
+        shape = RoundedCornerShape(4.dp),
+        text = {
+            Column(modifier = Modifier.fillMaxWidth().padding(8.dp)) {
+                Text(
+                    "New Stash",
+                    modifier = Modifier.padding(vertical = 8.dp),
+                    color = Color.White,
+                    fontFamily = jetbrainsMono(),
+                    style = MaterialTheme.typography.subtitle1
+                )
+
+                BasicTextField(
+                    value = message,
+                    onValueChange = { message = it },
+                    cursorBrush = Brush.verticalGradient(0.00f to Color.White),
+                    textStyle = TextStyle(color = Color.White, fontSize = 12.sp, fontFamily = jetbrainsMono()),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(Colors.DarkGrayBackground)
+                        .padding(8.dp)
+                )
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.padding(top = 8.dp)
+                ) {
+                    Checkbox(checked = includeUntrackedFiles, onCheckedChange = { includeUntrackedFiles = it })
+                    Text(
+                        "Include untracked files",
+                        color = Colors.LightGrayText,
+                        fontFamily = jetbrainsMono(),
+                        fontSize = 12.sp
+                    )
+                }
+            }
+        },
+        dismissButton = {
+            SlimButton("Cancel", onClick = { onDismiss() }, modifier = Modifier.padding(bottom = 8.dp).requiredHeight(28.dp))
+        },
+        confirmButton = {
+            SlimButton(
+                "Save Stash",
+                disabled = !canSaveStash(message),
+                onClick = { onConfirm(message, includeUntrackedFiles) },
+                modifier = Modifier.padding(bottom = 8.dp).requiredHeight(28.dp)
+            )
+        }
+    )
+}

--- a/src/main/kotlin/com/codymikol/components/stash/StashBottomToolbar.kt
+++ b/src/main/kotlin/com/codymikol/components/stash/StashBottomToolbar.kt
@@ -8,17 +8,40 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.codymikol.components.SlimButton
+import com.codymikol.components.commit.ConfirmDialog
 import com.codymikol.data.Colors
+import com.codymikol.services.StashService
+import com.codymikol.state.GitDownState
+import kotlinx.coroutines.launch
+import org.koin.java.KoinJavaComponent.inject
 
-fun stashToolbarButtonClicked(buttonText: String) = println(buttonText)
+internal val stashService: StashService by inject(StashService::class.java)
+
+fun dropStashConfirmationMessage(description: String): String =
+    "This will permanently delete the stash \"$description\", are you sure?"
+
+fun applyStashConfirmationMessage(description: String): String =
+    "This will apply the stash \"$description\" to your working directory, are you sure?"
 
 @Composable
 @Preview
 fun StashBottomToolbar() {
+    val scope = rememberCoroutineScope()
+    var isSavingStash by remember { mutableStateOf(false) }
+    var isConfirmingDrop by remember { mutableStateOf(false) }
+    var isConfirmingApply by remember { mutableStateOf(false) }
+
+    val selectedStash = GitDownState.selectedStash.value
+
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -29,10 +52,59 @@ fun StashBottomToolbar() {
             .padding(horizontal = 8.dp)
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
-            SlimButton("+", modifier = Modifier.padding(end = 8.dp), onClick = { stashToolbarButtonClicked("+") })
-            SlimButton("-", onClick = { stashToolbarButtonClicked("-") })
+            SlimButton("+", modifier = Modifier.padding(end = 8.dp), onClick = { isSavingStash = true })
+            SlimButton("-", disabled = selectedStash == null, onClick = { isConfirmingDrop = true })
         }
 
-        SlimButton("Apply", onClick = { stashToolbarButtonClicked("Apply") })
+        SlimButton("Apply", disabled = selectedStash == null, onClick = { isConfirmingApply = true })
+    }
+
+    if (isSavingStash) {
+        SaveStashDialog(
+            onDismiss = { isSavingStash = false },
+            onConfirm = { message, includeUntrackedFiles ->
+                scope.launch {
+                    try {
+                        stashService.saveStash(message, includeUntrackedFiles)
+                    } finally {
+                        isSavingStash = false
+                    }
+                }
+            }
+        )
+    }
+
+    if (isConfirmingDrop && selectedStash != null) {
+        ConfirmDialog(
+            title = "Drop Stash?",
+            content = dropStashConfirmationMessage(selectedStash.description),
+            onDismiss = { isConfirmingDrop = false },
+            onConfirm = {
+                scope.launch {
+                    try {
+                        stashService.dropStash(selectedStash)
+                    } finally {
+                        isConfirmingDrop = false
+                    }
+                }
+            }
+        )
+    }
+
+    if (isConfirmingApply && selectedStash != null) {
+        ConfirmDialog(
+            title = "Apply Stash?",
+            content = applyStashConfirmationMessage(selectedStash.description),
+            onDismiss = { isConfirmingApply = false },
+            onConfirm = {
+                scope.launch {
+                    try {
+                        stashService.applyStash(selectedStash)
+                    } finally {
+                        isConfirmingApply = false
+                    }
+                }
+            }
+        )
     }
 }

--- a/src/test/kotlin/com/codymikol/components/stash/SaveStashDialogSpec.kt
+++ b/src/test/kotlin/com/codymikol/components/stash/SaveStashDialogSpec.kt
@@ -1,0 +1,24 @@
+package com.codymikol.components.stash
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class SaveStashDialogSpec : DescribeSpec({
+
+    describe("canSaveStash") {
+
+        it("is false for a blank message") {
+            canSaveStash("   ") shouldBe false
+        }
+
+        it("is false for an empty message") {
+            canSaveStash("") shouldBe false
+        }
+
+        it("is true for a non-blank message") {
+            canSaveStash("my stash message") shouldBe true
+        }
+
+    }
+
+})

--- a/src/test/kotlin/com/codymikol/components/stash/StashBottomToolbarSpec.kt
+++ b/src/test/kotlin/com/codymikol/components/stash/StashBottomToolbarSpec.kt
@@ -2,23 +2,23 @@ package com.codymikol.components.stash
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
-import java.io.ByteArrayOutputStream
-import java.io.PrintStream
 
 class StashBottomToolbarSpec : DescribeSpec({
 
-    describe("stashToolbarButtonClicked") {
+    describe("dropStashConfirmationMessage") {
 
-        it("prints the button text to the console") {
-            val originalOut = System.out
-            val captured = ByteArrayOutputStream()
-            try {
-                System.setOut(PrintStream(captured))
-                stashToolbarButtonClicked("Apply")
-            } finally {
-                System.setOut(originalOut)
-            }
-            captured.toString().trim() shouldBe "Apply"
+        it("names the stash being dropped") {
+            dropStashConfirmationMessage("WIP on main: my stash") shouldBe
+                "This will permanently delete the stash \"WIP on main: my stash\", are you sure?"
+        }
+
+    }
+
+    describe("applyStashConfirmationMessage") {
+
+        it("names the stash being applied") {
+            applyStashConfirmationMessage("WIP on main: my stash") shouldBe
+                "This will apply the stash \"WIP on main: my stash\" to your working directory, are you sure?"
         }
 
     }


### PR DESCRIPTION
## Summary
- Wire the stash view's "+" / "-" / "Apply" bottom-toolbar buttons to the `StashService` built in #241/#242/#243.
- "-" (drop) and "Apply" confirm via the existing `ConfirmDialog` (Yes/No) against `GitDownState.selectedStash`.
- "+" (save) opens a new `SaveStashDialog` with a message textbox and an "include untracked files" checkbox, Cancel/Save Stash buttons; Save Stash stays disabled until the message is non-blank.
- Each dialog resets its visibility flag in a `finally` block so a failed git call doesn't leave it stuck open.

Closes #244

## Test plan
- [x] `./gradlew test` — 274 tests passing (ran locally via a temurin-21 JDK fetched through `nix build --store <tmp>`, since this container's default `/nix/store` is read-only with no daemon; bound into a `bwrap` namespace to run gradle — see note below)
- [x] Two rounds of automated review (`reviewer` subagent), both APPROVE; non-blocking findings folded in (try/finally reset, disabled-until-non-blank validation extracted as a tested pure predicate, dialog heading no longer duplicates the button label)

Note for reviewers: this sandbox's `nix develop` failed outright (`/nix/store` is mounted read-only, no nix-daemon), so I fetched just the JDK via `nix build --store /tmp/nixstore` and bind-mounted it into a `bwrap` namespace to run `./gradlew test` directly — full suite green, not just the new specs.