### PR TITLE
fix(map): lazy load commits on the vertical axis

### DIFF
--- a/src/main/kotlin/com/codymikol/data/map/CommitHistoryWalker.kt
+++ b/src/main/kotlin/com/codymikol/data/map/CommitHistoryWalker.kt
@@ -5,15 +5,33 @@ import org.eclipse.jgit.lib.Ref
 import org.eclipse.jgit.revwalk.RevWalk
 
 /**
- * Wraps a single JGit RevWalk over a branch's history, draining it in one call.
+ * Wraps a single JGit RevWalk so a branch's history can be paged in incrementally
+ * instead of walking the whole history up front - the walk only advances as far
+ * as nextPage() has been asked to go.
  */
 class CommitHistoryWalker(git: Git, ref: Ref) : AutoCloseable {
 
     private val walk = RevWalk(git.repository).also { it.markStart(it.parseCommit(ref.objectId)) }
 
-    fun loadAll(): List<CommitGraphNode> = generateSequence { walk.next() }
-        .map(CommitGraphNode::make)
-        .toList()
+    var hasMore = true
+        private set
+
+    fun nextPage(size: Int): List<CommitGraphNode> {
+        if (!hasMore) return emptyList()
+
+        val page = mutableListOf<CommitGraphNode>()
+
+        while (page.size < size) {
+            val commit = walk.next()
+            if (commit == null) {
+                hasMore = false
+                break
+            }
+            page.add(CommitGraphNode.make(commit))
+        }
+
+        return page
+    }
 
     override fun close() = walk.close()
 }

--- a/src/main/kotlin/com/codymikol/state/MapScrollState.kt
+++ b/src/main/kotlin/com/codymikol/state/MapScrollState.kt
@@ -1,0 +1,33 @@
+package com.codymikol.state
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import kotlin.math.ceil
+import kotlin.math.floor
+
+/**
+ * Every BranchLane windows its rows against this one shared vertical offset instead
+ * of each lane owning a LazyListState - sharing a LazyListState across lanes crashes
+ * the app (see #260 / #255), so lanes stay in lock-step by reading the same plain
+ * offset instead of a shared framework scroll state.
+ */
+object MapScrollState {
+
+    var offsetPx by mutableStateOf(0f)
+        private set
+
+    fun scrollBy(deltaPx: Float, maxOffsetPx: Float) {
+        offsetPx = (offsetPx + deltaPx).coerceIn(0f, maxOffsetPx.coerceAtLeast(0f))
+    }
+
+    fun firstVisibleIndex(rowHeightPx: Float): Int =
+        if (rowHeightPx <= 0f) 0 else floor(offsetPx / rowHeightPx).toInt().coerceAtLeast(0)
+
+    fun visibleRowCount(viewportHeightPx: Float, rowHeightPx: Float): Int =
+        if (rowHeightPx <= 0f) 0 else ceil(viewportHeightPx / rowHeightPx).toInt() + 1
+
+    fun reset() {
+        offsetPx = 0f
+    }
+}

--- a/src/main/kotlin/com/codymikol/state/MapState.kt
+++ b/src/main/kotlin/com/codymikol/state/MapState.kt
@@ -9,38 +9,53 @@ import com.codymikol.extensions.listLocalBranches
 import org.eclipse.jgit.lib.Ref
 
 /**
- * Backs the Map view. Each branch's full commit history is walked and loaded in one
- * call to load() - there is no lazy/paged loading of rows, since it exists as a simple
- * scroll-able container holding every graph.
+ * Backs the Map view. Branch history is walked lazily - loadMore() only advances
+ * a branch's RevWalk as far as the UI has actually scrolled, one CommitHistoryWalker
+ * per branch, kept open across calls so re-walking from the start is never needed.
  */
 object MapState {
 
+    const val PAGE_SIZE = 30
+    const val LOAD_MORE_THRESHOLD = 5
+
+    private val walkers = mutableMapOf<String, CommitHistoryWalker>()
+
     val commitsByBranch = mutableStateMapOf<String, MutableList<CommitGraphNode>>()
+
+    val hasMoreByBranch = mutableStateMapOf<String, Boolean>()
 
     val branches = derivedStateOf {
         GitDownState.git.value.listLocalBranches().sortedBy { it.name }
     }
 
-    /**
-     * Every lane's LazyColumn renders exactly this many rows (padding shorter branches
-     * with blank rows past their own commits) so all lanes share the same item count.
-     * That's what makes it safe for every lane to render against one shared
-     * LazyListState (see MapView) - a shared state clamps to whichever lane's item
-     * count last measured, so mismatched counts would fight over the scroll position.
-     */
-    val maxRowCount = derivedStateOf {
-        commitsByBranch.values.maxOfOrNull { it.size } ?: 0
+    fun loadMore(branch: Ref) {
+        if (hasMoreByBranch[branch.name] == false) return
+
+        val walker = walkers.getOrPut(branch.name) { CommitHistoryWalker(GitDownState.git.value, branch) }
+        val page = walker.nextPage(PAGE_SIZE)
+
+        commitsByBranch.getOrPut(branch.name) { mutableStateListOf() }.addAll(page)
+        hasMoreByBranch[branch.name] = walker.hasMore
     }
 
-    fun load(branch: Ref) {
-        if (commitsByBranch.containsKey(branch.name)) return
-
-        CommitHistoryWalker(GitDownState.git.value, branch).use { walker ->
-            commitsByBranch[branch.name] = mutableStateListOf<CommitGraphNode>().apply { addAll(walker.loadAll()) }
-        }
+    /**
+     * Branches share a single vertical scroll position (see MapScrollState), so a
+     * branch's own loaded-commit count is checked against that shared position rather
+     * than a lane-local one. lastVisibleIndex must be the last (bottom-most) visible
+     * row, not the first - the first visible index stays well short of loadedCount
+     * whenever more than LOAD_MORE_THRESHOLD rows fit in the viewport, so it would
+     * never trigger paging.
+     */
+    fun shouldLoadMore(branchName: String, lastVisibleIndex: Int): Boolean {
+        if (hasMoreByBranch[branchName] == false) return false
+        val loadedCount = commitsByBranch[branchName]?.size ?: 0
+        return lastVisibleIndex >= loadedCount - LOAD_MORE_THRESHOLD
     }
 
     fun reset() {
+        walkers.values.forEach { it.close() }
+        walkers.clear()
         commitsByBranch.clear()
+        hasMoreByBranch.clear()
     }
 }

--- a/src/main/kotlin/com/codymikol/views/MapView.kt
+++ b/src/main/kotlin/com/codymikol/views/MapView.kt
@@ -2,34 +2,49 @@ package com.codymikol.views
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.rememberScrollableState
+import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.codymikol.data.Colors
 import com.codymikol.data.map.CommitGraphNode
 import com.codymikol.state.GitDownState
+import com.codymikol.state.MapScrollState
 import com.codymikol.state.MapState
 import com.codymikol.typography.GitDownTypography
 import org.eclipse.jgit.lib.Ref
+import kotlin.math.roundToInt
 
 private val LaneWidth = 260.dp
 private val NodeRadius = 5.dp
 private val GutterX = 20.dp
 private val RowHeight = 48.dp
+private val LaneHeaderHeight = 32.dp
 
 @Composable
 @Preview
@@ -37,10 +52,10 @@ fun MapView() {
 
     LaunchedEffect(GitDownState.gitDirectory.value) {
         MapState.reset()
+        MapScrollState.reset()
     }
 
     val branches = MapState.branches.value
-    val rowCount = MapState.maxRowCount.value
 
     when (branches.isEmpty()) {
         true -> MapEmptyState()
@@ -51,15 +66,46 @@ fun MapView() {
 @Composable
 private fun Map(branches: List<Ref>) {
 
+    val rowHeightPx = with(LocalDensity.current) { RowHeight.toPx() }
+    val headerHeightPx = with(LocalDensity.current) { LaneHeaderHeight.toPx() }
+    var viewportHeightPx by remember { mutableStateOf(0f) }
+
+    // Every lane's own row viewport sits below its LaneHeaderHeight header, so windowing
+    // and the scroll bound are both computed against that shrunk height, not the raw
+    // container height - otherwise the last loaded row of the tallest lane clips.
+    val laneContentHeightPx = (viewportHeightPx - headerHeightPx).coerceAtLeast(0f)
+
+    val maxLoadedRows = branches.maxOfOrNull { MapState.commitsByBranch[it.name]?.size ?: 0 } ?: 0
+    val maxOffsetPx = (maxLoadedRows * rowHeightPx - laneContentHeightPx).coerceAtLeast(0f)
+
+    // Every lane windows against MapScrollState's one shared offset (see BranchLane)
+    // instead of a LazyListState, so this is the single place that translates drag/wheel
+    // input into that offset - no lane ever owns or drives scrolling on its own.
+    val verticalScrollableState = rememberScrollableState { delta ->
+        val before = MapScrollState.offsetPx
+        MapScrollState.scrollBy(delta, maxOffsetPx)
+        MapScrollState.offsetPx - before
+    }
+
     Column(modifier = Modifier.fillMaxSize()) {
 
         val lazyHorizontalState = rememberLazyListState()
 
-        LazyRow(
-            state = lazyHorizontalState,
-            modifier = Modifier.fillMaxWidth().fillMaxHeight().background(Colors.DarkGrayBackground)
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight()
+                .onSizeChanged { viewportHeightPx = it.height.toFloat() }
+                .scrollable(orientation = Orientation.Vertical, state = verticalScrollableState)
         ) {
-           items(branches.size, key = { branches[it].name }) { BranchLane(branch = branches[it]) }
+            LazyRow(
+                state = lazyHorizontalState,
+                modifier = Modifier.fillMaxWidth().fillMaxHeight().background(Colors.DarkGrayBackground)
+            ) {
+                items(branches.size, key = { branches[it].name }) {
+                    BranchLane(branch = branches[it], rowHeightPx = rowHeightPx, viewportHeightPx = laneContentHeightPx)
+                }
+            }
         }
     }
 
@@ -81,15 +127,24 @@ private fun MapEmptyState() {
 }
 
 @Composable
-private fun BranchLane(branch: Ref) {
+private fun BranchLane(branch: Ref, rowHeightPx: Float, viewportHeightPx: Float) {
     val branchName = branch.name.removePrefix("refs/heads/")
     val commits = MapState.commitsByBranch[branch.name] ?: emptyList()
 
-    // A lane's commits load in full as soon as it composes - LazyRow only composes
-    // a lane once it scrolls into view, but there is no further lazy loading past
-    // that; every graph, once shown, holds its entire history.
-    LaunchedEffect(branch.name) {
-        MapState.load(branch)
+    val firstVisibleIndex = MapScrollState.firstVisibleIndex(rowHeightPx)
+    val visibleRowCount = MapScrollState.visibleRowCount(viewportHeightPx, rowHeightPx)
+    val lastVisibleIndex = firstVisibleIndex + visibleRowCount - 1
+
+    // shouldLoadMore() is true before a branch has loaded anything, so this effect also
+    // covers the lane's first page - no separate initial-load effect needed. It's keyed
+    // on the scroll-derived lastVisibleIndex, never on commits.size or hasMore, which
+    // loadMore() mutates - keying an effect on a value it mutates is what caused the
+    // unbounded reload loop that froze the UI before (see #260 / #256). The while loop
+    // just lets one recomposition catch a lane up several pages instead of one.
+    LaunchedEffect(branch.name, lastVisibleIndex) {
+        while (MapState.shouldLoadMore(branch.name, lastVisibleIndex)) {
+            MapState.loadMore(branch)
+        }
     }
 
     Column(
@@ -97,17 +152,34 @@ private fun BranchLane(branch: Ref) {
             .width(LaneWidth)
             .fillMaxHeight()
     ) {
-        Text(style = TextStyle(fontWeight = FontWeight.Bold, fontSize = 12.sp), modifier = Modifier.padding(8.dp).fillMaxWidth(), color = Color.White, text = branchName)
-        Column(modifier = Modifier.fillMaxWidth().fillMaxHeight()) {
+        Text(
+            style = TextStyle(fontWeight = FontWeight.Bold, fontSize = 12.sp),
+            modifier = Modifier.height(LaneHeaderHeight).padding(8.dp).fillMaxWidth(),
+            color = Color.White,
+            text = branchName,
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight()
+                .clipToBounds()
+        ) {
+            val visibleEnd = (firstVisibleIndex + visibleRowCount).coerceIn(0, commits.size)
+            val visibleStart = firstVisibleIndex.coerceIn(0, visibleEnd)
 
-            commits.forEach {
-                CommitNode(
-                    commit = it,
-                    showLeadingGuideline = false,
-                    showTrailingGuideline = false,
-                )
+            for (index in visibleStart until visibleEnd) {
+                val commit = commits[index]
+                val yOffsetPx = (index * rowHeightPx - MapScrollState.offsetPx).roundToInt()
+
+                key(commit.sha) {
+                    CommitNode(
+                        commit = commit,
+                        showLeadingGuideline = false,
+                        showTrailingGuideline = false,
+                        modifier = Modifier.offset { IntOffset(0, yOffsetPx) },
+                    )
+                }
             }
-
         }
 
     }
@@ -115,9 +187,14 @@ private fun BranchLane(branch: Ref) {
 
 
 @Composable
-private fun CommitNode(commit: CommitGraphNode, showLeadingGuideline: Boolean, showTrailingGuideline: Boolean) {
+private fun CommitNode(
+    commit: CommitGraphNode,
+    showLeadingGuideline: Boolean,
+    showTrailingGuideline: Boolean,
+    modifier: Modifier = Modifier,
+) {
     Row(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .height(RowHeight)
             .drawBehind { drawCommitNode(commit, showLeadingGuideline, showTrailingGuideline) }
@@ -135,7 +212,6 @@ private fun DrawScope.drawCommitNode(
     showLeadingGuideline: Boolean,
     showTrailingGuideline: Boolean,
 ) {
-    println("drawing")
     val x = GutterX.toPx()
     val centerY = size.height / 2f
 
@@ -166,6 +242,5 @@ private fun DrawScope.drawDiamond(center: Offset, radius: Float, color: Color) {
         lineTo(center.x - radius, center.y)
         close()
     }
-    println("drawing path $path")
     drawPath(path, color = color)
 }

--- a/src/test/kotlin/com/codymikol/data/map/CommitHistoryWalkerSpec.kt
+++ b/src/test/kotlin/com/codymikol/data/map/CommitHistoryWalkerSpec.kt
@@ -37,12 +37,19 @@ class CommitHistoryWalkerSpec : DescribeSpec({
 
             val branch = GitDownState.git.value.listLocalBranches().single()
 
-            it("should load every commit newest first in one call") {
+            it("should page through history newest first") {
                 val walker = CommitHistoryWalker(GitDownState.git.value, branch)
 
-                val all = walker.loadAll()
+                val firstPage = walker.nextPage(3)
+                firstPage.map { it.shortMessage } shouldBe listOf("commit 5", "commit 4", "commit 3")
+                walker.hasMore shouldBe true
 
-                all.map { it.shortMessage } shouldBe listOf("commit 5", "commit 4", "commit 3", "commit 2", "commit 1")
+                val secondPage = walker.nextPage(3)
+                secondPage.map { it.shortMessage } shouldBe listOf("commit 2", "commit 1")
+                walker.hasMore shouldBe false
+
+                val thirdPage = walker.nextPage(3)
+                thirdPage shouldHaveSize 0
 
                 walker.close()
             }
@@ -74,7 +81,7 @@ class CommitHistoryWalkerSpec : DescribeSpec({
                     .first { it.name.endsWith(defaultBranchName) }
 
                 val walker = CommitHistoryWalker(GitDownState.git.value, branch)
-                val commits = walker.loadAll()
+                val commits = walker.nextPage(10)
 
                 val mergeCommits = commits.filter { it.isMergeCommit }
                 mergeCommits shouldHaveSize 1

--- a/src/test/kotlin/com/codymikol/state/MapScrollStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/MapScrollStateSpec.kt
@@ -1,0 +1,69 @@
+package com.codymikol.state
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class MapScrollStateSpec : DescribeSpec({
+
+    describe("MapScrollState") {
+
+        beforeEach { MapScrollState.reset() }
+
+        describe("scrollBy") {
+
+            it("should accumulate the offset across calls") {
+                MapScrollState.scrollBy(48f, maxOffsetPx = 1000f)
+                MapScrollState.scrollBy(32f, maxOffsetPx = 1000f)
+
+                MapScrollState.offsetPx shouldBe 80f
+            }
+
+            it("should not scroll past zero") {
+                MapScrollState.scrollBy(-20f, maxOffsetPx = 1000f)
+
+                MapScrollState.offsetPx shouldBe 0f
+            }
+
+            it("should not scroll past the given max offset") {
+                MapScrollState.scrollBy(5000f, maxOffsetPx = 200f)
+
+                MapScrollState.offsetPx shouldBe 200f
+            }
+        }
+
+        describe("firstVisibleIndex") {
+
+            it("should be zero when nothing has scrolled") {
+                MapScrollState.firstVisibleIndex(rowHeightPx = 48f) shouldBe 0
+            }
+
+            it("should floor the offset divided by row height") {
+                MapScrollState.scrollBy(100f, maxOffsetPx = 1000f)
+
+                MapScrollState.firstVisibleIndex(rowHeightPx = 48f) shouldBe 2
+            }
+        }
+
+        describe("visibleRowCount") {
+
+            it("should cover the viewport with one extra row for partial scroll") {
+                MapScrollState.visibleRowCount(viewportHeightPx = 480f, rowHeightPx = 48f) shouldBe 11
+            }
+
+            it("should round up a viewport that doesn't divide evenly by row height") {
+                MapScrollState.visibleRowCount(viewportHeightPx = 100f, rowHeightPx = 48f) shouldBe 4
+            }
+        }
+
+        describe("reset") {
+
+            it("should return the offset to zero") {
+                MapScrollState.scrollBy(300f, maxOffsetPx = 1000f)
+
+                MapScrollState.reset()
+
+                MapScrollState.offsetPx shouldBe 0f
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
@@ -39,47 +39,105 @@ class MapStateSpec : DescribeSpec({
                 MapState.branches.value shouldHaveSize 1
             }
 
-            it("should load every commit into commitsByBranch in a single call") {
+            it("should load every commit into commitsByBranch and mark the branch exhausted") {
                 val branch = MapState.branches.value.single()
 
-                MapState.load(branch)
+                MapState.loadMore(branch)
 
                 (MapState.commitsByBranch[branch.name] ?: emptyList()) shouldHaveSize 4
+                MapState.hasMoreByBranch[branch.name] shouldBe false
             }
 
-            it("should not duplicate rows when loaded twice") {
+            it("should not duplicate rows once a branch is exhausted") {
                 val branch = MapState.branches.value.single()
 
-                MapState.load(branch)
-                MapState.load(branch)
+                MapState.loadMore(branch)
+                MapState.loadMore(branch)
 
                 (MapState.commitsByBranch[branch.name] ?: emptyList()) shouldHaveSize 4
             }
 
             it("should clear loaded state on reset") {
                 val branch = MapState.branches.value.single()
-                MapState.load(branch)
+                MapState.loadMore(branch)
 
                 MapState.reset()
 
                 MapState.commitsByBranch.isEmpty() shouldBe true
+                MapState.hasMoreByBranch.isEmpty() shouldBe true
             }
         }
 
-        describe("maxRowCount") {
+        describe("shouldLoadMore") {
 
-            it("should return zero when nothing has loaded") {
-                MapState.reset()
-
-                MapState.maxRowCount.value shouldBe 0
-            }
-
-            it("should return the largest loaded commit count across branches") {
+            it("should return false once the branch has no more commits to load") {
                 MapState.reset()
                 MapState.commitsByBranch["refs/heads/main"] = dummyCommits(4)
-                MapState.commitsByBranch["refs/heads/feature"] = dummyCommits(30)
+                MapState.hasMoreByBranch["refs/heads/main"] = false
 
-                MapState.maxRowCount.value shouldBe 30
+                MapState.shouldLoadMore("refs/heads/main", 3) shouldBe false
+            }
+
+            it("should return false when the shared last-visible index is far from this branch's loaded end") {
+                MapState.reset()
+                MapState.commitsByBranch["refs/heads/main"] = dummyCommits(30)
+                MapState.hasMoreByBranch["refs/heads/main"] = true
+
+                MapState.shouldLoadMore("refs/heads/main", 0) shouldBe false
+            }
+
+            it("should return true when the shared last-visible index nears this branch's loaded end and more remain") {
+                MapState.reset()
+                MapState.commitsByBranch["refs/heads/main"] = dummyCommits(30)
+                MapState.hasMoreByBranch["refs/heads/main"] = true
+
+                MapState.shouldLoadMore("refs/heads/main", 28) shouldBe true
+            }
+
+            it("should return true exactly at the load-more threshold boundary") {
+                MapState.reset()
+                MapState.commitsByBranch["refs/heads/main"] = dummyCommits(30)
+                MapState.hasMoreByBranch["refs/heads/main"] = true
+
+                MapState.shouldLoadMore("refs/heads/main", 30 - MapState.LOAD_MORE_THRESHOLD) shouldBe true
+            }
+
+            it("should return true when nothing has loaded yet for the branch and more is assumed available") {
+                MapState.reset()
+
+                MapState.shouldLoadMore("refs/heads/main", 0) shouldBe true
+            }
+        }
+
+        describe("a branch with more commits than one page") {
+
+            val repo = createTestRepository().addFile("a.txt", "0").stageAll().commitAll("commit 0")
+            repeat(64) { i ->
+                repo.appendToFile("a.txt", "$i")
+                repo.stageAll()
+                repo.commitAll("commit ${i + 1}")
+            }
+            autoClose(repo.transferIntoGitDownState())
+
+            // Regression guard for #256: a loop driven by shouldLoadMore() (mirroring
+            // BranchLane's catch-up effect) must converge in a small, bounded number of
+            // iterations rather than spin forever - it must NOT be re-launched by a key
+            // that loadMore() itself mutates (commits.size / hasMore), the mechanism that
+            // previously froze the UI.
+            it("should catch a lane up to a deep scroll position in a bounded number of pages") {
+                val branch = MapState.branches.value.single()
+                val deepLastVisibleIndex = 60
+
+                var iterations = 0
+                while (MapState.shouldLoadMore(branch.name, deepLastVisibleIndex)) {
+                    check(iterations < 10) { "loadMore loop did not converge - possible regression of #256" }
+                    MapState.loadMore(branch)
+                    iterations++
+                }
+
+                iterations shouldBe 3
+                MapState.hasMoreByBranch[branch.name] shouldBe false
+                (MapState.commitsByBranch[branch.name] ?: emptyList()) shouldHaveSize 65
             }
         }
     }


### PR DESCRIPTION
## Summary

The Map view lazy-loaded branches horizontally (via `LazyRow`) but each
branch lane eagerly drained its full commit history the moment it composed,
and had no vertical scrolling at all. This adds true 2D lazy loading:

- `CommitHistoryWalker.nextPage()`/`hasMore` page a branch's JGit `RevWalk`
  incrementally instead of draining it in one `loadAll()` call.
- `MapState.loadMore()`/`shouldLoadMore()` keep one walker open per branch,
  paging `PAGE_SIZE` commits at a time and tracking `hasMoreByBranch`.
- `MapScrollState` is a new shared vertical offset that every `BranchLane`
  reads to decide which rows to render and where to place them.
- `BranchLane` now windows its commit rows against that shared offset
  instead of using a `LazyColumn`, so lanes scroll in lock-step without any
  lane owning a `LazyListState`.

Per the issue, sharing one `LazyListState` across lanes was already tried
in #255 and crashed the app, and a load-more effect keyed on a value it
mutates (`commits.size`/`hasMore`) previously froze the UI (#256). This
avoids both: no `LazyListState` is shared, and the load-more
`LaunchedEffect` is keyed only on the scroll-derived `lastVisibleIndex`,
which `loadMore()` never touches. A regression test in `MapStateSpec`
asserts the catch-up loop converges in a bounded number of pages instead
of spinning forever.

Closes #260

## Note for reviewers

This sandbox has no JDK/Gradle toolchain available (read-only Nix store,
no baked JDK - the same limitation noted in the issue's own research
comment for prior PRs #255/#257), so I could not run `./gradlew test`
locally. All logic-bearing changes (`CommitHistoryWalker`, `MapState`,
`MapScrollState`) are covered by kotest specs and were verified by careful
static review; the paging/state code mirrors a version of this design that
existed earlier in this repo's history (commits `e747636`/`e32c106`/
`5e334f6`, since reverted for the shared-`LazyListState` and effect-keying
bugs described above) minus those two bugs. Please confirm CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)