### PR TITLE
feat(map): add right-click context menu to commit nodes

### DIFF
--- a/src/main/kotlin/com/codymikol/components/menu/ThemedDropdownMenu.kt
+++ b/src/main/kotlin/com/codymikol/components/menu/ThemedDropdownMenu.kt
@@ -4,13 +4,18 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -45,5 +50,40 @@ fun ThemedDropdownMenuItem(
         modifier = modifier.background(if (isHovered) MenuColors.Highlight else MenuColors.Background)
     ) {
         Text(label, color = MenuColors.Text, fontSize = 12.sp)
+    }
+}
+
+/**
+ * A menu item that trails a dimmed keyboard-shortcut hint after its label, used
+ * by the map view's commit context menu (see issue #253).
+ */
+@Composable
+fun ThemedDropdownMenuItem(
+    label: String,
+    shortcut: String,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isHovered by interactionSource.collectIsHoveredAsState()
+
+    DropdownMenuItem(
+        onClick = onClick,
+        interactionSource = interactionSource,
+        modifier = modifier.background(if (isHovered) MenuColors.Highlight else MenuColors.Background)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(label, color = MenuColors.Text, fontSize = 12.sp)
+            Text(
+                shortcut,
+                color = MenuColors.Text.copy(alpha = 0.5f),
+                fontSize = 11.sp,
+                modifier = Modifier.padding(start = 24.dp),
+            )
+        }
     }
 }

--- a/src/main/kotlin/com/codymikol/data/map/CommitContextMenu.kt
+++ b/src/main/kotlin/com/codymikol/data/map/CommitContextMenu.kt
@@ -1,0 +1,57 @@
+package com.codymikol.data.map
+
+/**
+ * A single actionable entry in a commit node's right-click context menu (see
+ * issue #253): a human label plus the keyboard shortcut that will eventually
+ * trigger the same action. The concrete behaviours are wired up in follow-up
+ * issues; this model only describes the menu's shape.
+ */
+data class CommitContextMenuAction(
+    val label: String,
+    val shortcut: String,
+)
+
+/**
+ * The right-click context menu shown for a commit node in the map view. Actions
+ * are split into groups; a divider is drawn between each group when rendered.
+ * The grouping mirrors the divider layout described in issue #253.
+ */
+object CommitContextMenu {
+
+    val groups: List<List<CommitContextMenuAction>> = listOf(
+        listOf(
+            CommitContextMenuAction("Quick View", "Space"),
+        ),
+        listOf(
+            CommitContextMenuAction("Diff with HEAD...", "I"),
+        ),
+        listOf(
+            CommitContextMenuAction("Checkout Detached HEAD", "Enter"),
+        ),
+        listOf(
+            CommitContextMenuAction("Edit Message...", "E"),
+            CommitContextMenuAction("Fixup with Parent", "F"),
+            CommitContextMenuAction("Squash with Parent", "S"),
+            CommitContextMenuAction("Swap with Parent (Move Down)", "D"),
+            CommitContextMenuAction("Swap with Child (Move Up)", "U"),
+            CommitContextMenuAction("Delete", "Delete"),
+        ),
+        listOf(
+            CommitContextMenuAction("Rewrite...", "W"),
+            CommitContextMenuAction("Split...", "Ctrl S"),
+        ),
+        listOf(
+            CommitContextMenuAction("Revert Against Current Branch", "R"),
+            CommitContextMenuAction("Cherry-Pick Against Current Branch", "C"),
+            CommitContextMenuAction("Merge into Current Branch", "Ctrl M"),
+            CommitContextMenuAction("Rebase Current Branch onto Here", "Ctrl R"),
+            CommitContextMenuAction("Set Tip of Current Branch Here", "Ctrl T"),
+        ),
+        listOf(
+            CommitContextMenuAction("Add Tag", "T"),
+        ),
+        listOf(
+            CommitContextMenuAction("Create Branch", "B"),
+        ),
+    )
+}

--- a/src/main/kotlin/com/codymikol/state/MapState.kt
+++ b/src/main/kotlin/com/codymikol/state/MapState.kt
@@ -36,6 +36,16 @@ object MapState {
         selectedNodeSha.value = if (selectedNodeSha.value == sha) null else sha
     }
 
+    /**
+     * Selects a node outright, without the toggle-to-clear behaviour of
+     * toggleSelectedNode. Right-clicking a node opens its context menu and must
+     * always leave that node selected (see issue #253), even when it was already
+     * the selected node.
+     */
+    fun selectNode(sha: String) {
+        selectedNodeSha.value = sha
+    }
+
     val branches = derivedStateOf {
         GitDownState.git.value.listLocalBranches().sortedBy { it.name }
     }

--- a/src/main/kotlin/com/codymikol/views/MapView.kt
+++ b/src/main/kotlin/com/codymikol/views/MapView.kt
@@ -1,6 +1,8 @@
 package com.codymikol.views
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.PointerMatcher
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.Orientation
@@ -9,8 +11,10 @@ import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.onClick
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -31,6 +35,7 @@ import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
@@ -41,8 +46,12 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
+import com.codymikol.components.menu.MenuColors
+import com.codymikol.components.menu.ThemedDropdownMenu
+import com.codymikol.components.menu.ThemedDropdownMenuItem
 import com.codymikol.data.Colors
 import com.codymikol.data.map.CommitCard
+import com.codymikol.data.map.CommitContextMenu as CommitContextMenuModel
 import com.codymikol.data.map.CommitGraphNode
 import com.codymikol.state.GitDownState
 import com.codymikol.state.MapScrollState
@@ -263,6 +272,7 @@ private fun MapLaneTitle(branchName: String) {
 // The sha and commit message are hidden by default to preserve space (#252); the
 // node itself is the whole clickable target and its detail card only appears while
 // this node is selected.
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun CommitNode(
     commit: CommitGraphNode,
@@ -272,6 +282,8 @@ private fun CommitNode(
     showTrailingGuideline: Boolean,
     modifier: Modifier = Modifier,
 ) {
+    var menuExpanded by remember { mutableStateOf(false) }
+
     Box(
         modifier = modifier
             .fillMaxWidth()
@@ -280,6 +292,12 @@ private fun CommitNode(
             // than one row, floats over the neighbouring nodes rather than under them.
             .zIndex(if (isSelected) 1f else 0f)
             .clickable { onClick() }
+            // Right-clicking opens the context menu and always leaves this node
+            // selected (see issue #253) - selectNode, not the click toggle.
+            .onClick(matcher = PointerMatcher.mouse(PointerButton.Secondary)) {
+                MapState.selectNode(commit.sha)
+                menuExpanded = true
+            }
             .drawBehind { drawCommitNode(commit, showLeadingGuideline, showTrailingGuideline) }
     ) {
         if (isSelected) {
@@ -290,6 +308,36 @@ private fun CommitNode(
                     .align(Alignment.CenterStart)
                     .padding(start = GutterX - CardTabSize / 2)
             )
+        }
+
+        CommitContextMenu(
+            expanded = menuExpanded,
+            onDismiss = { menuExpanded = false },
+        )
+    }
+}
+
+// The right-click context menu for a commit node (#253). Its actions are grouped
+// by CommitContextMenu, with a divider drawn between each group; concrete
+// behaviours are wired up in follow-up issues, so items only dismiss for now.
+@Composable
+private fun CommitContextMenu(
+    expanded: Boolean,
+    onDismiss: () -> Unit,
+) {
+    ThemedDropdownMenu(
+        expanded = expanded,
+        onDismissRequest = onDismiss,
+    ) {
+        CommitContextMenuModel.groups.forEachIndexed { index, group ->
+            if (index > 0) Divider(color = MenuColors.Divider)
+            group.forEach { action ->
+                ThemedDropdownMenuItem(
+                    label = action.label,
+                    shortcut = action.shortcut,
+                    onClick = onDismiss,
+                )
+            }
         }
     }
 }

--- a/src/test/kotlin/com/codymikol/data/map/CommitContextMenuSpec.kt
+++ b/src/test/kotlin/com/codymikol/data/map/CommitContextMenuSpec.kt
@@ -1,0 +1,53 @@
+package com.codymikol.data.map
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+
+class CommitContextMenuSpec : DescribeSpec({
+
+    describe("CommitContextMenu") {
+
+        it("groups every action as laid out in the issue spec") {
+            val labelsByGroup = CommitContextMenu.groups.map { group -> group.map { it.label } }
+
+            labelsByGroup shouldContainExactly listOf(
+                listOf("Quick View"),
+                listOf("Diff with HEAD..."),
+                listOf("Checkout Detached HEAD"),
+                listOf(
+                    "Edit Message...",
+                    "Fixup with Parent",
+                    "Squash with Parent",
+                    "Swap with Parent (Move Down)",
+                    "Swap with Child (Move Up)",
+                    "Delete",
+                ),
+                listOf("Rewrite...", "Split..."),
+                listOf(
+                    "Revert Against Current Branch",
+                    "Cherry-Pick Against Current Branch",
+                    "Merge into Current Branch",
+                    "Rebase Current Branch onto Here",
+                    "Set Tip of Current Branch Here",
+                ),
+                listOf("Add Tag"),
+                listOf("Create Branch"),
+            )
+        }
+
+        it("pairs each action with its keyboard shortcut") {
+            val actions = CommitContextMenu.groups.flatten().associate { it.label to it.shortcut }
+
+            actions["Quick View"] shouldBe "Space"
+            actions["Diff with HEAD..."] shouldBe "I"
+            actions["Checkout Detached HEAD"] shouldBe "Enter"
+            actions["Delete"] shouldBe "Delete"
+            actions["Split..."] shouldBe "Ctrl S"
+            actions["Merge into Current Branch"] shouldBe "Ctrl M"
+            actions["Rebase Current Branch onto Here"] shouldBe "Ctrl R"
+            actions["Set Tip of Current Branch Here"] shouldBe "Ctrl T"
+            actions["Create Branch"] shouldBe "B"
+        }
+    }
+})

--- a/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
@@ -150,6 +150,32 @@ class MapStateSpec : DescribeSpec({
 
                 MapState.selectedNodeSha.value shouldBe null
             }
+
+            it("selects a node when explicitly selected") {
+                MapState.reset()
+
+                MapState.selectNode("sha1")
+
+                MapState.selectedNodeSha.value shouldBe "sha1"
+            }
+
+            it("keeps a node selected when it is selected again") {
+                MapState.reset()
+                MapState.selectNode("sha1")
+
+                MapState.selectNode("sha1")
+
+                MapState.selectedNodeSha.value shouldBe "sha1"
+            }
+
+            it("replaces the selection when a different node is selected") {
+                MapState.reset()
+                MapState.selectNode("sha1")
+
+                MapState.selectNode("sha2")
+
+                MapState.selectedNodeSha.value shouldBe "sha2"
+            }
         }
 
         describe("a branch with more commits than one page") {


### PR DESCRIPTION
Closes #253

Right-clicking a commit node in the map view now selects that node and
opens a themed dropdown context menu.

## Changes
- `MapState.selectNode(sha)` — selects a node outright (no toggle-to-clear),
  so right-clicking an already-selected node keeps it selected.
- `CommitContextMenu` data model — the grouped actions and keyboard-shortcut
  hints from the issue spec, as a plain testable value.
- `ThemedDropdownMenuItem(label, shortcut, …)` overload — renders a dimmed
  trailing shortcut hint alongside the label.
- `CommitNode` wiring — a secondary-button `Modifier.onClick` selects the node
  and expands a `ThemedDropdownMenu` listing the groups with dividers between them.

## Scope
Concrete action behaviours (Diff, Checkout, Rebase, …) are intentionally
deferred to follow-up issues per the issue text; menu items currently only
dismiss the menu. Left-click selection is unchanged.

## Tests
- `CommitContextMenuSpec` — asserts exact grouping and shortcut pairings.
- `MapStateSpec` — adds `selectNode` cases (always-selects, keeps selection
  on repeat, replaces on a different node).

Note: no JVM/gradle in the local sandbox (read-only nix store), so checks
were validated by review and rely on CI (`./gradlew build`).