### PR TITLE
fix(splash): open the email button via the mail client

### DIFF
--- a/src/main/kotlin/com/codymikol/services/LinkOpenerService.kt
+++ b/src/main/kotlin/com/codymikol/services/LinkOpenerService.kt
@@ -1,0 +1,32 @@
+package com.codymikol.services
+
+import org.koin.core.annotation.Single
+import java.awt.Desktop
+import java.net.URI
+
+@Single
+class LinkOpenerService {
+
+    /**
+     * Opens [url] with the operating system's default handler. A `mailto:` link is routed to the
+     * default mail client via [Desktop.mail], every other scheme to the browser via [Desktop.browse].
+     * The previous implementation sent every scheme through [Desktop.browse], which throws
+     * `IOException: Failed to show URI` for `mailto:` on platforms (e.g. Linux) that only accept
+     * browsable URIs there. [browse] and [mail] are injected so the scheme routing can be unit
+     * tested without invoking the real AWT Desktop.
+     */
+    fun open(
+        url: String,
+        browse: (URI) -> Unit = ::browseInDesktop,
+        mail: (URI) -> Unit = ::mailInDesktop,
+    ) {
+        val uri = URI.create(url)
+        if (uri.scheme?.equals("mailto", ignoreCase = true) == true) mail(uri) else browse(uri)
+    }
+
+    companion object {
+        fun browseInDesktop(uri: URI) = Desktop.getDesktop().browse(uri)
+        fun mailInDesktop(uri: URI) = Desktop.getDesktop().mail(uri)
+    }
+
+}

--- a/src/main/kotlin/com/codymikol/windows/DirectorySelector.kt
+++ b/src/main/kotlin/com/codymikol/windows/DirectorySelector.kt
@@ -30,16 +30,15 @@ import com.codymikol.data.recent.RecentProjects
 import com.codymikol.extensions.onFocusLost
 import com.codymikol.gitdown.generated.resources.*
 import com.codymikol.repositories.RecentProjectRepository
+import com.codymikol.services.LinkOpenerService
 import com.codymikol.state.GitDownState
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
 import org.koin.java.KoinJavaComponent.inject
-import java.awt.Desktop
 import java.awt.Dimension
 import java.awt.FileDialog
 import java.awt.Frame
 import java.io.File
-import java.net.URI
 import javax.swing.JFileChooser
 import javax.swing.JFrame
 
@@ -52,6 +51,8 @@ private val ButtonBackgroundColor = Color(53, 53, 53)
 private val ButtonBorderColor = Color(60, 60, 60)
 
 private val recentProjectsRepository: RecentProjectRepository by inject(RecentProjectRepository::class.java)
+
+private val linkOpenerService: LinkOpenerService by inject(LinkOpenerService::class.java)
 
 @Composable
 fun RecentProjectSelector(x: Int, y: Int, closeHandler: () -> Unit, recent: RecentProjects) {
@@ -325,10 +326,7 @@ private fun InspirationText() {
     }
 }
 
-fun openLink(url: String) {
-    val desktop = Desktop.getDesktop()
-    desktop.browse(URI.create(url))
-}
+fun openLink(url: String) = linkOpenerService.open(url)
 
 @Composable
 private fun FrameWindowScope.Toolbar(applicationScope: ApplicationScope) {

--- a/src/test/kotlin/com/codymikol/services/LinkOpenerServiceSpec.kt
+++ b/src/test/kotlin/com/codymikol/services/LinkOpenerServiceSpec.kt
@@ -1,0 +1,62 @@
+package com.codymikol.services
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.net.URI
+
+class LinkOpenerServiceSpec : DescribeSpec({
+
+    describe("LinkOpenerService") {
+
+        describe("open") {
+
+            it("should route a mailto: link to the mail client, not the browser") {
+                val service = LinkOpenerService()
+                var browsed: URI? = null
+                var mailed: URI? = null
+
+                service.open(
+                    "mailto:hi@codymikol.com",
+                    browse = { browsed = it },
+                    mail = { mailed = it },
+                )
+
+                mailed shouldBe URI.create("mailto:hi@codymikol.com")
+                browsed shouldBe null
+            }
+
+            it("should match the mailto scheme case-insensitively") {
+                val service = LinkOpenerService()
+                var browsed: URI? = null
+                var mailed: URI? = null
+
+                service.open(
+                    "MAILTO:hi@codymikol.com",
+                    browse = { browsed = it },
+                    mail = { mailed = it },
+                )
+
+                mailed shouldBe URI.create("MAILTO:hi@codymikol.com")
+                browsed shouldBe null
+            }
+
+            it("should route an https: link to the browser, not the mail client") {
+                val service = LinkOpenerService()
+                var browsed: URI? = null
+                var mailed: URI? = null
+
+                service.open(
+                    "https://gitup.co/",
+                    browse = { browsed = it },
+                    mail = { mailed = it },
+                )
+
+                browsed shouldBe URI.create("https://gitup.co/")
+                mailed shouldBe null
+            }
+
+        }
+
+    }
+
+})


### PR DESCRIPTION
## Problem

Clicking the email button on the splash screen threw
`java.io.IOException: Failed to show URI:mailto:hi@codymikol.com`.
`openLink` sent every URI through `java.awt.Desktop.browse`, but
`browse` rejects `mailto:` on platforms (e.g. Linux) that only accept
browsable URIs there.

## Change

- Add `LinkOpenerService` (`@Single`, component-scanned) that routes
  `mailto:` links to the default mail client via `Desktop.mail` and all
  other schemes to the browser via `Desktop.browse`. `browse`/`mail` are
  injectable lambdas so the routing is unit tested without the real AWT
  Desktop, matching the `FileSystemService`/`DiffToolService` pattern.
- Delegate `openLink` in `DirectorySelector` to the service; drop the
  now-unused `Desktop`/`URI` imports.
- Scheme match is null-safe and case-insensitive, both covered by
  `LinkOpenerServiceSpec`.

## Testing

Local JDK/gradle execution was unavailable in this environment
(`NIX_STORE_WRITABLE=false`, no baked JDK), so the Kotlin suite runs on
CI. Added `LinkOpenerServiceSpec` covering mailto→mail, https→browse, and
case-insensitive matching.

Closes #266