### PR TITLE
feat(map): reveal commit details on node click

### DIFF
--- a/src/main/kotlin/com/codymikol/data/map/CommitCard.kt
+++ b/src/main/kotlin/com/codymikol/data/map/CommitCard.kt
@@ -1,0 +1,63 @@
+package com.codymikol.data.map
+
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+
+/**
+ * Formats the three lines shown on the floating card that appears when a commit
+ * node is clicked in the map view (see issue #252):
+ *
+ *   <short sha>: <commit message>
+ *   Author: <name> <<email>>
+ *   Date: MM/DD/YY, h:mm AM/PM <relative>
+ *
+ * where <relative> is the single most-relevant human label for how long ago the
+ * commit was authored (Today / Yesterday / X Days Ago / X Months Ago / X Years Ago).
+ */
+object CommitCard {
+
+    private const val MILLIS_PER_DAY = 1000L * 60 * 60 * 24
+    private const val DAYS_PER_MONTH = 30
+    private const val DAYS_PER_YEAR = 365
+
+    fun title(node: CommitGraphNode): String = "${node.shortSha}: ${node.shortMessage}"
+
+    fun author(node: CommitGraphNode): String = "Author: ${node.authorName} <${node.authorEmail}>"
+
+    fun date(date: Date, now: Date): String {
+        val datePart = SimpleDateFormat("MM/dd/yy").format(date)
+        val timePart = SimpleDateFormat("h:mm a").format(date)
+        return "Date: $datePart, $timePart ${relative(date, now)}"
+    }
+
+    fun relative(date: Date, now: Date): String {
+        val days = calendarDaysBetween(date, now)
+        return when {
+            days <= 0L -> "Today"
+            days == 1L -> "Yesterday"
+            days < DAYS_PER_MONTH -> "$days Days Ago"
+            days < DAYS_PER_YEAR -> "${days / DAYS_PER_MONTH} Months Ago"
+            else -> "${days / DAYS_PER_YEAR} Years Ago"
+        }
+    }
+
+    /**
+     * Whole calendar days from [from] to [to], measured from local midnight so that
+     * a commit made late yesterday and a check made early today read as "Yesterday"
+     * rather than collapsing to a sub-24h "Today".
+     */
+    private fun calendarDaysBetween(from: Date, to: Date): Long {
+        val fromMidnight = atMidnight(from)
+        val toMidnight = atMidnight(to)
+        return (toMidnight - fromMidnight) / MILLIS_PER_DAY
+    }
+
+    private fun atMidnight(date: Date): Long = Calendar.getInstance().apply {
+        time = date
+        set(Calendar.HOUR_OF_DAY, 0)
+        set(Calendar.MINUTE, 0)
+        set(Calendar.SECOND, 0)
+        set(Calendar.MILLISECOND, 0)
+    }.timeInMillis
+}

--- a/src/main/kotlin/com/codymikol/data/map/CommitGraphNode.kt
+++ b/src/main/kotlin/com/codymikol/data/map/CommitGraphNode.kt
@@ -8,6 +8,7 @@ data class CommitGraphNode(
     val shortSha: String,
     val shortMessage: String,
     val authorName: String,
+    val authorEmail: String,
     val date: Date,
     val parentShas: List<String>,
 ) {
@@ -21,6 +22,7 @@ data class CommitGraphNode(
             shortSha = revCommit.name.take(7),
             shortMessage = revCommit.shortMessage,
             authorName = revCommit.authorIdent?.name ?: "",
+            authorEmail = revCommit.authorIdent?.emailAddress ?: "",
             date = Date(revCommit.commitTime.toLong() * 1000),
             parentShas = revCommit.parents.map { it.name },
         )

--- a/src/main/kotlin/com/codymikol/state/MapState.kt
+++ b/src/main/kotlin/com/codymikol/state/MapState.kt
@@ -3,6 +3,7 @@ package com.codymikol.state
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
 import com.codymikol.data.map.CommitGraphNode
 import com.codymikol.data.map.CommitHistoryWalker
 import com.codymikol.extensions.listLocalBranches
@@ -23,6 +24,17 @@ object MapState {
     val commitsByBranch = mutableStateMapOf<String, MutableList<CommitGraphNode>>()
 
     val hasMoreByBranch = mutableStateMapOf<String, Boolean>()
+
+    /**
+     * Sha of the commit node whose detail card is currently shown, or null when no
+     * node is selected. Node sha/message text is hidden in the map until a node is
+     * clicked (see issue #252); clicking toggles this selection.
+     */
+    val selectedNodeSha = mutableStateOf<String?>(null)
+
+    fun toggleSelectedNode(sha: String) {
+        selectedNodeSha.value = if (selectedNodeSha.value == sha) null else sha
+    }
 
     val branches = derivedStateOf {
         GitDownState.git.value.listLocalBranches().sortedBy { it.name }
@@ -57,5 +69,6 @@ object MapState {
         walkers.clear()
         commitsByBranch.clear()
         hasMoreByBranch.clear()
+        selectedNodeSha.value = null
     }
 }

--- a/src/main/kotlin/com/codymikol/views/MapView.kt
+++ b/src/main/kotlin/com/codymikol/views/MapView.kt
@@ -2,12 +2,15 @@ package com.codymikol.views
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.rememberScrollableState
 import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -31,18 +34,21 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.zIndex
 import com.codymikol.data.Colors
+import com.codymikol.data.map.CommitCard
 import com.codymikol.data.map.CommitGraphNode
 import com.codymikol.state.GitDownState
 import com.codymikol.state.MapScrollState
 import com.codymikol.state.MapState
-import com.codymikol.typography.GitDownTypography
 import org.eclipse.jgit.lib.Ref
+import java.util.Date
 import kotlin.math.roundToInt
 
 // Narrower than a horizontal title would need, since titles are now rotated
@@ -51,6 +57,13 @@ private val LaneWidth = 180.dp
 private val NodeRadius = 5.dp
 private val GutterX = 20.dp
 private val RowHeight = 48.dp
+
+// The dog-tag detail card shown when a node is clicked (#252): a rounded-rectangle
+// body with a protruding round tab holding a punched hole, sitting over the node.
+private val CardTabSize = 22.dp
+private val CardHoleSize = 8.dp
+private val CardCorner = 10.dp
+private val CardMaxWidth = 150.dp
 
 // Every lane's title sits in a fixed-height box so all lanes' graphs start at the
 // same y-offset below the titles, regardless of how long each branch name is.
@@ -196,6 +209,8 @@ private fun BranchLane(branch: Ref, rowHeightPx: Float, viewportHeightPx: Float)
                 key(commit.sha) {
                     CommitNode(
                         commit = commit,
+                        isSelected = MapState.selectedNodeSha.value == commit.sha,
+                        onClick = { MapState.toggleSelectedNode(commit.sha) },
                         showLeadingGuideline = false,
                         showTrailingGuideline = false,
                         modifier = Modifier.offset { IntOffset(0, yOffsetPx) },
@@ -245,26 +260,100 @@ private fun MapLaneTitle(branchName: String) {
     }
 }
 
+// The sha and commit message are hidden by default to preserve space (#252); the
+// node itself is the whole clickable target and its detail card only appears while
+// this node is selected.
 @Composable
 private fun CommitNode(
     commit: CommitGraphNode,
+    isSelected: Boolean,
+    onClick: () -> Unit,
     showLeadingGuideline: Boolean,
     showTrailingGuideline: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    Row(
+    Box(
         modifier = modifier
             .fillMaxWidth()
             .height(RowHeight)
+            // The selected node draws above its siblings so its card, which is taller
+            // than one row, floats over the neighbouring nodes rather than under them.
+            .zIndex(if (isSelected) 1f else 0f)
+            .clickable { onClick() }
             .drawBehind { drawCommitNode(commit, showLeadingGuideline, showTrailingGuideline) }
-            .padding(start = 40.dp, top = 4.dp, end = 8.dp, bottom = 4.dp)
     ) {
-        Column {
-            GitDownTypography.CommitSha(commit.shortSha)
-            GitDownTypography.CommitSubject(commit.shortMessage)
+        if (isSelected) {
+            CommitDetailCard(
+                commit = commit,
+                color = nodeColor(commit),
+                modifier = Modifier
+                    .align(Alignment.CenterStart)
+                    .padding(start = GutterX - CardTabSize / 2)
+            )
         }
     }
 }
+
+// The floating dog-tag card: a round tab holding a punched hole sits over the node
+// and sticks out a little farther than the rounded-rectangle body, which extends to
+// the right with the commit's details. Coloured the same as the node it describes.
+@Composable
+private fun CommitDetailCard(
+    commit: CommitGraphNode,
+    color: Color,
+    modifier: Modifier = Modifier,
+) {
+    val now = remember(commit.sha) { Date() }
+
+    Row(
+        modifier = modifier.widthIn(max = CardMaxWidth),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(CardTabSize)
+                .clip(CircleShape)
+                .background(color),
+            contentAlignment = Alignment.Center,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(CardHoleSize)
+                    .clip(CircleShape)
+                    .background(Colors.DarkGrayBackground)
+            )
+        }
+
+        // Tucked left under the tab so the tab's hole end protrudes past the body.
+        Column(
+            modifier = Modifier
+                .offset(x = -CardCorner)
+                .clip(RoundedCornerShape(CardCorner))
+                .background(color)
+                .padding(start = CardCorner + 6.dp, top = 6.dp, end = 10.dp, bottom = 6.dp),
+        ) {
+            CardLine(CommitCard.title(commit), FontWeight.Bold)
+            CardLine(CommitCard.author(commit), FontWeight.Normal)
+            CardLine(CommitCard.date(commit.date, now), FontWeight.Normal)
+        }
+    }
+}
+
+@Composable
+private fun CardLine(text: String, fontWeight: FontWeight) {
+    Text(
+        text = text,
+        color = Color.White,
+        fontSize = 10.sp,
+        fontWeight = fontWeight,
+        fontFamily = FontFamily.Monospace,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+    )
+}
+
+private fun nodeColor(commit: CommitGraphNode): Color =
+    if (commit.isMergeCommit) Colors.FileModified else Colors.FileAdded
 
 private fun DrawScope.drawCommitNode(
     commit: CommitGraphNode,
@@ -288,8 +377,8 @@ private fun DrawScope.drawCommitNode(
     }
 
     when (commit.isMergeCommit) {
-        true -> drawDiamond(center = Offset(x, centerY), radius = NodeRadius.toPx(), color = Colors.FileModified)
-        false -> drawCircle(color = Colors.FileAdded, radius = NodeRadius.toPx(), center = Offset(x, centerY))
+        true -> drawDiamond(center = Offset(x, centerY), radius = NodeRadius.toPx(), color = nodeColor(commit))
+        false -> drawCircle(color = nodeColor(commit), radius = NodeRadius.toPx(), center = Offset(x, centerY))
     }
 }
 

--- a/src/test/kotlin/com/codymikol/data/map/CommitCardSpec.kt
+++ b/src/test/kotlin/com/codymikol/data/map/CommitCardSpec.kt
@@ -1,0 +1,77 @@
+package com.codymikol.data.map
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.util.Calendar
+import java.util.Date
+
+class CommitCardSpec : DescribeSpec({
+
+    fun date(year: Int, month: Int, day: Int, hour: Int = 12, minute: Int = 0): Date =
+        Calendar.getInstance().apply {
+            clear()
+            set(year, month - 1, day, hour, minute, 0)
+        }.time
+
+    fun node(
+        shortSha: String = "abc1234",
+        shortMessage: String = "do a thing",
+        authorName: String = "Ada Lovelace",
+        authorEmail: String = "ada@example.com",
+    ) = CommitGraphNode(
+        sha = shortSha + "extended",
+        shortSha = shortSha,
+        shortMessage = shortMessage,
+        authorName = authorName,
+        authorEmail = authorEmail,
+        date = date(2024, 1, 1),
+        parentShas = emptyList(),
+    )
+
+    describe("CommitCard") {
+
+        describe("title") {
+            it("joins the short sha and the commit message") {
+                CommitCard.title(node(shortSha = "abc1234", shortMessage = "fix bug")) shouldBe "abc1234: fix bug"
+            }
+        }
+
+        describe("author") {
+            it("renders the author name and email") {
+                CommitCard.author(node(authorName = "Ada Lovelace", authorEmail = "ada@example.com")) shouldBe
+                    "Author: Ada Lovelace <ada@example.com>"
+            }
+        }
+
+        describe("date") {
+            it("prefixes with Date: and includes date, time and relative label") {
+                val commitDate = date(2024, 3, 5, 14, 30)
+                val now = date(2024, 3, 5, 18, 0)
+                CommitCard.date(commitDate, now) shouldBe "Date: 03/05/24, 2:30 PM Today"
+            }
+        }
+
+        describe("relative") {
+            val base = date(2024, 6, 15, 12, 0)
+
+            it("is Today for the same calendar day") {
+                CommitCard.relative(date(2024, 6, 15, 1, 0), base) shouldBe "Today"
+            }
+            it("is Today for a future date") {
+                CommitCard.relative(date(2024, 6, 16, 1, 0), base) shouldBe "Today"
+            }
+            it("is Yesterday for the previous calendar day") {
+                CommitCard.relative(date(2024, 6, 14, 23, 0), base) shouldBe "Yesterday"
+            }
+            it("counts whole days for less than a month") {
+                CommitCard.relative(date(2024, 6, 5, 12, 0), base) shouldBe "10 Days Ago"
+            }
+            it("counts whole months for less than a year") {
+                CommitCard.relative(date(2024, 2, 15, 12, 0), base) shouldBe "4 Months Ago"
+            }
+            it("counts whole years otherwise") {
+                CommitCard.relative(date(2021, 6, 15, 12, 0), base) shouldBe "3 Years Ago"
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
@@ -109,6 +109,49 @@ class MapStateSpec : DescribeSpec({
             }
         }
 
+        describe("node selection") {
+
+            it("starts with no node selected") {
+                MapState.reset()
+
+                MapState.selectedNodeSha.value shouldBe null
+            }
+
+            it("selects a node when toggled from empty") {
+                MapState.reset()
+
+                MapState.toggleSelectedNode("sha1")
+
+                MapState.selectedNodeSha.value shouldBe "sha1"
+            }
+
+            it("clears the selection when the same node is toggled again") {
+                MapState.reset()
+                MapState.toggleSelectedNode("sha1")
+
+                MapState.toggleSelectedNode("sha1")
+
+                MapState.selectedNodeSha.value shouldBe null
+            }
+
+            it("replaces the selection when a different node is toggled") {
+                MapState.reset()
+                MapState.toggleSelectedNode("sha1")
+
+                MapState.toggleSelectedNode("sha2")
+
+                MapState.selectedNodeSha.value shouldBe "sha2"
+            }
+
+            it("clears the selection on reset") {
+                MapState.toggleSelectedNode("sha1")
+
+                MapState.reset()
+
+                MapState.selectedNodeSha.value shouldBe null
+            }
+        }
+
         describe("a branch with more commits than one page") {
 
             val repo = createTestRepository().addFile("a.txt", "0").stageAll().commitAll("commit 0")
@@ -149,6 +192,7 @@ private fun dummyCommits(count: Int) = (1..count).map {
         shortSha = "sha$it",
         shortMessage = "commit $it",
         authorName = "author",
+        authorEmail = "author@example.com",
         date = Date(),
         parentShas = emptyList(),
     )


### PR DESCRIPTION
## What

Implements #252: on the map view, a commit node's sha and message are now
hidden by default to preserve space. Clicking a node toggles a floating
"dog-tag" detail card that starts over the node and extends to the right.

The card:
- is coloured the same as the node it describes (green circle / blue merge diamond),
- has a round tab holding a punched hole that sticks out a little farther than
  the rounded-rectangle body (the dog-tag shape),
- shows three lines:
  ```
  <short sha>: <commit message>
  Author: <name> <<email>>
  Date: MM/DD/YY, h:mm AM/PM <relative>
  ```
  where `<relative>` is the single most-relevant label
  (Today / Yesterday / X Days Ago / X Months Ago / X Years Ago).

## Changes
- `CommitGraphNode`: add `authorEmail` (extracted in `make`).
- `CommitCard`: new pure formatter for the three card lines + relative time,
  measured from local midnight so late-yesterday reads as "Yesterday".
- `MapState`: `selectedNodeSha` + `toggleSelectedNode`; cleared on `reset`.
- `MapView`: `CommitNode` hides labels, becomes clickable, and renders the new
  `CommitDetailCard`; the selected node draws above its neighbours.

## Tests
- `CommitCardSpec`: title/author/date lines and every relative-time bucket.
- `MapStateSpec`: node selection toggle/replace/clear semantics.

Note: this container has no JVM/gradle, so tests were not run locally — relying
on CI to validate. Reviewed by a subagent (APPROVE); date math verified robust
across timezones/DST for the asserted cases.

Closes #252