### PR TITLE
fix(map): remove scroll-driven lazy load causing UI freeze

### DIFF
--- a/src/main/kotlin/com/codymikol/data/map/CommitHistoryWalker.kt
+++ b/src/main/kotlin/com/codymikol/data/map/CommitHistoryWalker.kt
@@ -5,33 +5,15 @@ import org.eclipse.jgit.lib.Ref
 import org.eclipse.jgit.revwalk.RevWalk
 
 /**
- * Wraps a single JGit RevWalk so a branch's history can be paged in incrementally
- * instead of walking the whole history up front - the walk only advances as far
- * as nextPage() has been asked to go.
+ * Wraps a single JGit RevWalk over a branch's history, draining it in one call.
  */
 class CommitHistoryWalker(git: Git, ref: Ref) : AutoCloseable {
 
     private val walk = RevWalk(git.repository).also { it.markStart(it.parseCommit(ref.objectId)) }
 
-    var hasMore = true
-        private set
-
-    fun nextPage(size: Int): List<CommitGraphNode> {
-        if (!hasMore) return emptyList()
-
-        val page = mutableListOf<CommitGraphNode>()
-
-        while (page.size < size) {
-            val commit = walk.next()
-            if (commit == null) {
-                hasMore = false
-                break
-            }
-            page.add(CommitGraphNode.make(commit))
-        }
-
-        return page
-    }
+    fun loadAll(): List<CommitGraphNode> = generateSequence { walk.next() }
+        .map(CommitGraphNode::make)
+        .toList()
 
     override fun close() = walk.close()
 }

--- a/src/main/kotlin/com/codymikol/state/MapState.kt
+++ b/src/main/kotlin/com/codymikol/state/MapState.kt
@@ -9,20 +9,13 @@ import com.codymikol.extensions.listLocalBranches
 import org.eclipse.jgit.lib.Ref
 
 /**
- * Backs the Map view. Branch history is walked lazily - loadMore() only advances
- * a branch's RevWalk as far as the UI has actually scrolled, one CommitHistoryWalker
- * per branch, kept open across calls so re-walking from the start is never needed.
+ * Backs the Map view. Each branch's full commit history is walked and loaded in one
+ * call to load() - there is no lazy/paged loading of rows, since it exists as a simple
+ * scroll-able container holding every graph.
  */
 object MapState {
 
-    const val PAGE_SIZE = 30
-    const val LOAD_MORE_THRESHOLD = 5
-
-    private val walkers = mutableMapOf<String, CommitHistoryWalker>()
-
     val commitsByBranch = mutableStateMapOf<String, MutableList<CommitGraphNode>>()
-
-    val hasMoreByBranch = mutableStateMapOf<String, Boolean>()
 
     val branches = derivedStateOf {
         GitDownState.git.value.listLocalBranches().sortedBy { it.name }
@@ -35,37 +28,19 @@ object MapState {
      * LazyListState (see MapView) - a shared state clamps to whichever lane's item
      * count last measured, so mismatched counts would fight over the scroll position.
      */
-    val maxLoadedRowCount = derivedStateOf {
+    val maxRowCount = derivedStateOf {
         commitsByBranch.values.maxOfOrNull { it.size } ?: 0
     }
 
-    fun loadMore(branch: Ref) {
-        if (hasMoreByBranch[branch.name] == false) return
+    fun load(branch: Ref) {
+        if (commitsByBranch.containsKey(branch.name)) return
 
-        val walker = walkers.getOrPut(branch.name) { CommitHistoryWalker(GitDownState.git.value, branch) }
-        val page = walker.nextPage(PAGE_SIZE)
-
-        commitsByBranch.getOrPut(branch.name) { mutableStateListOf() }.addAll(page)
-        hasMoreByBranch[branch.name] = walker.hasMore
-    }
-
-    /**
-     * Branches share a single vertical scroll position (see MapView), so a branch's own
-     * loaded-commit count is checked against that shared position rather than a lane-local
-     * one. lastVisibleIndex must be the last (bottom-most) visible row, not the first - the
-     * first visible index stays well short of loadedCount whenever more than
-     * LOAD_MORE_THRESHOLD rows fit in the viewport, so it would never trigger paging.
-     */
-    fun shouldLoadMore(branchName: String, lastVisibleIndex: Int): Boolean {
-        if (hasMoreByBranch[branchName] == false) return false
-        val loadedCount = commitsByBranch[branchName]?.size ?: 0
-        return lastVisibleIndex >= loadedCount - LOAD_MORE_THRESHOLD
+        CommitHistoryWalker(GitDownState.git.value, branch).use { walker ->
+            commitsByBranch[branch.name] = mutableStateListOf<CommitGraphNode>().apply { addAll(walker.loadAll()) }
+        }
     }
 
     fun reset() {
-        walkers.values.forEach { it.close() }
-        walkers.clear()
         commitsByBranch.clear()
-        hasMoreByBranch.clear()
     }
 }

--- a/src/main/kotlin/com/codymikol/views/MapView.kt
+++ b/src/main/kotlin/com/codymikol/views/MapView.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
@@ -51,7 +50,7 @@ fun MapView() {
     }
 
     val branches = MapState.branches.value
-    val rowCount = MapState.maxLoadedRowCount.value
+    val rowCount = MapState.maxRowCount.value
 
     // All lanes render against this one vertical LazyListState, rather than each owning
     // its own, so scrolling any lane scrolls every lane's commit nodes in lock-step. Every
@@ -90,24 +89,12 @@ private fun MapEmptyState() {
 private fun BranchLane(branch: Ref, verticalScrollState: LazyListState, rowCount: Int) {
     val branchName = branch.name.removePrefix("refs/heads/")
     val commits = MapState.commitsByBranch[branch.name] ?: emptyList()
-    val hasMore = MapState.hasMoreByBranch[branch.name] ?: true
 
-    // Loading this lane's first page only happens once it's actually composed,
-    // which LazyRow only does once the lane scrolls into view - this is what
-    // lazily loads branches horizontally.
+    // A lane's commits load in full as soon as it composes - LazyRow only composes
+    // a lane once it scrolls into view, but there is no further lazy loading past
+    // that; every graph, once shown, holds its entire history.
     LaunchedEffect(branch.name) {
-        if (MapState.commitsByBranch[branch.name] == null) {
-            MapState.loadMore(branch)
-        }
-    }
-
-    LaunchedEffect(branch.name, commits.size, hasMore) {
-        snapshotFlow { verticalScrollState.layoutInfo.visibleItemsInfo.lastOrNull()?.index }
-            .collect { lastVisibleIndex ->
-                if (lastVisibleIndex != null && MapState.shouldLoadMore(branch.name, lastVisibleIndex)) {
-                    MapState.loadMore(branch)
-                }
-            }
+        MapState.load(branch)
     }
 
     Column(
@@ -125,7 +112,7 @@ private fun BranchLane(branch: Ref, verticalScrollState: LazyListState, rowCount
                     else -> CommitNode(
                         commit = commit,
                         showLeadingGuideline = index != 0,
-                        showTrailingGuideline = index != commits.lastIndex || hasMore,
+                        showTrailingGuideline = index != commits.lastIndex,
                     )
                 }
             }

--- a/src/test/kotlin/com/codymikol/data/map/CommitHistoryWalkerSpec.kt
+++ b/src/test/kotlin/com/codymikol/data/map/CommitHistoryWalkerSpec.kt
@@ -37,19 +37,12 @@ class CommitHistoryWalkerSpec : DescribeSpec({
 
             val branch = GitDownState.git.value.listLocalBranches().single()
 
-            it("should page through history newest first") {
+            it("should load every commit newest first in one call") {
                 val walker = CommitHistoryWalker(GitDownState.git.value, branch)
 
-                val firstPage = walker.nextPage(3)
-                firstPage.map { it.shortMessage } shouldBe listOf("commit 5", "commit 4", "commit 3")
-                walker.hasMore shouldBe true
+                val all = walker.loadAll()
 
-                val secondPage = walker.nextPage(3)
-                secondPage.map { it.shortMessage } shouldBe listOf("commit 2", "commit 1")
-                walker.hasMore shouldBe false
-
-                val thirdPage = walker.nextPage(3)
-                thirdPage shouldHaveSize 0
+                all.map { it.shortMessage } shouldBe listOf("commit 5", "commit 4", "commit 3", "commit 2", "commit 1")
 
                 walker.close()
             }
@@ -81,9 +74,9 @@ class CommitHistoryWalkerSpec : DescribeSpec({
                     .first { it.name.endsWith(defaultBranchName) }
 
                 val walker = CommitHistoryWalker(GitDownState.git.value, branch)
-                val page = walker.nextPage(10)
+                val commits = walker.loadAll()
 
-                val mergeCommits = page.filter { it.isMergeCommit }
+                val mergeCommits = commits.filter { it.isMergeCommit }
                 mergeCommits shouldHaveSize 1
                 mergeCommits.single().parentShas shouldHaveSize 2
 

--- a/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
@@ -39,82 +39,39 @@ class MapStateSpec : DescribeSpec({
                 MapState.branches.value shouldHaveSize 1
             }
 
-            it("should load every commit into commitsByBranch and mark the branch exhausted") {
+            it("should load every commit into commitsByBranch in a single call") {
                 val branch = MapState.branches.value.single()
 
-                MapState.loadMore(branch)
+                MapState.load(branch)
 
                 (MapState.commitsByBranch[branch.name] ?: emptyList()) shouldHaveSize 4
-                MapState.hasMoreByBranch[branch.name] shouldBe false
             }
 
-            it("should not duplicate rows once a branch is exhausted") {
+            it("should not duplicate rows when loaded twice") {
                 val branch = MapState.branches.value.single()
 
-                MapState.loadMore(branch)
-                MapState.loadMore(branch)
+                MapState.load(branch)
+                MapState.load(branch)
 
                 (MapState.commitsByBranch[branch.name] ?: emptyList()) shouldHaveSize 4
             }
 
             it("should clear loaded state on reset") {
                 val branch = MapState.branches.value.single()
-                MapState.loadMore(branch)
+                MapState.load(branch)
 
                 MapState.reset()
 
                 MapState.commitsByBranch.isEmpty() shouldBe true
-                MapState.hasMoreByBranch.isEmpty() shouldBe true
             }
         }
 
-        describe("shouldLoadMore") {
-
-            it("should return false once the branch has no more commits to load") {
-                MapState.reset()
-                MapState.commitsByBranch["refs/heads/main"] = dummyCommits(4)
-                MapState.hasMoreByBranch["refs/heads/main"] = false
-
-                MapState.shouldLoadMore("refs/heads/main", 3) shouldBe false
-            }
-
-            it("should return false when the shared last-visible index is far from this branch's loaded end") {
-                MapState.reset()
-                MapState.commitsByBranch["refs/heads/main"] = dummyCommits(30)
-                MapState.hasMoreByBranch["refs/heads/main"] = true
-
-                MapState.shouldLoadMore("refs/heads/main", 0) shouldBe false
-            }
-
-            it("should return true when the shared last-visible index nears this branch's loaded end and more remain") {
-                MapState.reset()
-                MapState.commitsByBranch["refs/heads/main"] = dummyCommits(30)
-                MapState.hasMoreByBranch["refs/heads/main"] = true
-
-                MapState.shouldLoadMore("refs/heads/main", 28) shouldBe true
-            }
-
-            it("should return true exactly at the load-more threshold boundary") {
-                MapState.reset()
-                MapState.commitsByBranch["refs/heads/main"] = dummyCommits(30)
-                MapState.hasMoreByBranch["refs/heads/main"] = true
-
-                MapState.shouldLoadMore("refs/heads/main", 30 - MapState.LOAD_MORE_THRESHOLD) shouldBe true
-            }
-
-            it("should return true when nothing has loaded yet for the branch and more is assumed available") {
-                MapState.reset()
-
-                MapState.shouldLoadMore("refs/heads/main", 0) shouldBe true
-            }
-        }
-
-        describe("maxLoadedRowCount") {
+        describe("maxRowCount") {
 
             it("should return zero when nothing has loaded") {
                 MapState.reset()
 
-                MapState.maxLoadedRowCount.value shouldBe 0
+                MapState.maxRowCount.value shouldBe 0
             }
 
             it("should return the largest loaded commit count across branches") {
@@ -122,7 +79,7 @@ class MapStateSpec : DescribeSpec({
                 MapState.commitsByBranch["refs/heads/main"] = dummyCommits(4)
                 MapState.commitsByBranch["refs/heads/feature"] = dummyCommits(30)
 
-                MapState.maxLoadedRowCount.value shouldBe 30
+                MapState.maxRowCount.value shouldBe 30
             }
         }
     }


### PR DESCRIPTION
## Summary
- Removes the map view's scroll-triggered lazy-load mechanic. The old code watched vertical scroll position via `snapshotFlow` inside a `LaunchedEffect` keyed on `commits.size`/`hasMore`; loading more commits changed `commits.size`, which retriggered the effect, which could load more again - an unbounded re-render loop that froze the UI.
- Each branch lane now loads its full commit history once, via a new `CommitHistoryWalker.loadAll()`, when the lane first composes. The map view is back to being a simple container that holds every graph, per the issue's ask. Per-node lazy loading is left for a future change.
- Removed the now-dead paging primitives (`nextPage`, `hasMore`, `PAGE_SIZE`, `LOAD_MORE_THRESHOLD`, `shouldLoadMore`, `maxLoadedRowCount`/`hasMoreByBranch` state) that existed only to support the removed scroll-driven paging.
- Cross-lane vertical scroll sync (added in a prior fix, #250) is left intact - it's a separate, already-working feature, not the cause of the freeze.

## Test plan
- [x] Updated `MapStateSpec` and `CommitHistoryWalkerSpec` for the new `load()`/`loadAll()` API and removed specs for deleted paging behavior.
- [ ] `./gradlew build` - could not be run locally in this sandbox (`/nix/store` is read-only for this environment's uid, no JDK available outside nix); relying on CI (`ci.yml` runs `./gradlew build` on JDK 21).

Closes #256