### PR TITLE
fix(map): show one commit preview per clicked node

### DIFF
--- a/src/main/kotlin/com/codymikol/state/MapState.kt
+++ b/src/main/kotlin/com/codymikol/state/MapState.kt
@@ -26,14 +26,20 @@ object MapState {
     val hasMoreByBranch = mutableStateMapOf<String, Boolean>()
 
     /**
-     * Sha of the commit node whose detail card is currently shown, or null when no
-     * node is selected. Node sha/message text is hidden in the map until a node is
-     * clicked (see issue #252); clicking toggles this selection.
+     * The commit node whose detail card is currently shown, or null when no node is
+     * selected. Node sha/message text is hidden in the map until a node is clicked
+     * (see issue #252); clicking toggles this selection.
+     *
+     * Identity is (branchName, sha), not sha alone: a commit reachable from several
+     * branches is drawn once per lane, so keying selection on sha lit every lane's
+     * copy at once. Keying on the lane too means only the clicked node's card shows -
+     * never more than one at a time (see issue #263).
      */
-    val selectedNodeSha = mutableStateOf<String?>(null)
+    val selectedNode = mutableStateOf<SelectedNode?>(null)
 
-    fun toggleSelectedNode(sha: String) {
-        selectedNodeSha.value = if (selectedNodeSha.value == sha) null else sha
+    fun toggleSelectedNode(branchName: String, sha: String) {
+        val target = SelectedNode(branchName, sha)
+        selectedNode.value = if (selectedNode.value == target) null else target
     }
 
     /**
@@ -42,9 +48,16 @@ object MapState {
      * always leave that node selected (see issue #253), even when it was already
      * the selected node.
      */
-    fun selectNode(sha: String) {
-        selectedNodeSha.value = sha
+    fun selectNode(branchName: String, sha: String) {
+        selectedNode.value = SelectedNode(branchName, sha)
     }
+
+    /**
+     * True only for the one rendered node matching the current selection's lane and
+     * sha, so lanes sharing a sha never light up together (see issue #263).
+     */
+    fun isNodeSelected(branchName: String, sha: String): Boolean =
+        selectedNode.value == SelectedNode(branchName, sha)
 
     val branches = derivedStateOf {
         GitDownState.git.value.listLocalBranches().sortedBy { it.name }
@@ -79,6 +92,13 @@ object MapState {
         walkers.clear()
         commitsByBranch.clear()
         hasMoreByBranch.clear()
-        selectedNodeSha.value = null
+        selectedNode.value = null
     }
 }
+
+/**
+ * Identity of a selected commit node: its lane (branchName) plus its sha. Two
+ * branches can hold the same commit, so the sha alone does not identify which
+ * rendered node is selected (see issue #263).
+ */
+data class SelectedNode(val branchName: String, val sha: String)

--- a/src/main/kotlin/com/codymikol/views/MapView.kt
+++ b/src/main/kotlin/com/codymikol/views/MapView.kt
@@ -1,10 +1,15 @@
 package com.codymikol.views
 
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.PointerMatcher
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.rememberScrollableState
 import androidx.compose.foundation.gestures.scrollable
@@ -73,6 +78,12 @@ private val CardTabSize = 22.dp
 private val CardHoleSize = 8.dp
 private val CardCorner = 10.dp
 private val CardMaxWidth = 150.dp
+
+// The node itself signals interaction (#263): it grows a little while hovered and
+// shrinks below its resting size while pressed, instead of a background wash. Both
+// ends are driven through animateFloatAsState so the change is animated.
+private const val HoveredNodeScale = 1.4f
+private const val PressedNodeScale = 0.7f
 
 // Every lane's title sits in a fixed-height box so all lanes' graphs start at the
 // same y-offset below the titles, regardless of how long each branch name is.
@@ -286,6 +297,18 @@ private fun CommitNode(
 ) {
     var menuExpanded by remember { mutableStateOf(false) }
 
+    val interactionSource = remember { MutableInteractionSource() }
+    val isHovered by interactionSource.collectIsHoveredAsState()
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val nodeScale by animateFloatAsState(
+        targetValue = when {
+            isPressed -> PressedNodeScale
+            isHovered -> HoveredNodeScale
+            else -> 1f
+        },
+        label = "commitNodeScale",
+    )
+
     Box(
         modifier = modifier
             .fillMaxWidth()
@@ -293,14 +316,18 @@ private fun CommitNode(
             // The selected node draws above its siblings so its card, which is taller
             // than one row, floats over the neighbouring nodes rather than under them.
             .zIndex(if (isSelected) 1f else 0f)
-            .clickable { onClick() }
+            .hoverable(interactionSource)
+            // indication = null drops the default ripple/hover background wash so only
+            // the node graphic reacts to hover and press (see issue #263); the scale is
+            // applied when the node is drawn, below.
+            .clickable(interactionSource = interactionSource, indication = null) { onClick() }
             // Right-clicking opens the context menu and always leaves this node
             // selected (see issue #253) - selectNode, not the click toggle.
             .onClick(matcher = PointerMatcher.mouse(PointerButton.Secondary)) {
                 MapState.selectNode(branchName, commit.sha)
                 menuExpanded = true
             }
-            .drawBehind { drawCommitNode(commit, showLeadingGuideline, showTrailingGuideline) }
+            .drawBehind { drawCommitNode(commit, nodeScale, showLeadingGuideline, showTrailingGuideline) }
     ) {
         if (isSelected) {
             CommitDetailCard(
@@ -407,6 +434,7 @@ private fun nodeColor(commit: CommitGraphNode): Color =
 
 private fun DrawScope.drawCommitNode(
     commit: CommitGraphNode,
+    scale: Float,
     showLeadingGuideline: Boolean,
     showTrailingGuideline: Boolean,
 ) {
@@ -426,9 +454,13 @@ private fun DrawScope.drawCommitNode(
         )
     }
 
+    // Only the node graphic scales with hover/press, so the row's click target and
+    // any detail card stay put while the node itself grows or shrinks (see issue #263).
+    val radius = NodeRadius.toPx() * scale
+
     when (commit.isMergeCommit) {
-        true -> drawDiamond(center = Offset(x, centerY), radius = NodeRadius.toPx(), color = nodeColor(commit))
-        false -> drawCircle(color = nodeColor(commit), radius = NodeRadius.toPx(), center = Offset(x, centerY))
+        true -> drawDiamond(center = Offset(x, centerY), radius = radius, color = nodeColor(commit))
+        false -> drawCircle(color = nodeColor(commit), radius = radius, center = Offset(x, centerY))
     }
 }
 

--- a/src/main/kotlin/com/codymikol/views/MapView.kt
+++ b/src/main/kotlin/com/codymikol/views/MapView.kt
@@ -218,8 +218,9 @@ private fun BranchLane(branch: Ref, rowHeightPx: Float, viewportHeightPx: Float)
                 key(commit.sha) {
                     CommitNode(
                         commit = commit,
-                        isSelected = MapState.selectedNodeSha.value == commit.sha,
-                        onClick = { MapState.toggleSelectedNode(commit.sha) },
+                        branchName = branch.name,
+                        isSelected = MapState.isNodeSelected(branch.name, commit.sha),
+                        onClick = { MapState.toggleSelectedNode(branch.name, commit.sha) },
                         showLeadingGuideline = false,
                         showTrailingGuideline = false,
                         modifier = Modifier.offset { IntOffset(0, yOffsetPx) },
@@ -276,6 +277,7 @@ private fun MapLaneTitle(branchName: String) {
 @Composable
 private fun CommitNode(
     commit: CommitGraphNode,
+    branchName: String,
     isSelected: Boolean,
     onClick: () -> Unit,
     showLeadingGuideline: Boolean,
@@ -295,7 +297,7 @@ private fun CommitNode(
             // Right-clicking opens the context menu and always leaves this node
             // selected (see issue #253) - selectNode, not the click toggle.
             .onClick(matcher = PointerMatcher.mouse(PointerButton.Secondary)) {
-                MapState.selectNode(commit.sha)
+                MapState.selectNode(branchName, commit.sha)
                 menuExpanded = true
             }
             .drawBehind { drawCommitNode(commit, showLeadingGuideline, showTrailingGuideline) }

--- a/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
@@ -114,67 +114,96 @@ class MapStateSpec : DescribeSpec({
             it("starts with no node selected") {
                 MapState.reset()
 
-                MapState.selectedNodeSha.value shouldBe null
+                MapState.selectedNode.value shouldBe null
             }
 
             it("selects a node when toggled from empty") {
                 MapState.reset()
 
-                MapState.toggleSelectedNode("sha1")
+                MapState.toggleSelectedNode("refs/heads/main", "sha1")
 
-                MapState.selectedNodeSha.value shouldBe "sha1"
+                MapState.selectedNode.value shouldBe SelectedNode("refs/heads/main", "sha1")
             }
 
             it("clears the selection when the same node is toggled again") {
                 MapState.reset()
-                MapState.toggleSelectedNode("sha1")
+                MapState.toggleSelectedNode("refs/heads/main", "sha1")
 
-                MapState.toggleSelectedNode("sha1")
+                MapState.toggleSelectedNode("refs/heads/main", "sha1")
 
-                MapState.selectedNodeSha.value shouldBe null
+                MapState.selectedNode.value shouldBe null
             }
 
             it("replaces the selection when a different node is toggled") {
                 MapState.reset()
-                MapState.toggleSelectedNode("sha1")
+                MapState.toggleSelectedNode("refs/heads/main", "sha1")
 
-                MapState.toggleSelectedNode("sha2")
+                MapState.toggleSelectedNode("refs/heads/main", "sha2")
 
-                MapState.selectedNodeSha.value shouldBe "sha2"
+                MapState.selectedNode.value shouldBe SelectedNode("refs/heads/main", "sha2")
             }
 
             it("clears the selection on reset") {
-                MapState.toggleSelectedNode("sha1")
+                MapState.toggleSelectedNode("refs/heads/main", "sha1")
 
                 MapState.reset()
 
-                MapState.selectedNodeSha.value shouldBe null
+                MapState.selectedNode.value shouldBe null
             }
 
             it("selects a node when explicitly selected") {
                 MapState.reset()
 
-                MapState.selectNode("sha1")
+                MapState.selectNode("refs/heads/main", "sha1")
 
-                MapState.selectedNodeSha.value shouldBe "sha1"
+                MapState.selectedNode.value shouldBe SelectedNode("refs/heads/main", "sha1")
             }
 
             it("keeps a node selected when it is selected again") {
                 MapState.reset()
-                MapState.selectNode("sha1")
+                MapState.selectNode("refs/heads/main", "sha1")
 
-                MapState.selectNode("sha1")
+                MapState.selectNode("refs/heads/main", "sha1")
 
-                MapState.selectedNodeSha.value shouldBe "sha1"
+                MapState.selectedNode.value shouldBe SelectedNode("refs/heads/main", "sha1")
             }
 
             it("replaces the selection when a different node is selected") {
                 MapState.reset()
-                MapState.selectNode("sha1")
+                MapState.selectNode("refs/heads/main", "sha1")
 
-                MapState.selectNode("sha2")
+                MapState.selectNode("refs/heads/main", "sha2")
 
-                MapState.selectedNodeSha.value shouldBe "sha2"
+                MapState.selectedNode.value shouldBe SelectedNode("refs/heads/main", "sha2")
+            }
+
+            // Regression for #263: a commit reachable from two branches renders once
+            // per lane, but selection was keyed on sha alone, so clicking one lane's
+            // node lit every lane's copy. Identity must be per (branch, sha) so only
+            // the clicked node's preview shows - never more than one at a time.
+            it("selects only the clicked lane's node when two branches share a sha") {
+                MapState.reset()
+
+                MapState.selectNode("refs/heads/feature", "shared-sha")
+
+                MapState.isNodeSelected("refs/heads/feature", "shared-sha") shouldBe true
+                MapState.isNodeSelected("refs/heads/main", "shared-sha") shouldBe false
+            }
+
+            it("reports no node selected for isNodeSelected when selection is empty") {
+                MapState.reset()
+
+                MapState.isNodeSelected("refs/heads/main", "sha1") shouldBe false
+            }
+
+            it("toggling a same-sha node in another lane moves the selection across lanes") {
+                MapState.reset()
+                MapState.toggleSelectedNode("refs/heads/main", "shared-sha")
+
+                MapState.toggleSelectedNode("refs/heads/feature", "shared-sha")
+
+                MapState.isNodeSelected("refs/heads/main", "shared-sha") shouldBe false
+                MapState.isNodeSelected("refs/heads/feature", "shared-sha") shouldBe true
             }
         }
 


### PR DESCRIPTION
## What

Fixes the map view's click display bugs where clicking a commit node lit
every lane's copy of that commit at once.

### Primary bug — never more than one preview

A commit reachable from several branches is drawn once per lane, but node
selection was keyed on the sha alone (`selectedNodeSha`). Clicking one
lane's node therefore matched — and popped a preview card over — every
lane holding that sha.

Selection is now keyed on a `SelectedNode(branchName, sha)` identity via
`isNodeSelected(branchName, sha)`, so only the clicked node's card shows —
never more than one at a time. `toggleSelectedNode` / `selectNode` take the
lane too; `reset()` still clears. Covered by new `MapStateSpec` cases,
including a duplicate-sha-across-branches regression test.

### Requirement (c) — node reacts, not the background

Dropped the default `clickable` indication (the background hover/press
wash) and instead animate the node graphic itself: it grows slightly while
hovered and shrinks below its resting size while pressed, via
`animateFloatAsState`. The scale is applied only to the drawn node radius,
so the row's click target and the detail card stay put.

## Deferred (follow-ups)

Requirements a, b, d, e are larger rendering/graph-layout changes and are
not included here:
- a/b) popover as a map-level overlay that escapes lane clipping, stretches
  to its contents, and leaves a neck so the node isn't covered — needs a
  `Popup`/overlay refactor of the lane's `clipToBounds`.
- d/e) parent/merge connection lines and lateral merge-node layout — a real
  commit-graph rendering feature spanning lanes.

These warrant their own scoped issue and visual verification.

## Testing

The build/test environment here has no JDK and a read-only nix store, so the
Kotlin/Compose suite could not be run locally; correctness was verified
statically and the change relies on CI. Compose UI behavior (animation,
rendering) is not unit-testable.

Closes #263