### PR TITLE
feat(map): draw parent/child connector lines across lanes

### DIFF
--- a/src/main/kotlin/com/codymikol/data/map/MapConnector.kt
+++ b/src/main/kotlin/com/codymikol/data/map/MapConnector.kt
@@ -1,0 +1,8 @@
+package com.codymikol.data.map
+
+data class MapConnector(
+    val childIndex: Int,
+    val childLane: Int,
+    val parentIndex: Int,
+    val parentLane: Int,
+)

--- a/src/main/kotlin/com/codymikol/services/MapConnectors.kt
+++ b/src/main/kotlin/com/codymikol/services/MapConnectors.kt
@@ -1,0 +1,28 @@
+package com.codymikol.services
+
+import com.codymikol.data.map.CommitGraphNode
+import com.codymikol.data.map.MapConnector
+
+/**
+ * Computes the parent/child connector lines to draw over the map's lanes (#271):
+ * one connector per edge whose parent has already been loaded (and lane-assigned).
+ * A parent that pagination hasn't reached yet is simply skipped - the connector
+ * appears on its own once loadMore() reaches it, since compute() is re-run off the
+ * same commits/lanesBySha it reads from.
+ */
+object MapConnectors {
+
+    fun compute(commits: List<CommitGraphNode>, lanesBySha: Map<String, Int>): List<MapConnector> {
+        val indexBySha = commits.withIndex().associate { (index, commit) -> commit.sha to index }
+
+        return commits.flatMapIndexed { childIndex, commit ->
+            val childLane = lanesBySha[commit.sha] ?: return@flatMapIndexed emptyList()
+
+            commit.parentShas.mapNotNull { parentSha ->
+                val parentIndex = indexBySha[parentSha] ?: return@mapNotNull null
+                val parentLane = lanesBySha[parentSha] ?: return@mapNotNull null
+                MapConnector(childIndex, childLane, parentIndex, parentLane)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/codymikol/views/MapView.kt
+++ b/src/main/kotlin/com/codymikol/views/MapView.kt
@@ -1,12 +1,14 @@
 package com.codymikol.views
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.PointerMatcher
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.onClick
 import androidx.compose.foundation.shape.CircleShape
@@ -42,6 +44,8 @@ import com.codymikol.data.Colors
 import com.codymikol.data.map.CommitCard
 import com.codymikol.data.map.CommitContextMenu as CommitContextMenuModel
 import com.codymikol.data.map.CommitGraphNode
+import com.codymikol.data.map.MapConnector
+import com.codymikol.services.MapConnectors
 import com.codymikol.state.GitDownState
 import com.codymikol.state.MapState
 import java.util.Date
@@ -50,6 +54,7 @@ private val LaneWidth = 180.dp
 private val NodeRadius = 5.dp
 private val GutterX = 20.dp
 private val RowHeight = 48.dp
+private const val ConnectorStrokeWidth = 2f
 
 // The dog-tag detail card shown when a node is clicked (#252): a rounded-rectangle
 // body with a protruding round tab holding a punched hole, sitting over the node.
@@ -101,23 +106,71 @@ private fun Map() {
         }
     }
 
-    LazyColumn(
-        state = lazyListState,
-        modifier = Modifier.fillMaxSize().background(Colors.DarkGrayBackground),
-    ) {
-        items(commits.size, key = { commits[it].sha }) { index ->
-            val commit = commits[index]
-            val lane = MapState.lanesBySha[commit.sha] ?: 0
+    // Recomputed only when commits/lanesBySha themselves change (i.e. on page load),
+    // not on every scroll frame - the Canvas below reads lazyListState directly during
+    // its own draw phase, so scrolling never triggers recomposition of this list.
+    val connectors by remember { derivedStateOf { MapConnectors.compute(commits, MapState.lanesBySha) } }
 
-            CommitNode(
-                commit = commit,
-                isSelected = MapState.selectedNodeSha.value == commit.sha,
-                onClick = { MapState.toggleSelectedNode(commit.sha) },
-                showLeadingGuideline = false,
-                showTrailingGuideline = false,
-                modifier = Modifier.offset(x = LaneWidth * lane).width(LaneWidth),
-            )
+    Box(modifier = Modifier.fillMaxSize().background(Colors.DarkGrayBackground)) {
+        // A single overlay pass over the currently-visible rows (#271): an individual
+        // commit row's own draw bounds are clipped to that row, so a diagonal line
+        // reaching into a neighbouring row/lane can only be drawn here, not per-node.
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            drawConnectors(connectors, lazyListState)
         }
+
+        LazyColumn(
+            state = lazyListState,
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            items(commits.size, key = { commits[it].sha }) { index ->
+                val commit = commits[index]
+                val lane = MapState.lanesBySha[commit.sha] ?: 0
+
+                CommitNode(
+                    commit = commit,
+                    isSelected = MapState.selectedNodeSha.value == commit.sha,
+                    onClick = { MapState.toggleSelectedNode(commit.sha) },
+                    modifier = Modifier.offset(x = LaneWidth * lane).width(LaneWidth),
+                )
+            }
+        }
+    }
+}
+
+// Row height is fixed, so a row's on-screen y-offset is a straight formula from the
+// first visible row - true for every loaded row, not just the ones currently in
+// layoutInfo.visibleItemsInfo, which is what lets a connector reach into a
+// neighbouring row without that row needing to be measured this frame.
+private fun DrawScope.drawConnectors(connectors: List<MapConnector>, lazyListState: LazyListState) {
+    val rowHeightPx = RowHeight.toPx()
+    val gutterXPx = GutterX.toPx()
+    val laneWidthPx = LaneWidth.toPx()
+    val firstIndex = lazyListState.firstVisibleItemIndex
+    val firstOffset = lazyListState.firstVisibleItemScrollOffset
+
+    fun rowCenterY(index: Int) = (index - firstIndex) * rowHeightPx - firstOffset + rowHeightPx / 2f
+    fun laneCenterX(lane: Int) = gutterXPx + lane * laneWidthPx
+
+    val visibleTop = -rowHeightPx
+    val visibleBottom = size.height + rowHeightPx
+
+    connectors.forEach { connector ->
+        val childY = rowCenterY(connector.childIndex)
+        val parentY = rowCenterY(connector.parentIndex)
+        if (childY < visibleTop && parentY < visibleTop) return@forEach
+        if (childY > visibleBottom && parentY > visibleBottom) return@forEach
+
+        // Cross-lane connectors (merge splits, reconvergences) get the same blue as a
+        // merge node so the line reads as distinct from a same-lane continuation,
+        // rather than relying on the diagonal angle alone.
+        val sameLane = connector.childLane == connector.parentLane
+        drawLine(
+            color = if (sameLane) Colors.LightGrayText else Colors.FileModified,
+            start = Offset(laneCenterX(connector.childLane), childY),
+            end = Offset(laneCenterX(connector.parentLane), parentY),
+            strokeWidth = ConnectorStrokeWidth,
+        )
     }
 }
 
@@ -145,8 +198,6 @@ private fun CommitNode(
     commit: CommitGraphNode,
     isSelected: Boolean,
     onClick: () -> Unit,
-    showLeadingGuideline: Boolean,
-    showTrailingGuideline: Boolean,
     modifier: Modifier = Modifier,
 ) {
     var menuExpanded by remember { mutableStateOf(false) }
@@ -166,7 +217,7 @@ private fun CommitNode(
                 MapState.selectNode(commit.sha)
                 menuExpanded = true
             }
-            .drawBehind { drawCommitNode(commit, showLeadingGuideline, showTrailingGuideline) }
+            .drawBehind { drawCommitNode(commit) }
     ) {
         if (isSelected) {
             CommitDetailCard(
@@ -315,26 +366,9 @@ private fun CardLine(text: String, fontWeight: FontWeight) {
 private fun nodeColor(commit: CommitGraphNode): Color =
     if (commit.isMergeCommit) Colors.FileModified else Colors.FileAdded
 
-private fun DrawScope.drawCommitNode(
-    commit: CommitGraphNode,
-    showLeadingGuideline: Boolean,
-    showTrailingGuideline: Boolean,
-) {
+private fun DrawScope.drawCommitNode(commit: CommitGraphNode) {
     val x = GutterX.toPx()
     val centerY = size.height / 2f
-
-    if (showLeadingGuideline) {
-        drawLine(color = Colors.LightGrayText, start = Offset(x, 0f), end = Offset(x, centerY), strokeWidth = 2f)
-    }
-
-    if (showTrailingGuideline) {
-        drawLine(
-            color = Colors.LightGrayText,
-            start = Offset(x, centerY),
-            end = Offset(x, size.height),
-            strokeWidth = 2f
-        )
-    }
 
     when (commit.isMergeCommit) {
         true -> drawDiamond(center = Offset(x, centerY), radius = NodeRadius.toPx(), color = nodeColor(commit))

--- a/src/test/kotlin/com/codymikol/services/MapConnectorsSpec.kt
+++ b/src/test/kotlin/com/codymikol/services/MapConnectorsSpec.kt
@@ -1,0 +1,71 @@
+package com.codymikol.services
+
+import com.codymikol.data.map.CommitGraphNode
+import com.codymikol.data.map.MapConnector
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.util.Date
+
+private fun node(sha: String, vararg parents: String) = CommitGraphNode(
+    sha = sha,
+    shortSha = sha.take(7),
+    shortMessage = "message $sha",
+    authorName = "Author",
+    authorEmail = "author@example.com",
+    date = Date(0),
+    parentShas = parents.toList(),
+)
+
+class MapConnectorsSpec : DescribeSpec({
+
+    describe("MapConnectors") {
+
+        describe("compute") {
+
+            it("should connect a linear stretch of commits with same-lane connectors") {
+                val commits = listOf(node("C", "B"), node("B", "A"), node("A"))
+                val lanesBySha = mapOf("C" to 0, "B" to 0, "A" to 0)
+
+                val connectors = MapConnectors.compute(commits, lanesBySha)
+
+                connectors shouldBe listOf(
+                    MapConnector(childIndex = 0, childLane = 0, parentIndex = 1, parentLane = 0),
+                    MapConnector(childIndex = 1, childLane = 0, parentIndex = 2, parentLane = 0),
+                )
+            }
+
+            it("should connect a merge commit's extra parent to its own split-off lane") {
+                val commits = listOf(node("M", "main1", "side1"), node("main1"), node("side1"))
+                val lanesBySha = mapOf("M" to 0, "main1" to 0, "side1" to 1)
+
+                val connectors = MapConnectors.compute(commits, lanesBySha)
+
+                connectors shouldBe listOf(
+                    MapConnector(childIndex = 0, childLane = 0, parentIndex = 1, parentLane = 0),
+                    MapConnector(childIndex = 0, childLane = 0, parentIndex = 2, parentLane = 1),
+                )
+            }
+
+            it("should converge two lanes onto the same ancestor rather than overlap silently") {
+                val commits = listOf(node("main1", "Base"), node("side1", "Base"), node("Base"))
+                val lanesBySha = mapOf("main1" to 0, "side1" to 1, "Base" to 0)
+
+                val connectors = MapConnectors.compute(commits, lanesBySha)
+
+                connectors shouldBe listOf(
+                    MapConnector(childIndex = 0, childLane = 0, parentIndex = 2, parentLane = 0),
+                    MapConnector(childIndex = 1, childLane = 1, parentIndex = 2, parentLane = 0),
+                )
+            }
+
+            it("should draw no connector for a parent pagination hasn't loaded yet") {
+                val commits = listOf(node("C", "NotLoaded"))
+                val lanesBySha = mapOf("C" to 0)
+
+                val connectors = MapConnectors.compute(commits, lanesBySha)
+
+                connectors shouldBe emptyList()
+            }
+        }
+    }
+})


### PR DESCRIPTION
## Summary
- Adds `MapConnectors.compute()` (services), a pure function that derives one connector edge per loaded parent link from the deduped commit list and `MapState.lanesBySha`, skipping any parent pagination hasn't reached yet (its line appears once that page loads).
- Draws those connectors in `MapView.kt` as a single Canvas overlay behind the map's `LazyColumn`: straight when child/parent share a lane, diagonal across lanes on a merge split or reconvergence, with cross-lane lines colored to match the merge-node blue so they read as visibly distinct from a same-lane continuation. Row y-offsets are computed from the fixed row height and current scroll position so a connector can reach into a neighbouring row without that row being in `layoutInfo.visibleItemsInfo` this frame; connectors entirely outside a padded viewport band are skipped.
- Removes the now-dead, always-false `showLeadingGuideline`/`showTrailingGuideline` plumbing on `CommitNode`, the old per-row intra-lane guide mechanism this overlay replaces.

Closes #271

## Test plan
- [x] `MapConnectorsSpec`: linear stretch (straight line), merge commit (extra parent to its own lane), reconvergence (two lanes into one ancestor), and a not-yet-loaded parent (no connector) — all new, TDD'd one at a time.
- [x] Full `./gradlew test` suite green.

## Notes for reviewer
- Prerequisite issues #269 (LaneAssigner) and #270 (unified deduped graph / single LazyColumn) are merged into main, so this ticket's originally-blocked precondition is resolved.
- The Canvas draw/culling math itself has no automated coverage — the repo's existing test conventions only Spec-test services/state, not Compose rendering (matches the untested `drawCommitNode`); reviewed by hand instead.