### PR TITLE
fix(map): sync all branch lane scroll positions into one plane

### DIFF
--- a/src/main/kotlin/com/codymikol/state/MapState.kt
+++ b/src/main/kotlin/com/codymikol/state/MapState.kt
@@ -27,6 +27,17 @@ object MapState {
         GitDownState.git.value.listLocalBranches().sortedBy { it.name }
     }
 
+    /**
+     * Every lane's LazyColumn renders exactly this many rows (padding shorter branches
+     * with blank rows past their own commits) so all lanes share the same item count.
+     * That's what makes it safe for every lane to render against one shared
+     * LazyListState (see MapView) - a shared state clamps to whichever lane's item
+     * count last measured, so mismatched counts would fight over the scroll position.
+     */
+    val maxLoadedRowCount = derivedStateOf {
+        commitsByBranch.values.maxOfOrNull { it.size } ?: 0
+    }
+
     fun loadMore(branch: Ref) {
         if (hasMoreByBranch[branch.name] == false) return
 

--- a/src/main/kotlin/com/codymikol/state/MapState.kt
+++ b/src/main/kotlin/com/codymikol/state/MapState.kt
@@ -16,6 +16,7 @@ import org.eclipse.jgit.lib.Ref
 object MapState {
 
     const val PAGE_SIZE = 30
+    const val LOAD_MORE_THRESHOLD = 5
 
     private val walkers = mutableMapOf<String, CommitHistoryWalker>()
 
@@ -46,6 +47,19 @@ object MapState {
 
         commitsByBranch.getOrPut(branch.name) { mutableStateListOf() }.addAll(page)
         hasMoreByBranch[branch.name] = walker.hasMore
+    }
+
+    /**
+     * Branches share a single vertical scroll position (see MapView), so a branch's own
+     * loaded-commit count is checked against that shared position rather than a lane-local
+     * one. lastVisibleIndex must be the last (bottom-most) visible row, not the first - the
+     * first visible index stays well short of loadedCount whenever more than
+     * LOAD_MORE_THRESHOLD rows fit in the viewport, so it would never trigger paging.
+     */
+    fun shouldLoadMore(branchName: String, lastVisibleIndex: Int): Boolean {
+        if (hasMoreByBranch[branchName] == false) return false
+        val loadedCount = commitsByBranch[branchName]?.size ?: 0
+        return lastVisibleIndex >= loadedCount - LOAD_MORE_THRESHOLD
     }
 
     fun reset() {

--- a/src/main/kotlin/com/codymikol/views/MapView.kt
+++ b/src/main/kotlin/com/codymikol/views/MapView.kt
@@ -6,14 +6,15 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.Text
@@ -39,7 +40,7 @@ import org.eclipse.jgit.lib.Ref
 private val LaneWidth = 260.dp
 private val NodeRadius = 5.dp
 private val GutterX = 20.dp
-private const val LoadMoreThreshold = 5
+private val RowHeight = 48.dp
 
 @Composable
 @Preview
@@ -50,14 +51,22 @@ fun MapView() {
     }
 
     val branches = MapState.branches.value
+    val rowCount = MapState.maxLoadedRowCount.value
+
+    // All lanes render against this one vertical LazyListState, rather than each owning
+    // its own, so scrolling any lane scrolls every lane's commit nodes in lock-step. Every
+    // lane also renders the same rowCount (see BranchLane), which is what makes sharing
+    // this state safe across lanes with different numbers of loaded commits.
+    val verticalScrollState = rememberLazyListState()
+    val horizontalScrollState = rememberLazyListState()
 
     when (branches.isEmpty()) {
         true -> MapEmptyState()
         false -> LazyRow(
-            state = rememberLazyListState(),
+            state = horizontalScrollState,
             modifier = Modifier.fillMaxWidth().fillMaxHeight().background(Colors.DarkGrayBackground)
         ) {
-            items(branches, key = { it.name }) { branch -> BranchLane(branch) }
+            items(branches, key = { it.name }) { branch -> BranchLane(branch, verticalScrollState, rowCount) }
         }
     }
 }
@@ -78,11 +87,10 @@ private fun MapEmptyState() {
 }
 
 @Composable
-private fun BranchLane(branch: Ref) {
+private fun BranchLane(branch: Ref, verticalScrollState: LazyListState, rowCount: Int) {
     val branchName = branch.name.removePrefix("refs/heads/")
     val commits = MapState.commitsByBranch[branch.name] ?: emptyList()
     val hasMore = MapState.hasMoreByBranch[branch.name] ?: true
-    val listState = rememberLazyListState()
 
     // Loading this lane's first page only happens once it's actually composed,
     // which LazyRow only does once the lane scrolls into view - this is what
@@ -94,10 +102,9 @@ private fun BranchLane(branch: Ref) {
     }
 
     LaunchedEffect(branch.name, commits.size, hasMore) {
-        snapshotFlow { listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index }
+        snapshotFlow { verticalScrollState.layoutInfo.visibleItemsInfo.lastOrNull()?.index }
             .collect { lastVisibleIndex ->
-                val nearBottom = lastVisibleIndex != null && lastVisibleIndex >= commits.size - LoadMoreThreshold
-                if (hasMore && nearBottom) {
+                if (lastVisibleIndex != null && MapState.shouldLoadMore(branch.name, lastVisibleIndex)) {
                     MapState.loadMore(branch)
                 }
             }
@@ -110,13 +117,17 @@ private fun BranchLane(branch: Ref) {
             .border(width = 1.dp, color = Color.Black)
     ) {
         Subheader(branchName)
-        LazyColumn(state = listState, modifier = Modifier.fillMaxWidth().fillMaxHeight()) {
-            itemsIndexed(commits, key = { _, commit -> commit.sha }) { index, commit ->
-                CommitNode(
-                    commit = commit,
-                    showLeadingGuideline = index != 0,
-                    showTrailingGuideline = index != commits.lastIndex || hasMore,
-                )
+        LazyColumn(state = verticalScrollState, modifier = Modifier.fillMaxWidth().fillMaxHeight()) {
+            items(rowCount, key = { index -> commits.getOrNull(index)?.sha ?: "blank-$index" }) { index ->
+                val commit = commits.getOrNull(index)
+                when (commit) {
+                    null -> Spacer(modifier = Modifier.fillMaxWidth().height(RowHeight))
+                    else -> CommitNode(
+                        commit = commit,
+                        showLeadingGuideline = index != 0,
+                        showTrailingGuideline = index != commits.lastIndex || hasMore,
+                    )
+                }
             }
         }
     }
@@ -127,7 +138,7 @@ private fun CommitNode(commit: CommitGraphNode, showLeadingGuideline: Boolean, s
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .height(48.dp)
+            .height(RowHeight)
             .drawBehind { drawCommitNode(commit, showLeadingGuideline, showTrailingGuideline) }
             .padding(start = 40.dp, top = 4.dp, end = 8.dp, bottom = 4.dp)
     ) {

--- a/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
@@ -68,6 +68,47 @@ class MapStateSpec : DescribeSpec({
             }
         }
 
+        describe("shouldLoadMore") {
+
+            it("should return false once the branch has no more commits to load") {
+                MapState.reset()
+                MapState.commitsByBranch["refs/heads/main"] = dummyCommits(4)
+                MapState.hasMoreByBranch["refs/heads/main"] = false
+
+                MapState.shouldLoadMore("refs/heads/main", 3) shouldBe false
+            }
+
+            it("should return false when the shared last-visible index is far from this branch's loaded end") {
+                MapState.reset()
+                MapState.commitsByBranch["refs/heads/main"] = dummyCommits(30)
+                MapState.hasMoreByBranch["refs/heads/main"] = true
+
+                MapState.shouldLoadMore("refs/heads/main", 0) shouldBe false
+            }
+
+            it("should return true when the shared last-visible index nears this branch's loaded end and more remain") {
+                MapState.reset()
+                MapState.commitsByBranch["refs/heads/main"] = dummyCommits(30)
+                MapState.hasMoreByBranch["refs/heads/main"] = true
+
+                MapState.shouldLoadMore("refs/heads/main", 28) shouldBe true
+            }
+
+            it("should return true exactly at the load-more threshold boundary") {
+                MapState.reset()
+                MapState.commitsByBranch["refs/heads/main"] = dummyCommits(30)
+                MapState.hasMoreByBranch["refs/heads/main"] = true
+
+                MapState.shouldLoadMore("refs/heads/main", 30 - MapState.LOAD_MORE_THRESHOLD) shouldBe true
+            }
+
+            it("should return true when nothing has loaded yet for the branch and more is assumed available") {
+                MapState.reset()
+
+                MapState.shouldLoadMore("refs/heads/main", 0) shouldBe true
+            }
+        }
+
         describe("maxLoadedRowCount") {
 
             it("should return zero when nothing has loaded") {

--- a/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
@@ -1,9 +1,11 @@
 package com.codymikol.state
 
+import com.codymikol.data.map.CommitGraphNode
 import com.codymikol.repository.TestRepository.Companion.createTestRepository
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import java.util.Date
 
 class MapStateSpec : DescribeSpec({
 
@@ -65,5 +67,33 @@ class MapStateSpec : DescribeSpec({
                 MapState.hasMoreByBranch.isEmpty() shouldBe true
             }
         }
+
+        describe("maxLoadedRowCount") {
+
+            it("should return zero when nothing has loaded") {
+                MapState.reset()
+
+                MapState.maxLoadedRowCount.value shouldBe 0
+            }
+
+            it("should return the largest loaded commit count across branches") {
+                MapState.reset()
+                MapState.commitsByBranch["refs/heads/main"] = dummyCommits(4)
+                MapState.commitsByBranch["refs/heads/feature"] = dummyCommits(30)
+
+                MapState.maxLoadedRowCount.value shouldBe 30
+            }
+        }
     }
 })
+
+private fun dummyCommits(count: Int) = (1..count).map {
+    CommitGraphNode(
+        sha = "sha$it",
+        shortSha = "sha$it",
+        shortMessage = "commit $it",
+        authorName = "author",
+        date = Date(),
+        parentShas = emptyList(),
+    )
+}.toMutableList()


### PR DESCRIPTION
## Summary
- Map view branch lanes each owned an independent vertical scroll state, so scrolling one lane's commits left every other lane frozen — they read as independent scrollable rows instead of one map.
- `MapState.maxLoadedRowCount` now tracks the tallest currently-loaded lane, and `MapState.shouldLoadMore` checks a branch's own loaded-commit count against a shared scroll index.
- `MapView` creates a single `LazyListState` shared by every `BranchLane`; each lane pads its `LazyColumn` out to `maxLoadedRowCount` rows (blank spacers past its own commits) so all lanes report a uniform item count — required for one shared `LazyListState` to stay in lock-step instead of lanes clamping/fighting over the scroll position.

Closes #250

## Notes for reviewer
- This sandbox has no working JDK / nix devShell (`nix develop` fails on store permission errors, no baked JDK on PATH), so `./gradlew test`/`build` could not be run locally. Verification was manual/static (traced every `MapStateSpec` assertion against the implementation) plus two independent fresh-agent code reviews (both `VERDICT: APPROVE`, no blocking findings). CI will provide the first real build/test signal — please watch it.
- Design mirrors a validated prior implementation of the identical fix from sibling issue #195 (unmerged, same root cause: "each lane owns an independent vertical scroll state").

## Test plan
- [ ] CI: `./gradlew build` green
- [ ] Manual: open Map view with multiple branches loaded, scroll one lane, confirm all lanes scroll together
- [ ] Manual: scroll a lane to the bottom, confirm pagination still loads more commits per branch