### PR TITLE
feat(services): add LaneAssigner for map graph lanes

### DIFF
--- a/src/main/kotlin/com/codymikol/services/LaneAssigner.kt
+++ b/src/main/kotlin/com/codymikol/services/LaneAssigner.kt
@@ -1,0 +1,60 @@
+package com.codymikol.services
+
+import com.codymikol.data.map.CommitGraphNode
+
+/**
+ * Assigns each commit in a newest-to-oldest (reverse topological) walk to a
+ * lane/column number, GitUp-style: a lane tracks an ancestry lineage, not a
+ * branch. Stateful and streaming so callers can feed it paginated batches -
+ * see issue #269 - and get the same lane numbers as a single call over the
+ * whole history.
+ */
+class LaneAssigner {
+
+    private val laneAwaitingSha = mutableMapOf<String, MutableList<Int>>()
+    private val freeLanes = sortedSetOf<Int>()
+    private var laneCount = 0
+
+    /**
+     * Assigns lanes to [commits], which must already be in reverse
+     * topological (newest-to-oldest, child-before-parent) order.
+     */
+    fun assign(commits: List<CommitGraphNode>): List<Int> = commits.map { assign(it) }
+
+    /**
+     * Assigns a lane to a single [commit]. Callers must feed commits in
+     * reverse topological order one page at a time; state carries over
+     * between calls, so splitting a history across several calls yields the
+     * same lanes as one call over the whole thing.
+     */
+    fun assign(commit: CommitGraphNode): Int {
+        val waitingLanes = laneAwaitingSha.remove(commit.sha)
+        val lane = waitingLanes?.min() ?: allocateLane()
+        waitingLanes?.filter { it != lane }?.forEach { freeLanes.add(it) }
+
+        val parents = commit.parentShas
+        if (parents.isEmpty()) {
+            freeLanes.add(lane)
+        } else {
+            awaitOn(parents[0], lane)
+            // Extra parents (merge commits) each need their own lane; if a
+            // sibling parent just freed one above, it's fair game for reuse
+            // here too - a lane is free the moment nothing awaits it.
+            for (i in 1 until parents.size) {
+                awaitOn(parents[i], allocateLane())
+            }
+        }
+
+        return lane
+    }
+
+    private fun allocateLane(): Int {
+        val reused = freeLanes.firstOrNull() ?: return laneCount++
+        freeLanes.remove(reused)
+        return reused
+    }
+
+    private fun awaitOn(sha: String, lane: Int) {
+        laneAwaitingSha.getOrPut(sha) { mutableListOf() }.add(lane)
+    }
+}

--- a/src/test/kotlin/com/codymikol/services/LaneAssignerSpec.kt
+++ b/src/test/kotlin/com/codymikol/services/LaneAssignerSpec.kt
@@ -1,0 +1,133 @@
+package com.codymikol.services
+
+import com.codymikol.data.map.CommitGraphNode
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.util.Date
+
+private fun node(sha: String, vararg parents: String) = CommitGraphNode(
+    sha = sha,
+    shortSha = sha.take(7),
+    shortMessage = "message $sha",
+    authorName = "Author",
+    authorEmail = "author@example.com",
+    date = Date(0),
+    parentShas = parents.toList(),
+)
+
+class LaneAssignerSpec : DescribeSpec({
+
+    describe("LaneAssigner") {
+
+        describe("assign") {
+
+            it("should keep every commit in a linear history on the same lane") {
+                val assigner = LaneAssigner()
+                val commits = listOf(
+                    node("C", "B"),
+                    node("B", "A"),
+                    node("A"),
+                )
+
+                val lanes = assigner.assign(commits)
+
+                lanes shouldBe listOf(0, 0, 0)
+            }
+
+            it("should give the merge side a new lane and reclaim it after rejoin") {
+                val assigner = LaneAssigner()
+                // M merges "side" onto "main"; both rejoin at Base, freeing
+                // side's lane while main's lane (0) stays active awaiting
+                // Root. Unrelated is a fresh, non-converging root commit
+                // that should reuse the freed lane rather than allocate a
+                // new one.
+                val commits = listOf(
+                    node("M", "main1", "side1"),
+                    node("side1", "Base"),
+                    node("main1", "Base"),
+                    node("Base", "Root"),
+                    node("Unrelated"),
+                    node("Root"),
+                )
+
+                val lanes = assigner.assign(commits)
+
+                lanes shouldBe listOf(0, 1, 0, 0, 1, 0)
+            }
+
+            it("should free a dead-end fork's lane once it runs out of parents, and reuse it") {
+                val assigner = LaneAssigner()
+                // F forks off "main" into "dead", which has no further
+                // parents. Main keeps going on lane 0; dead's lane (1)
+                // should free immediately and be reused by Other.
+                val commits = listOf(
+                    node("F", "main1", "dead"),
+                    node("dead"),
+                    node("main1", "Root"),
+                    node("Other"),
+                    node("Root"),
+                )
+
+                val lanes = assigner.assign(commits)
+
+                lanes shouldBe listOf(0, 1, 0, 1, 0)
+            }
+
+            it("should keep the leftmost lane and free the rest when 3+ lanes converge") {
+                val assigner = LaneAssigner()
+                // M is a three-way octopus merge of a, b, c, each of which
+                // is a direct child of the same Ancestor. All three lanes
+                // should collapse onto the leftmost (0) at Ancestor.
+                val commits = listOf(
+                    node("M", "a", "b", "c"),
+                    node("a", "Ancestor"),
+                    node("b", "Ancestor"),
+                    node("c", "Ancestor"),
+                    node("Ancestor"),
+                )
+
+                val lanes = assigner.assign(commits)
+
+                lanes shouldBe listOf(0, 0, 1, 2, 0)
+            }
+
+            it("should give a new commit the leftmost free lane, not lane 0 unconditionally") {
+                val assigner = LaneAssigner()
+                // F forks lane 0 into main0 (stays lane 0, stays active) and
+                // dead1 (lane 1, dies immediately). With lane 0 still busy,
+                // a fresh root commit must land on the only free lane (1),
+                // not lane 0.
+                val commits = listOf(
+                    node("F", "main0", "dead1"),
+                    node("dead1"),
+                    node("main0", "mainParent"),
+                    node("NewRoot"),
+                    node("mainParent"),
+                )
+
+                val lanes = assigner.assign(commits)
+
+                lanes shouldBe listOf(0, 1, 0, 1, 0)
+            }
+
+            it("should assign identical lanes whether a page is walked in one call or split across two") {
+                val commits = listOf(
+                    node("M", "main1", "side1"),
+                    node("side1", "Base"),
+                    node("main1", "Base"),
+                    node("Base", "Root"),
+                    node("Unrelated"),
+                    node("Root"),
+                )
+
+                val oneCall = LaneAssigner().assign(commits)
+
+                val paged = LaneAssigner().let { assigner ->
+                    assigner.assign(commits.subList(0, 3)) + assigner.assign(commits.subList(3, commits.size))
+                }
+
+                paged shouldBe oneCall
+            }
+        }
+    }
+})


### PR DESCRIPTION
## Summary
- Adds `LaneAssigner`, a pure, stateful, streaming (O(V+E)) lane-assignment algorithm for the map graph, GitUp-style: walks commits newest→oldest and assigns each one a lane/column number.
- Handles linear continuation, merge commits splitting into new lanes, convergence back to the leftmost lane (freeing the others in the same step), and reuse of freed lanes for the leftmost-free-lane allocation.
- State persists across repeated `assign()` calls on the same instance, so paginated batches produce identical lane numbers to a single call over the whole history.
- Foundational only, per the issue: nothing in the app calls it yet — no `MapState`/`MapView` wiring in this change.

## Test plan
- [x] `LaneAssignerSpec` covers all six acceptance criteria: linear history, fork+rejoin lane reclaim, dead-end fork lane free/reuse, 3+ lane convergence to leftmost, leftmost-free-lane allocation, and incremental (paginated) equivalence.
- [x] `./gradlew build` (fallback JDK 21 toolchain — `nix develop` is unusable in this sandbox: no nix-daemon and a root-owned `/nix/store` reject writes from the non-root `agent` user) — BUILD SUCCESSFUL, all specs pass, no regressions.

Closes #269