### PR TITLE
feat(map): show branch-name pills on tip commit nodes

### DIFF
--- a/src/main/kotlin/com/codymikol/state/MapState.kt
+++ b/src/main/kotlin/com/codymikol/state/MapState.kt
@@ -61,6 +61,18 @@ object MapState {
         GitDownState.git.value.listLocalBranches().sortedBy { it.name }
     }
 
+    /**
+     * Every local branch's tip commit sha, mapped to the name(s) of the branch(es)
+     * pointing at it - a commit shared by multiple branch tips collects all of their
+     * names. Backs the branch-name pills shown on tip commits (see issue #272).
+     */
+    val branchTipsBySha = derivedStateOf {
+        branches.value.groupBy(
+            keySelector = { it.objectId.name },
+            valueTransform = { it.name.removePrefix("refs/heads/") }
+        )
+    }
+
     fun loadMore(branch: Ref) {
         if (hasMoreByBranch[branch.name] == false) return
 

--- a/src/main/kotlin/com/codymikol/views/MapView.kt
+++ b/src/main/kotlin/com/codymikol/views/MapView.kt
@@ -31,14 +31,10 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.RectangleShape
-import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.drawscope.DrawScope
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -60,8 +56,6 @@ import org.eclipse.jgit.lib.Ref
 import java.util.Date
 import kotlin.math.roundToInt
 
-// Narrower than a horizontal title would need, since titles are now rotated
-// diagonally and take up far less width per lane.
 private val LaneWidth = 180.dp
 private val NodeRadius = 5.dp
 private val GutterX = 20.dp
@@ -74,26 +68,18 @@ private val CardHoleSize = 8.dp
 private val CardCorner = 10.dp
 private val CardMaxWidth = 150.dp
 
-// Every lane's title sits in a fixed-height box so all lanes' graphs start at the
-// same y-offset below the titles, regardless of how long each branch name is.
+// Branch-name pills shown on tip commits (#272), colored the same as the node they
+// label so they read as an extension of it rather than an unrelated UI element.
+private val PillCorner = 8.dp
+private val PillFontSize = 10.sp
+private val PillSpacing = 4.dp
+private val PillEndPadding = 12.dp
+private val PillMaxWidth = 80.dp
+
+// Reserves the same header height the old per-column branch name title used to
+// fill (see BranchLane and Map()'s headerHeightPx), so lane content still starts
+// at a consistent y-offset now that the name itself lives on the tip pill (#272).
 private val TitleHeight = 110.dp
-
-// Positive (clockwise) so, pivoting on the text's own top-start corner below,
-// the label sweeps down-and-right into the box rather than up and out of it.
-private val TitleRotation = 45f
-private val TitleFontSize = 12.sp
-private val TitleTextStartPadding = 12.dp
-private val TitleTextTopPadding = 4.dp
-private val TitleTextLineHeight = 16.sp
-
-// Text is capped to this width before rotating, so its rotated footprint is
-// bounded: rotated 45 degrees around its own top-start corner, its deepest
-// point is (TitleTextMaxWidth + ~TitleTextLineHeight) * sin(45deg) below the
-// pivot, i.e. below the top of the box, which is ~89dp at default font scale
-// for the values here - comfortably under TitleHeight (110dp) with margin
-// for TitleTextTopPadding. clip(RectangleShape) below is still a hard
-// backstop against any overflow (e.g. from a larger system font scale).
-private val TitleTextMaxWidth = 110.dp
 
 @Composable
 @Preview
@@ -177,7 +163,6 @@ private fun MapEmptyState() {
 
 @Composable
 private fun BranchLane(branch: Ref, rowHeightPx: Float, viewportHeightPx: Float) {
-    val branchName = branch.name.removePrefix("refs/heads/")
     val commits = MapState.commitsByBranch[branch.name] ?: emptyList()
 
     val firstVisibleIndex = MapScrollState.firstVisibleIndex(rowHeightPx)
@@ -201,7 +186,11 @@ private fun BranchLane(branch: Ref, rowHeightPx: Float, viewportHeightPx: Float)
             .width(LaneWidth)
             .fillMaxHeight()
     ) {
-        MapLaneTitle(branchName)
+        // Reserves the same TitleHeight the old per-column branch name header used
+        // to occupy (see Map()'s headerHeightPx), so lane content still starts at a
+        // consistent y-offset - the name itself now lives on the tip commit's pill
+        // instead (#272), rather than duplicated up here too.
+        Spacer(modifier = Modifier.fillMaxWidth().requiredHeight(TitleHeight))
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -232,43 +221,6 @@ private fun BranchLane(branch: Ref, rowHeightPx: Float, viewportHeightPx: Float)
 }
 
 
-@Composable
-private fun MapLaneTitle(branchName: String) {
-    // The map's own background already shows through here (BranchLane's Column
-    // paints no background of its own), so the title needs no fill of its own
-    // to satisfy "same background color as the map".
-    //
-    // The text's own top-start corner is pinned as the rotation pivot (rather
-    // than the default center), so it stays fixed at the top of the box and
-    // the rest of the label sweeps down/across into the title box's own
-    // reserved height rather than toward the graph below; clipping to the box
-    // is a hard backstop against any residual overflow so a rotated title can
-    // never bleed into the graph.
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .requiredHeight(TitleHeight)
-            .clip(RectangleShape),
-        contentAlignment = Alignment.TopStart
-    ) {
-        Text(
-            text = branchName,
-            style = TextStyle(
-                fontWeight = FontWeight.Bold,
-                fontSize = TitleFontSize,
-                lineHeight = TitleTextLineHeight
-            ),
-            color = Color.White,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier
-                .padding(start = TitleTextStartPadding, top = TitleTextTopPadding)
-                .width(TitleTextMaxWidth)
-                .graphicsLayer(rotationZ = TitleRotation, transformOrigin = TransformOrigin(0f, 0f))
-        )
-    }
-}
-
 // The sha and commit message are hidden by default to preserve space (#252); the
 // node itself is the whole clickable target and its detail card only appears while
 // this node is selected.
@@ -283,6 +235,7 @@ private fun CommitNode(
     modifier: Modifier = Modifier,
 ) {
     var menuExpanded by remember { mutableStateOf(false) }
+    val tipBranches = MapState.branchTipsBySha.value[commit.sha] ?: emptyList()
 
     Box(
         modifier = modifier
@@ -310,10 +263,46 @@ private fun CommitNode(
             )
         }
 
+        // Hidden while the detail card is showing: the card (up to CardMaxWidth,
+        // leading) and a full row of pills (up to PillMaxWidth each, trailing) can
+        // together exceed LaneWidth, so they'd otherwise risk overlapping.
+        if (tipBranches.isNotEmpty() && !isSelected) {
+            Row(
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .padding(end = PillEndPadding),
+                horizontalArrangement = Arrangement.spacedBy(PillSpacing),
+            ) {
+                tipBranches.forEach { branchName -> BranchPill(branchName, nodeColor(commit)) }
+            }
+        }
+
         CommitContextMenu(
             commit = commit,
             expanded = menuExpanded,
             onDismiss = { menuExpanded = false },
+        )
+    }
+}
+
+// A small labeled pill naming a local branch whose tip is this commit (#272); shown
+// instead of the old per-column branch header now that it labels a node directly.
+@Composable
+private fun BranchPill(branchName: String, color: Color) {
+    Box(
+        modifier = Modifier
+            .widthIn(max = PillMaxWidth)
+            .clip(RoundedCornerShape(PillCorner))
+            .background(color)
+            .padding(horizontal = 6.dp, vertical = 2.dp),
+    ) {
+        Text(
+            text = branchName,
+            color = Color.White,
+            fontSize = PillFontSize,
+            fontWeight = FontWeight.Bold,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
         )
     }
 }

--- a/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
@@ -3,6 +3,7 @@ package com.codymikol.state
 import com.codymikol.data.map.CommitGraphNode
 import com.codymikol.repository.TestRepository.Companion.createTestRepository
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import java.util.Date
@@ -198,6 +199,49 @@ class MapStateSpec : DescribeSpec({
                 MapState.selectNode("sha-missing")
 
                 MapState.selectedNode() shouldBe null
+            }
+        }
+
+        describe("branchTipsBySha") {
+
+            autoClose(
+                createTestRepository()
+                    .addFile("a.txt", "a")
+                    .stageAll()
+                    .commitAll("commit 1")
+                    .transferIntoGitDownState()
+            )
+
+            it("maps a branch's tip commit sha to that branch's name") {
+                val branch = MapState.branches.value.single()
+                val tipSha = branch.objectId.name
+
+                MapState.branchTipsBySha.value[tipSha] shouldBe listOf(branch.name.removePrefix("refs/heads/"))
+            }
+
+            it("collects every branch name pointing at a shared tip commit") {
+                val original = MapState.branches.value.single()
+                val tipSha = original.objectId.name
+                GitDownState.git.value.branchCreate().setName("feature").call()
+                // branches/branchTipsBySha are derivedStateOf on GitDownState.git,
+                // which only recomputes off lastRequestedUpdateTimestamp (see
+                // GitDownState.git and Git.command in GitExtensions.kt) - bump it
+                // manually since branchCreate() above bypassed that command() wrapper.
+                // Incrementing (rather than re-reading the clock) guarantees a value
+                // change even if this runs within the same clock tick as the initial
+                // read, which mutableStateOf's equality check would otherwise ignore.
+                GitDownState.lastRequestedUpdateTimestamp.value += 1
+
+                val names = MapState.branchTipsBySha.value[tipSha]
+
+                names shouldContainExactlyInAnyOrder listOf(
+                    original.name.removePrefix("refs/heads/"),
+                    "feature",
+                )
+            }
+
+            it("has no entry for a commit that is nobody's branch tip") {
+                MapState.branchTipsBySha.value["not-a-real-sha"] shouldBe null
             }
         }
 


### PR DESCRIPTION
## Summary

- Adds `MapState.branchTipsBySha`, deriving each local branch's tip commit sha -> the branch name(s) pointing at it (a shared tip collects every name).
- Renders a small pill per branch name on whichever commit node is that branch's tip, colored like the node itself. No pill for a commit that's nobody's tip; a shared tip shows a pill for each branch.
- Removes the old per-column branch-name header (`MapLaneTitle`) now that the tip pill is the name's home, per the issue's own "pills instead of the old per-column branch header" framing - its reserved layout height is kept as a blank spacer so lane scroll/windowing math is untouched.
- Pills are hidden while a node's detail card is showing (card + a full pill row can together exceed the 180dp lane width).

Closes #272

## Notes for reviewers

- #272 is "Blocked by #270" (unified, deduped, ancestry-lane graph). #270 hasn't landed yet, so the map still renders one lane per branch. A commit that is the tip of N branches therefore still renders as N separate per-lane node instances (pre-existing duplicate-rendering, tracked by #270/#263) - each instance shows the full pill set for that sha, so a shared-tip commit's pills currently appear once per lane rather than once overall. This resolves naturally once #270's dedup lands; not fixed here since it's explicitly in #270's scope.
- Local checks could not be run in this sandbox: there is no JDK anywhere in the container's PATH, and `nix develop` cannot provision the flake's `temurin-bin-21` because `/nix/store` is mounted read-only for this user (`NIX_STORE_WRITABLE=false`) with no nix-daemon available to broker writes. I verified an alternate writable Nix store could fetch the JDK, but the substituted binaries hardcode canonical `/nix/store` self-references that don't exist there, and no bind-mount tooling (`unshare`, root) was available to work around it. Code was reviewed carefully (brace/paren-balance checked, patterns mirrored from existing tested code) but not locally compiled or run; CI's `actions/setup-java` runs on a normal GitHub-hosted runner unaffected by this and is the actual gate here.