### PR TITLE
feat: implement a quick view

### DIFF
--- a/src/main/kotlin/com/codymikol/data/map/CommitCard.kt
+++ b/src/main/kotlin/com/codymikol/data/map/CommitCard.kt
@@ -1,7 +1,7 @@
 package com.codymikol.data.map
 
+import com.codymikol.services.RelativeDateTime
 import java.text.SimpleDateFormat
-import java.util.Calendar
 import java.util.Date
 
 /**
@@ -13,13 +13,9 @@ import java.util.Date
  *   Date: MM/DD/YY, h:mm AM/PM <relative>
  *
  * where <relative> is the single most-relevant human label for how long ago the
- * commit was authored (Today / Yesterday / X Days Ago / X Months Ago / X Years Ago).
+ * commit was authored, supplied by [RelativeDateTime].
  */
 object CommitCard {
-
-    private const val MILLIS_PER_DAY = 1000L * 60 * 60 * 24
-    private const val DAYS_PER_MONTH = 30
-    private const val DAYS_PER_YEAR = 365
 
     fun title(node: CommitGraphNode): String = "${node.shortSha}: ${node.shortMessage}"
 
@@ -28,36 +24,6 @@ object CommitCard {
     fun date(date: Date, now: Date): String {
         val datePart = SimpleDateFormat("MM/dd/yy").format(date)
         val timePart = SimpleDateFormat("h:mm a").format(date)
-        return "Date: $datePart, $timePart ${relative(date, now)}"
+        return "Date: $datePart, $timePart ${RelativeDateTime.relative(date, now)}"
     }
-
-    fun relative(date: Date, now: Date): String {
-        val days = calendarDaysBetween(date, now)
-        return when {
-            days <= 0L -> "Today"
-            days == 1L -> "Yesterday"
-            days < DAYS_PER_MONTH -> "$days Days Ago"
-            days < DAYS_PER_YEAR -> "${days / DAYS_PER_MONTH} Months Ago"
-            else -> "${days / DAYS_PER_YEAR} Years Ago"
-        }
-    }
-
-    /**
-     * Whole calendar days from [from] to [to], measured from local midnight so that
-     * a commit made late yesterday and a check made early today read as "Yesterday"
-     * rather than collapsing to a sub-24h "Today".
-     */
-    private fun calendarDaysBetween(from: Date, to: Date): Long {
-        val fromMidnight = atMidnight(from)
-        val toMidnight = atMidnight(to)
-        return (toMidnight - fromMidnight) / MILLIS_PER_DAY
-    }
-
-    private fun atMidnight(date: Date): Long = Calendar.getInstance().apply {
-        time = date
-        set(Calendar.HOUR_OF_DAY, 0)
-        set(Calendar.MINUTE, 0)
-        set(Calendar.SECOND, 0)
-        set(Calendar.MILLISECOND, 0)
-    }.timeInMillis
 }

--- a/src/main/kotlin/com/codymikol/data/map/QuickViewCommitDetails.kt
+++ b/src/main/kotlin/com/codymikol/data/map/QuickViewCommitDetails.kt
@@ -1,0 +1,31 @@
+package com.codymikol.data.map
+
+import com.codymikol.services.RelativeDateTime
+import java.text.SimpleDateFormat
+import java.util.Date
+
+/**
+ * Formats the lines shown in the quick view's left panel (see issue #254):
+ *
+ *   <full sha>
+ *   <commit message>
+ *   <committer name> <<email>>
+ *   MM/DD/YY, h:mm AM/PM <relative>
+ *
+ * Unlike CommitCard this exposes the full sha and drops the "Author:" / "Date:"
+ * prefixes, since the quick view lays each value out on its own line.
+ */
+object QuickViewCommitDetails {
+
+    fun hash(node: CommitGraphNode): String = node.sha
+
+    fun message(node: CommitGraphNode): String = node.shortMessage
+
+    fun committer(node: CommitGraphNode): String = "${node.authorName} <${node.authorEmail}>"
+
+    fun date(date: Date, now: Date): String {
+        val datePart = SimpleDateFormat("MM/dd/yy").format(date)
+        val timePart = SimpleDateFormat("h:mm a").format(date)
+        return "$datePart, $timePart ${RelativeDateTime.relative(date, now)}"
+    }
+}

--- a/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
+++ b/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
@@ -23,6 +23,7 @@ import org.eclipse.jgit.dircache.DirCacheEditor
 import org.eclipse.jgit.dircache.DirCacheEntry
 import org.eclipse.jgit.dircache.DirCacheIterator
 import org.eclipse.jgit.errors.LockFailedException
+import org.eclipse.jgit.lib.AnyObjectId
 import org.eclipse.jgit.lib.Constants.OBJ_BLOB
 import org.eclipse.jgit.lib.FileMode
 import org.eclipse.jgit.lib.Ref
@@ -77,9 +78,28 @@ fun Git.listLocalBranches(): List<Ref> = try {
     emptyList()
 }
 
-fun Git.getStashDiff(stash: RevCommit): List<FileDelta> = try {
+fun Git.getStashDiff(stash: RevCommit): List<FileDelta> = diffAgainstFirstParent(stash)
+
+/**
+ * The file deltas a commit introduces relative to its first parent, resolved from
+ * [sha] (any ref or object-id string jgit can resolve). Backs the quick view (see
+ * issue #254). An unresolvable or parentless commit yields an empty diff.
+ */
+fun Git.getCommitDiff(sha: String): List<FileDelta> {
+    val id = this.repository.resolve(sha) ?: return emptyList()
+    return diffAgainstFirstParent(id)
+}
+
+/**
+ * The file deltas introduced by [id] relative to its first parent, each carrying
+ * pre-formatted diff text. The read-only Stash.File* carriers are reused since a
+ * committed diff has no working-tree or index backing to stage against - exactly
+ * the shape Status.STASH already models. A parentless (root) commit yields no
+ * deltas.
+ */
+private fun Git.diffAgainstFirstParent(id: AnyObjectId): List<FileDelta> = try {
     RevWalk(this.repository).use { walk ->
-        val commit = walk.parseCommit(stash)
+        val commit = walk.parseCommit(id)
 
         when (commit.parentCount > 0) {
             false -> emptyList()
@@ -112,7 +132,7 @@ fun Git.getStashDiff(stash: RevCommit): List<FileDelta> = try {
         }
     }
 } catch (e: Exception) {
-    logger.error("An exception was thrown while diffing a stash: ${e.message}")
+    logger.error("An exception was thrown while diffing against the first parent: ${e.message}")
     emptyList()
 }
 

--- a/src/main/kotlin/com/codymikol/services/RelativeDateTime.kt
+++ b/src/main/kotlin/com/codymikol/services/RelativeDateTime.kt
@@ -1,0 +1,49 @@
+package com.codymikol.services
+
+import java.util.Calendar
+import java.util.Date
+
+/**
+ * The single most-relevant human label for how long ago [date] was, measured
+ * against [now]: Today / Yesterday / X Days Ago / X Months Ago / X Years Ago.
+ *
+ * Extracted out of CommitCard (see issue #254) so any view - the commit detail
+ * card, the quick view, and future surfaces - can render the same relative
+ * timestamp from one place.
+ */
+object RelativeDateTime {
+
+    private const val MILLIS_PER_DAY = 1000L * 60 * 60 * 24
+    private const val DAYS_PER_MONTH = 30
+    private const val DAYS_PER_YEAR = 365
+
+    fun relative(date: Date, now: Date): String {
+        val days = calendarDaysBetween(date, now)
+        return when {
+            days <= 0L -> "Today"
+            days == 1L -> "Yesterday"
+            days < DAYS_PER_MONTH -> "$days Days Ago"
+            days < DAYS_PER_YEAR -> "${days / DAYS_PER_MONTH} Months Ago"
+            else -> "${days / DAYS_PER_YEAR} Years Ago"
+        }
+    }
+
+    /**
+     * Whole calendar days from [from] to [to], measured from local midnight so that
+     * a commit made late yesterday and a check made early today read as "Yesterday"
+     * rather than collapsing to a sub-24h "Today".
+     */
+    private fun calendarDaysBetween(from: Date, to: Date): Long {
+        val fromMidnight = atMidnight(from)
+        val toMidnight = atMidnight(to)
+        return (toMidnight - fromMidnight) / MILLIS_PER_DAY
+    }
+
+    private fun atMidnight(date: Date): Long = Calendar.getInstance().apply {
+        time = date
+        set(Calendar.HOUR_OF_DAY, 0)
+        set(Calendar.MINUTE, 0)
+        set(Calendar.SECOND, 0)
+        set(Calendar.MILLISECOND, 0)
+    }.timeInMillis
+}

--- a/src/main/kotlin/com/codymikol/state/MapState.kt
+++ b/src/main/kotlin/com/codymikol/state/MapState.kt
@@ -46,6 +46,17 @@ object MapState {
         selectedNodeSha.value = sha
     }
 
+    /**
+     * The full node for the currently selected sha, looked up across every loaded
+     * branch, or null when nothing is selected (or the node has scrolled out of the
+     * loaded window). Used to launch the quick view (see issue #254) for the node
+     * the user selected in the map.
+     */
+    fun selectedNode(): CommitGraphNode? {
+        val sha = selectedNodeSha.value ?: return null
+        return commitsByBranch.values.asSequence().flatten().firstOrNull { it.sha == sha }
+    }
+
     val branches = derivedStateOf {
         GitDownState.git.value.listLocalBranches().sortedBy { it.name }
     }

--- a/src/main/kotlin/com/codymikol/state/state.kt
+++ b/src/main/kotlin/com/codymikol/state/state.kt
@@ -6,7 +6,9 @@ import com.codymikol.data.file.FileDelta
 import com.codymikol.data.file.Index
 import com.codymikol.data.file.Status
 import com.codymikol.data.file.WorkingDirectory
+import com.codymikol.data.map.CommitGraphNode
 import com.codymikol.data.stash.StashListItem
+import com.codymikol.extensions.getCommitDiff
 import com.codymikol.extensions.getCurrentRefCommitCount
 import com.codymikol.extensions.getStashDiff
 import com.codymikol.extensions.getStashes
@@ -77,6 +79,19 @@ object GitDownState {
     }
 
     val selectedStash = mutableStateOf<StashListItem?>(null)
+
+    // The commit the quick view (see issue #254) is launched against, or null when
+    // the quick view is closed. Held here rather than read from MapState so the view
+    // survives the map scrolling or resetting out from under it.
+    val quickViewCommit = mutableStateOf<CommitGraphNode?>(null)
+
+    val quickViewDiffTree = derivedStateOf {
+        DiffTree.make(quickViewCommit.value?.let { git.value.getCommitDiff(it.sha) } ?: emptyList())
+    }
+
+    // The tab to return to when the quick view is dismissed. Only captured on the way
+    // in so reopening the quick view for a different commit keeps the original.
+    private var tabBeforeQuickView: Tab = Tab.Map
 
     val stashDiffTree = derivedStateOf {
         DiffTree.make(selectedStash.value?.let { git.value.getStashDiff(it.revCommit) } ?: emptyList())
@@ -184,6 +199,22 @@ object GitDownState {
             val firstFile = workingDirectory.value.firstOrNull() ?: index.value.firstOrNull()
             firstFile?.let { selectedFiles.add(it) }
         }
+    }
+
+    /**
+     * Launches the quick view (see issue #254) against [commit], remembering the tab
+     * to return to on close.
+     */
+    fun openQuickView(commit: CommitGraphNode) {
+        if (currentTab.value != Tab.QuickView) tabBeforeQuickView = currentTab.value
+        quickViewCommit.value = commit
+        selectTab(Tab.QuickView)
+    }
+
+    /** Closes the quick view, clearing its commit and restoring the prior tab. */
+    fun closeQuickView() {
+        quickViewCommit.value = null
+        selectTab(tabBeforeQuickView)
     }
 
     fun selectAdjacentFile(offset: Int) {

--- a/src/main/kotlin/com/codymikol/tabs/Tab.kt
+++ b/src/main/kotlin/com/codymikol/tabs/Tab.kt
@@ -4,4 +4,9 @@ sealed class Tab {
     object Commit : Tab()
     object Stash : Tab()
     object Map : Tab()
+
+    // Launched against a specific commit rather than reached from the tab bar; the
+    // quick view (see issue #254) is an ephemeral overlay that restores the prior
+    // tab when dismissed.
+    object QuickView : Tab()
 }

--- a/src/main/kotlin/com/codymikol/views/MapView.kt
+++ b/src/main/kotlin/com/codymikol/views/MapView.kt
@@ -311,6 +311,7 @@ private fun CommitNode(
         }
 
         CommitContextMenu(
+            commit = commit,
             expanded = menuExpanded,
             onDismiss = { menuExpanded = false },
         )
@@ -318,10 +319,12 @@ private fun CommitNode(
 }
 
 // The right-click context menu for a commit node (#253). Its actions are grouped
-// by CommitContextMenu, with a divider drawn between each group; concrete
-// behaviours are wired up in follow-up issues, so items only dismiss for now.
+// by CommitContextMenu, with a divider drawn between each group. Quick View (#254)
+// launches the quick view for this commit; the remaining behaviours are wired up
+// in follow-up issues, so those items only dismiss for now.
 @Composable
 private fun CommitContextMenu(
+    commit: CommitGraphNode,
     expanded: Boolean,
     onDismiss: () -> Unit,
 ) {
@@ -335,7 +338,12 @@ private fun CommitContextMenu(
                 ThemedDropdownMenuItem(
                     label = action.label,
                     shortcut = action.shortcut,
-                    onClick = onDismiss,
+                    onClick = when (action.label) {
+                        "Quick View" -> {
+                            { GitDownState.openQuickView(commit); onDismiss() }
+                        }
+                        else -> onDismiss
+                    },
                 )
             }
         }

--- a/src/main/kotlin/com/codymikol/views/QuickView.kt
+++ b/src/main/kotlin/com/codymikol/views/QuickView.kt
@@ -1,0 +1,163 @@
+package com.codymikol.views
+
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.codymikol.components.Subheader
+import com.codymikol.components.commit.diff.Diff
+import com.codymikol.data.Colors
+import com.codymikol.data.map.CommitGraphNode
+import com.codymikol.data.map.QuickViewCommitDetails
+import com.codymikol.state.GitDownState
+import java.util.Date
+
+/**
+ * The quick view (see issue #254): an ephemeral overlay launched against a single
+ * commit. Its commit details sit on the left and the commit's diff (reusing the
+ * shared Diff component, read-only) on the right, mirroring the stash view layout.
+ */
+@Composable
+@Preview
+fun QuickView() {
+    Row(modifier = Modifier.fillMaxWidth().fillMaxHeight()) {
+        Column(
+            modifier = Modifier
+                .background(Colors.DarkGrayBackground)
+                .weight(40f)
+                .fillMaxHeight()
+                .border(width = 1.dp, color = Color.Black)
+        ) {
+            QuickViewDetailPanel()
+        }
+        Column(
+            modifier = Modifier
+                .weight(60f)
+                .fillMaxHeight()
+                .background(Colors.DarkGrayBackground)
+                .border(width = 1.dp, color = Color.Black)
+        ) {
+            QuickViewDiffPanel()
+        }
+    }
+}
+
+@Composable
+private fun ColumnScope.QuickViewDetailPanel() {
+    Subheader("Commit")
+    when (val commit = GitDownState.quickViewCommit.value) {
+        null -> QuickViewEmptyState("No commit selected")
+        else -> CommitDetails(commit)
+    }
+}
+
+@Composable
+private fun ColumnScope.CommitDetails(commit: CommitGraphNode) {
+    val now = remember(commit.sha) { Date() }
+
+    Column(
+        modifier = Modifier
+            .weight(1f)
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp)
+    ) {
+        Text(
+            text = QuickViewCommitDetails.hash(commit),
+            color = Colors.LightGrayText,
+            fontFamily = FontFamily.Monospace,
+            fontSize = 12.sp
+        )
+        Spacer(Modifier.height(12.dp))
+        Text(
+            text = QuickViewCommitDetails.message(commit),
+            color = Color.White,
+            fontWeight = FontWeight.Bold,
+            fontSize = 14.sp
+        )
+        Spacer(Modifier.height(12.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            CommitterAvatar(commit)
+            Spacer(Modifier.width(8.dp))
+            Text(
+                text = QuickViewCommitDetails.committer(commit),
+                color = Colors.LightGrayText,
+                fontSize = 12.sp
+            )
+        }
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = QuickViewCommitDetails.date(commit.date, now),
+            color = Colors.LightGrayText,
+            fontSize = 12.sp
+        )
+    }
+}
+
+// A small ASCII-initial avatar for the committer - the "<user ascii>" glyph the
+// issue calls for, drawn from the first letter of the committer's name.
+@Composable
+private fun CommitterAvatar(commit: CommitGraphNode) {
+    val initial = commit.authorName.trim().firstOrNull()?.uppercaseChar()?.toString() ?: "?"
+
+    Box(
+        modifier = Modifier.size(24.dp).clip(CircleShape).background(Colors.LightGrayBackground),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text = initial, color = Color.White, fontSize = 12.sp, fontWeight = FontWeight.Bold)
+    }
+}
+
+@Composable
+private fun QuickViewDiffPanel() = when (GitDownState.quickViewCommit.value) {
+    null -> Column { QuickViewEmptyState("No commit selected") }
+    else -> when (GitDownState.quickViewDiffTree.value.fileDeltaNodes.isNotEmpty()) {
+        true -> Diff(GitDownState.quickViewDiffTree.value.fileDeltaNodes, showActions = false)
+        false -> Column { QuickViewEmptyState("No changes in commit") }
+    }
+}
+
+@Composable
+private fun ColumnScope.QuickViewEmptyState(message: String) {
+    Column(
+        modifier = Modifier
+            .weight(1f)
+            .fillMaxWidth()
+            .fillMaxHeight(),
+        verticalArrangement = Arrangement.Center
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.CenterHorizontally),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Text(message, color = Color.Gray)
+        }
+    }
+}

--- a/src/main/kotlin/com/codymikol/windows/GitDown.kt
+++ b/src/main/kotlin/com/codymikol/windows/GitDown.kt
@@ -43,10 +43,12 @@ import com.codymikol.gitdown.generated.resources.stash_white
 import com.codymikol.services.WindowSizeService
 import com.codymikol.state.GitDownState
 import com.codymikol.state.Keys
+import com.codymikol.state.MapState
 import com.codymikol.tabs.Tab
 import com.codymikol.views.CommitView
 import com.codymikol.views.isCommitMessageFocused
 import com.codymikol.views.MapView
+import com.codymikol.views.QuickView
 import com.codymikol.views.StashView
 import org.jetbrains.compose.resources.painterResource
 import org.koin.java.KoinJavaComponent.inject
@@ -65,17 +67,38 @@ fun GitDown(applicationScope: ApplicationScope) {
             Keys.isShiftPressed.value = it.isShiftPressed
             Keys.isCtrlPressed.value = it.isCtrlPressed
 
-            val isFileSelectionArrow = it.type == KeyEventType.KeyDown &&
+            val isDown = it.type == KeyEventType.KeyDown
+            val tab = GitDownState.currentTab.value
+
+            val isFileSelectionArrow = isDown &&
                 (it.key == Key.DirectionUp || it.key == Key.DirectionDown) &&
-                GitDownState.currentTab.value == Tab.Commit &&
+                tab == Tab.Commit &&
                 !isCommitMessageFocused.value &&
                 GitDownState.selectedFiles.size == 1
 
-            if (isFileSelectionArrow) {
-                GitDownState.selectAdjacentFile(if (it.key == Key.DirectionUp) -1 else 1)
-                true
-            } else {
-                false
+            // Space on the map with a node selected launches the quick view (#254)
+            // against that node.
+            val quickViewTarget = if (isDown && it.key == Key.Spacebar && tab == Tab.Map)
+                MapState.selectedNode() else null
+
+            // Space or Escape closes the quick view while it is open.
+            val shouldCloseQuickView = isDown && tab == Tab.QuickView &&
+                (it.key == Key.Spacebar || it.key == Key.Escape)
+
+            when {
+                isFileSelectionArrow -> {
+                    GitDownState.selectAdjacentFile(if (it.key == Key.DirectionUp) -1 else 1)
+                    true
+                }
+                shouldCloseQuickView -> {
+                    GitDownState.closeQuickView()
+                    true
+                }
+                quickViewTarget != null -> {
+                    GitDownState.openQuickView(quickViewTarget)
+                    true
+                }
+                else -> false
             }
         },
         onCloseRequest = {
@@ -168,6 +191,7 @@ fun GitDown(applicationScope: ApplicationScope) {
                         Tab.Commit -> CommitView()
                         Tab.Map -> MapView()
                         Tab.Stash -> StashView()
+                        Tab.QuickView -> QuickView()
                     }
                 }
             }

--- a/src/test/kotlin/com/codymikol/data/map/CommitCardSpec.kt
+++ b/src/test/kotlin/com/codymikol/data/map/CommitCardSpec.kt
@@ -50,28 +50,5 @@ class CommitCardSpec : DescribeSpec({
                 CommitCard.date(commitDate, now) shouldBe "Date: 03/05/24, 2:30 PM Today"
             }
         }
-
-        describe("relative") {
-            val base = date(2024, 6, 15, 12, 0)
-
-            it("is Today for the same calendar day") {
-                CommitCard.relative(date(2024, 6, 15, 1, 0), base) shouldBe "Today"
-            }
-            it("is Today for a future date") {
-                CommitCard.relative(date(2024, 6, 16, 1, 0), base) shouldBe "Today"
-            }
-            it("is Yesterday for the previous calendar day") {
-                CommitCard.relative(date(2024, 6, 14, 23, 0), base) shouldBe "Yesterday"
-            }
-            it("counts whole days for less than a month") {
-                CommitCard.relative(date(2024, 6, 5, 12, 0), base) shouldBe "10 Days Ago"
-            }
-            it("counts whole months for less than a year") {
-                CommitCard.relative(date(2024, 2, 15, 12, 0), base) shouldBe "4 Months Ago"
-            }
-            it("counts whole years otherwise") {
-                CommitCard.relative(date(2021, 6, 15, 12, 0), base) shouldBe "3 Years Ago"
-            }
-        }
     }
 })

--- a/src/test/kotlin/com/codymikol/data/map/QuickViewCommitDetailsSpec.kt
+++ b/src/test/kotlin/com/codymikol/data/map/QuickViewCommitDetailsSpec.kt
@@ -1,0 +1,60 @@
+package com.codymikol.data.map
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.util.Calendar
+import java.util.Date
+
+class QuickViewCommitDetailsSpec : DescribeSpec({
+
+    fun date(year: Int, month: Int, day: Int, hour: Int = 12, minute: Int = 0): Date =
+        Calendar.getInstance().apply {
+            clear()
+            set(year, month - 1, day, hour, minute, 0)
+        }.time
+
+    fun node(
+        sha: String = "abc1234def5678",
+        shortMessage: String = "do a thing",
+        authorName: String = "Ada Lovelace",
+        authorEmail: String = "ada@example.com",
+    ) = CommitGraphNode(
+        sha = sha,
+        shortSha = sha.take(7),
+        shortMessage = shortMessage,
+        authorName = authorName,
+        authorEmail = authorEmail,
+        date = date(2024, 1, 1),
+        parentShas = emptyList(),
+    )
+
+    describe("QuickViewCommitDetails") {
+
+        describe("hash") {
+            it("is the commit's full sha") {
+                QuickViewCommitDetails.hash(node(sha = "abc1234def5678")) shouldBe "abc1234def5678"
+            }
+        }
+
+        describe("message") {
+            it("is the commit message") {
+                QuickViewCommitDetails.message(node(shortMessage = "fix bug")) shouldBe "fix bug"
+            }
+        }
+
+        describe("committer") {
+            it("renders the committer name and email") {
+                QuickViewCommitDetails.committer(node(authorName = "Ada Lovelace", authorEmail = "ada@example.com")) shouldBe
+                    "Ada Lovelace <ada@example.com>"
+            }
+        }
+
+        describe("date") {
+            it("renders date, time and relative label without a prefix") {
+                val commitDate = date(2024, 3, 5, 14, 30)
+                val now = date(2024, 3, 5, 18, 0)
+                QuickViewCommitDetails.date(commitDate, now) shouldBe "03/05/24, 2:30 PM Today"
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/codymikol/extensions/CommitDiffSpec.kt
+++ b/src/test/kotlin/com/codymikol/extensions/CommitDiffSpec.kt
@@ -1,0 +1,63 @@
+package com.codymikol.extensions
+
+import com.codymikol.data.diff.DiffTree
+import com.codymikol.data.diff.LineType
+import com.codymikol.repository.TestRepository.Companion.createTestRepository
+import com.codymikol.state.GitDownState
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+class CommitDiffSpec : DescribeSpec({
+
+    describe("Git.getCommitDiff") {
+
+        describe("a commit that modifies a single file") {
+
+            autoClose(
+                createTestRepository()
+                    .addFile("foo.txt", "one\n")
+                    .stageAll()
+                    .commitAll("init")
+                    .appendToFile("foo.txt", "two\n")
+                    .stageAll()
+                    .commitAll("add two")
+                    .transferIntoGitDownState()
+            )
+
+            val headSha = GitDownState.git.value.repository.resolve("HEAD").name
+
+            it("should contain a single file delta") {
+                GitDownState.git.value.getCommitDiff(headSha) shouldHaveSize 1
+            }
+
+            it("should expose the added line through the diff tree") {
+                val node = DiffTree.make(GitDownState.git.value.getCommitDiff(headSha))
+                    .fileDeltaNodes
+                    .single()
+
+                val addedValues = node.hunkNodes
+                    .flatMap { it.lineNodes }
+                    .filter { it.line.type == LineType.Added }
+                    .map { it.line.value }
+
+                addedValues shouldBe listOf("two")
+            }
+        }
+
+        describe("an unknown commit reference") {
+
+            autoClose(
+                createTestRepository()
+                    .addFile("init.txt", "init")
+                    .stageAll()
+                    .commitAll("init")
+                    .transferIntoGitDownState()
+            )
+
+            it("should produce an empty diff") {
+                GitDownState.git.value.getCommitDiff("does-not-exist") shouldHaveSize 0
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/codymikol/services/RelativeDateTimeSpec.kt
+++ b/src/test/kotlin/com/codymikol/services/RelativeDateTimeSpec.kt
@@ -1,0 +1,39 @@
+package com.codymikol.services
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.util.Calendar
+import java.util.Date
+
+class RelativeDateTimeSpec : DescribeSpec({
+
+    fun date(year: Int, month: Int, day: Int, hour: Int = 12, minute: Int = 0): Date =
+        Calendar.getInstance().apply {
+            clear()
+            set(year, month - 1, day, hour, minute, 0)
+        }.time
+
+    describe("RelativeDateTime.relative") {
+
+        val base = date(2024, 6, 15, 12, 0)
+
+        it("is Today for the same calendar day") {
+            RelativeDateTime.relative(date(2024, 6, 15, 1, 0), base) shouldBe "Today"
+        }
+        it("is Today for a future date") {
+            RelativeDateTime.relative(date(2024, 6, 16, 1, 0), base) shouldBe "Today"
+        }
+        it("is Yesterday for the previous calendar day") {
+            RelativeDateTime.relative(date(2024, 6, 14, 23, 0), base) shouldBe "Yesterday"
+        }
+        it("counts whole days for less than a month") {
+            RelativeDateTime.relative(date(2024, 6, 5, 12, 0), base) shouldBe "10 Days Ago"
+        }
+        it("counts whole months for less than a year") {
+            RelativeDateTime.relative(date(2024, 2, 15, 12, 0), base) shouldBe "4 Months Ago"
+        }
+        it("counts whole years otherwise") {
+            RelativeDateTime.relative(date(2021, 6, 15, 12, 0), base) shouldBe "3 Years Ago"
+        }
+    }
+})

--- a/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
@@ -176,6 +176,29 @@ class MapStateSpec : DescribeSpec({
 
                 MapState.selectedNodeSha.value shouldBe "sha2"
             }
+
+            it("resolves the selected node from the loaded commits") {
+                MapState.reset()
+                MapState.commitsByBranch["refs/heads/main"] = dummyCommits(3)
+                MapState.selectNode("sha2")
+
+                MapState.selectedNode()?.shortMessage shouldBe "commit 2"
+            }
+
+            it("resolves to null when nothing is selected") {
+                MapState.reset()
+                MapState.commitsByBranch["refs/heads/main"] = dummyCommits(3)
+
+                MapState.selectedNode() shouldBe null
+            }
+
+            it("resolves to null when the selected sha is not loaded") {
+                MapState.reset()
+                MapState.commitsByBranch["refs/heads/main"] = dummyCommits(3)
+                MapState.selectNode("sha-missing")
+
+                MapState.selectedNode() shouldBe null
+            }
         }
 
         describe("a branch with more commits than one page") {

--- a/src/test/kotlin/com/codymikol/state/QuickViewStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/QuickViewStateSpec.kt
@@ -1,0 +1,89 @@
+package com.codymikol.state
+
+import com.codymikol.data.map.CommitGraphNode
+import com.codymikol.repository.TestRepository.Companion.createTestRepository
+import com.codymikol.tabs.Tab
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import java.util.Date
+
+class QuickViewStateSpec : DescribeSpec({
+
+    fun node(sha: String = "abc123def456", message: String = "do a thing") = CommitGraphNode(
+        sha = sha,
+        shortSha = sha.take(7),
+        shortMessage = message,
+        authorName = "Ada Lovelace",
+        authorEmail = "ada@example.com",
+        date = Date(),
+        parentShas = emptyList(),
+    )
+
+    describe("GitDownState quick view") {
+
+        describe("openQuickView") {
+
+            it("stores the commit and switches to the QuickView tab") {
+                GitDownState.selectTab(Tab.Map)
+
+                GitDownState.openQuickView(node(message = "hello"))
+
+                GitDownState.quickViewCommit.value?.shortMessage shouldBe "hello"
+                GitDownState.currentTab.value shouldBe Tab.QuickView
+            }
+        }
+
+        describe("closeQuickView") {
+
+            it("clears the commit and restores the previous tab") {
+                GitDownState.selectTab(Tab.Map)
+                GitDownState.openQuickView(node())
+
+                GitDownState.closeQuickView()
+
+                GitDownState.quickViewCommit.value shouldBe null
+                GitDownState.currentTab.value shouldBe Tab.Map
+            }
+
+            it("keeps the originally remembered tab when reopened for another commit") {
+                GitDownState.selectTab(Tab.Map)
+                GitDownState.openQuickView(node(sha = "one"))
+                GitDownState.openQuickView(node(sha = "two"))
+
+                GitDownState.closeQuickView()
+
+                GitDownState.currentTab.value shouldBe Tab.Map
+            }
+        }
+
+        describe("quickViewDiffTree") {
+
+            beforeContainer { GitDownState.git.value.close() }
+
+            autoClose(
+                createTestRepository()
+                    .addFile("foo.txt", "one\n")
+                    .stageAll()
+                    .commitAll("init")
+                    .appendToFile("foo.txt", "two\n")
+                    .stageAll()
+                    .commitAll("add two")
+                    .transferIntoGitDownState()
+            )
+
+            it("builds the diff tree for the quick view commit") {
+                val headSha = GitDownState.git.value.repository.resolve("HEAD").name
+                GitDownState.openQuickView(node(sha = headSha))
+
+                GitDownState.quickViewDiffTree.value.fileDeltaNodes shouldHaveSize 1
+            }
+
+            it("is empty when no quick view commit is set") {
+                GitDownState.closeQuickView()
+
+                GitDownState.quickViewDiffTree.value.fileDeltaNodes shouldHaveSize 0
+            }
+        }
+    }
+})


### PR DESCRIPTION
Implements the Quick View (#254): an ephemeral view launched against a
specific commit from the map, with a commit-details left panel and a
read-only diff right panel.

## What changed
- **RelativeDateTime service** — extracted the relative-time label logic
  (Today / Yesterday / X Days/Months/Years Ago) out of `CommitCard` into
  `services/RelativeDateTime` so any view can reuse it. `CommitCard.date`
  now delegates; its relative-time tests moved to `RelativeDateTimeSpec`.
- **`Git.getCommitDiff(sha)`** — diffs a commit against its first parent.
  `getStashDiff` now delegates to a shared `diffAgainstFirstParent` helper
  so both format diffs identically. Read-only `Stash.File*` carriers are
  reused since a committed diff has no working-tree/index backing to stage.
- **State** — `Tab.QuickView`, `GitDownState.quickViewCommit` /
  `quickViewDiffTree`, and `openQuickView` / `closeQuickView` (restores the
  prior tab). `MapState.selectedNode()` resolves the selected sha to its
  node.
- **QuickView screen** — two-panel layout mirroring the stash view; left
  panel shows sha, message, committer (with an ASCII-initial avatar) and
  the formatted date, right panel reuses the shared `Diff` component.
- **Wiring** — the map context menu's Quick View action opens the view for
  the right-clicked commit; space on a selected map node opens it, and
  space/escape closes it.

## Notes for reviewers
- `CommitGraphNode` carries only author identity, so the "committer" line
  and avatar are sourced from the author fields.
- Root (parentless) commits render an empty diff, matching the stash path.

Closes #254