### PR TITLE
feat: diff a selected commit against HEAD

### DIFF
--- a/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
+++ b/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
@@ -29,6 +29,7 @@ import org.eclipse.jgit.lib.FileMode
 import org.eclipse.jgit.lib.Ref
 import org.eclipse.jgit.lib.Repository
 import org.eclipse.jgit.revwalk.RevCommit
+import org.eclipse.jgit.revwalk.RevTree
 import org.eclipse.jgit.revwalk.RevWalk
 import org.eclipse.jgit.treewalk.FileTreeIterator
 import org.eclipse.jgit.treewalk.NameConflictTreeWalk
@@ -91,11 +92,28 @@ fun Git.getCommitDiff(sha: String): List<FileDelta> {
 }
 
 /**
- * The file deltas introduced by [id] relative to its first parent, each carrying
- * pre-formatted diff text. The read-only Stash.File* carriers are reused since a
- * committed diff has no working-tree or index backing to stage against - exactly
- * the shape Status.STASH already models. A parentless (root) commit yields no
- * deltas.
+ * The file deltas that turn HEAD into the commit [sha] resolves to (any ref or
+ * object-id string jgit can resolve): the diff of the selected commit against the
+ * current HEAD, backing the "Diff with HEAD" view (see issue #280). Mirrors the
+ * shape [getCommitDiff] produces so the same read-only diff view renders it. An
+ * unresolvable commit, or a repository with no HEAD, yields an empty diff; a commit
+ * identical to HEAD yields no deltas.
+ */
+fun Git.getCommitDiffAgainstHead(sha: String): List<FileDelta> = try {
+    val targetId = this.repository.resolve(sha)
+    val headId = this.repository.resolve("HEAD")
+    if (targetId == null || headId == null) emptyList()
+    else RevWalk(this.repository).use { walk ->
+        diffTrees(walk.parseCommit(headId).tree, walk.parseCommit(targetId).tree)
+    }
+} catch (e: Exception) {
+    logger.error("An exception was thrown while diffing against HEAD: ${e.message}")
+    emptyList()
+}
+
+/**
+ * The file deltas introduced by [id] relative to its first parent. A parentless
+ * (root) commit yields no deltas.
  */
 private fun Git.diffAgainstFirstParent(id: AnyObjectId): List<FileDelta> = try {
     RevWalk(this.repository).use { walk ->
@@ -103,38 +121,43 @@ private fun Git.diffAgainstFirstParent(id: AnyObjectId): List<FileDelta> = try {
 
         when (commit.parentCount > 0) {
             false -> emptyList()
-            true -> {
-                val parent = walk.parseCommit(commit.getParent(0))
-
-                DiffFormatter(DisabledOutputStream.INSTANCE).use { scanner ->
-                    scanner.setRepository(this.repository)
-                    scanner.scan(parent.tree, commit.tree).map { entry ->
-
-                        val diffText = ByteArrayOutputStream().also { stream ->
-                            DiffFormatter(stream).use { formatter ->
-                                formatter.setRepository(this.repository)
-                                formatter.format(entry)
-                            }
-                        }.toString()
-
-                        val path = Path.of(
-                            if (entry.changeType == DiffEntry.ChangeType.DELETE) entry.oldPath else entry.newPath
-                        )
-
-                        when (entry.changeType) {
-                            DiffEntry.ChangeType.ADD -> Stash.FileAdded(path, diffText)
-                            DiffEntry.ChangeType.DELETE -> Stash.FileDeleted(path, diffText)
-                            else -> Stash.FileModified(path, diffText)
-                        }
-                    }
-                }
-            }
+            true -> diffTrees(walk.parseCommit(commit.getParent(0)).tree, commit.tree)
         }
     }
 } catch (e: Exception) {
     logger.error("An exception was thrown while diffing against the first parent: ${e.message}")
     emptyList()
 }
+
+/**
+ * Scans [baseTree] to [targetTree] and maps each changed entry to a FileDelta
+ * carrying its pre-formatted diff text. The read-only Stash.File* carriers are
+ * reused since a committed diff has no working-tree or index backing to stage
+ * against - exactly the shape Status.STASH already models.
+ */
+private fun Git.diffTrees(baseTree: RevTree, targetTree: RevTree): List<FileDelta> =
+    DiffFormatter(DisabledOutputStream.INSTANCE).use { scanner ->
+        scanner.setRepository(this.repository)
+        scanner.scan(baseTree, targetTree).map { entry ->
+
+            val diffText = ByteArrayOutputStream().also { stream ->
+                DiffFormatter(stream).use { formatter ->
+                    formatter.setRepository(this.repository)
+                    formatter.format(entry)
+                }
+            }.toString()
+
+            val path = Path.of(
+                if (entry.changeType == DiffEntry.ChangeType.DELETE) entry.oldPath else entry.newPath
+            )
+
+            when (entry.changeType) {
+                DiffEntry.ChangeType.ADD -> Stash.FileAdded(path, diffText)
+                DiffEntry.ChangeType.DELETE -> Stash.FileDeleted(path, diffText)
+                else -> Stash.FileModified(path, diffText)
+            }
+        }
+    }
 
 private const val INDEX_LOCK_RETRY_MAX_ATTEMPTS = 6
 private const val INDEX_LOCK_RETRY_INITIAL_DELAY_MS = 100L

--- a/src/main/kotlin/com/codymikol/state/state.kt
+++ b/src/main/kotlin/com/codymikol/state/state.kt
@@ -9,6 +9,7 @@ import com.codymikol.data.file.WorkingDirectory
 import com.codymikol.data.map.CommitGraphNode
 import com.codymikol.data.stash.StashListItem
 import com.codymikol.extensions.getCommitDiff
+import com.codymikol.extensions.getCommitDiffAgainstHead
 import com.codymikol.extensions.getCurrentRefCommitCount
 import com.codymikol.extensions.getStashDiff
 import com.codymikol.extensions.getStashes
@@ -85,8 +86,17 @@ object GitDownState {
     // survives the map scrolling or resetting out from under it.
     val quickViewCommit = mutableStateOf<CommitGraphNode?>(null)
 
+    // True when the quick view diffs its commit against HEAD (Diff with HEAD, see
+    // issue #280) rather than against the commit's own first parent (the plain quick
+    // view, #254). Both reuse the same ephemeral diff view; only the base tree differs.
+    val quickViewAgainstHead = mutableStateOf(false)
+
     val quickViewDiffTree = derivedStateOf {
-        DiffTree.make(quickViewCommit.value?.let { git.value.getCommitDiff(it.sha) } ?: emptyList())
+        val deltas = quickViewCommit.value?.let { commit ->
+            if (quickViewAgainstHead.value) git.value.getCommitDiffAgainstHead(commit.sha)
+            else git.value.getCommitDiff(commit.sha)
+        } ?: emptyList()
+        DiffTree.make(deltas)
     }
 
     // The tab to return to when the quick view is dismissed. Only captured on the way
@@ -208,12 +218,26 @@ object GitDownState {
     fun openQuickView(commit: CommitGraphNode) {
         if (currentTab.value != Tab.QuickView) tabBeforeQuickView = currentTab.value
         quickViewCommit.value = commit
+        quickViewAgainstHead.value = false
+        selectTab(Tab.QuickView)
+    }
+
+    /**
+     * Launches the "Diff with HEAD" view (see issue #280) against [commit]: the same
+     * ephemeral diff view as the quick view, but diffing [commit] against the current
+     * HEAD instead of its own first parent.
+     */
+    fun openDiffWithHead(commit: CommitGraphNode) {
+        if (currentTab.value != Tab.QuickView) tabBeforeQuickView = currentTab.value
+        quickViewCommit.value = commit
+        quickViewAgainstHead.value = true
         selectTab(Tab.QuickView)
     }
 
     /** Closes the quick view, clearing its commit and restoring the prior tab. */
     fun closeQuickView() {
         quickViewCommit.value = null
+        quickViewAgainstHead.value = false
         selectTab(tabBeforeQuickView)
     }
 

--- a/src/main/kotlin/com/codymikol/views/MapView.kt
+++ b/src/main/kotlin/com/codymikol/views/MapView.kt
@@ -275,8 +275,9 @@ private fun BranchPill(branchName: String, color: Color) {
 
 // The right-click context menu for a commit node (#253). Its actions are grouped
 // by CommitContextMenu, with a divider drawn between each group. Quick View (#254)
-// launches the quick view for this commit; the remaining behaviours are wired up
-// in follow-up issues, so those items only dismiss for now.
+// launches the quick view for this commit and Diff with HEAD (#280) diffs it
+// against the current HEAD; the remaining behaviours are wired up in follow-up
+// issues, so those items only dismiss for now.
 @Composable
 private fun CommitContextMenu(
     commit: CommitGraphNode,
@@ -296,6 +297,9 @@ private fun CommitContextMenu(
                     onClick = when (action.label) {
                         "Quick View" -> {
                             { GitDownState.openQuickView(commit); onDismiss() }
+                        }
+                        "Diff with HEAD..." -> {
+                            { GitDownState.openDiffWithHead(commit); onDismiss() }
                         }
                         else -> onDismiss
                     },

--- a/src/main/kotlin/com/codymikol/windows/GitDown.kt
+++ b/src/main/kotlin/com/codymikol/windows/GitDown.kt
@@ -81,6 +81,10 @@ fun GitDown(applicationScope: ApplicationScope) {
             val quickViewTarget = if (isDown && it.key == Key.Spacebar && tab == Tab.Map)
                 MapState.selectedNode() else null
 
+            // "I" on the map with a node selected diffs that node against HEAD (#280).
+            val diffWithHeadTarget = if (isDown && it.key == Key.I && tab == Tab.Map)
+                MapState.selectedNode() else null
+
             // Space or Escape closes the quick view while it is open.
             val shouldCloseQuickView = isDown && tab == Tab.QuickView &&
                 (it.key == Key.Spacebar || it.key == Key.Escape)
@@ -96,6 +100,10 @@ fun GitDown(applicationScope: ApplicationScope) {
                 }
                 quickViewTarget != null -> {
                     GitDownState.openQuickView(quickViewTarget)
+                    true
+                }
+                diffWithHeadTarget != null -> {
+                    GitDownState.openDiffWithHead(diffWithHeadTarget)
                     true
                 }
                 else -> false

--- a/src/test/kotlin/com/codymikol/extensions/CommitDiffAgainstHeadSpec.kt
+++ b/src/test/kotlin/com/codymikol/extensions/CommitDiffAgainstHeadSpec.kt
@@ -1,0 +1,67 @@
+package com.codymikol.extensions
+
+import com.codymikol.data.diff.DiffTree
+import com.codymikol.data.diff.LineType
+import com.codymikol.repository.TestRepository.Companion.createTestRepository
+import com.codymikol.state.GitDownState
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+class CommitDiffAgainstHeadSpec : DescribeSpec({
+
+    describe("Git.getCommitDiffAgainstHead") {
+
+        describe("a commit that differs from HEAD") {
+
+            autoClose(
+                createTestRepository()
+                    .addFile("foo.txt", "one\n")
+                    .stageAll()
+                    .commitAll("init")
+                    .appendToFile("foo.txt", "two\n")
+                    .stageAll()
+                    .commitAll("add two")
+                    .transferIntoGitDownState()
+            )
+
+            it("should contain a single file delta") {
+                GitDownState.git.value.getCommitDiffAgainstHead("HEAD~1") shouldHaveSize 1
+            }
+
+            it("should diff the selected commit against HEAD, not its own parent") {
+                val node = DiffTree.make(GitDownState.git.value.getCommitDiffAgainstHead("HEAD~1"))
+                    .fileDeltaNodes
+                    .single()
+
+                // HEAD has "one\ntwo"; the selected commit (HEAD~1) has only "one",
+                // so turning HEAD into it removes "two".
+                val removedValues = node.hunkNodes
+                    .flatMap { it.lineNodes }
+                    .filter { it.line.type == LineType.Removed }
+                    .map { it.line.value }
+
+                removedValues shouldBe listOf("two")
+            }
+
+            it("should produce an empty diff for HEAD against itself") {
+                GitDownState.git.value.getCommitDiffAgainstHead("HEAD") shouldHaveSize 0
+            }
+        }
+
+        describe("an unknown commit reference") {
+
+            autoClose(
+                createTestRepository()
+                    .addFile("init.txt", "init")
+                    .stageAll()
+                    .commitAll("init")
+                    .transferIntoGitDownState()
+            )
+
+            it("should produce an empty diff") {
+                GitDownState.git.value.getCommitDiffAgainstHead("does-not-exist") shouldHaveSize 0
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/codymikol/state/QuickViewStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/QuickViewStateSpec.kt
@@ -57,6 +57,18 @@ class QuickViewStateSpec : DescribeSpec({
             }
         }
 
+        describe("openDiffWithHead") {
+
+            it("stores the commit and switches to the QuickView tab") {
+                GitDownState.selectTab(Tab.Map)
+
+                GitDownState.openDiffWithHead(node(message = "hello"))
+
+                GitDownState.quickViewCommit.value?.shortMessage shouldBe "hello"
+                GitDownState.currentTab.value shouldBe Tab.QuickView
+            }
+        }
+
         describe("quickViewDiffTree") {
 
             beforeContainer { GitDownState.git.value.close() }
@@ -83,6 +95,32 @@ class QuickViewStateSpec : DescribeSpec({
                 GitDownState.closeQuickView()
 
                 GitDownState.quickViewDiffTree.value.fileDeltaNodes shouldHaveSize 0
+            }
+
+            it("diffs against HEAD when opened via openDiffWithHead") {
+                val parentSha = GitDownState.git.value.repository.resolve("HEAD~1").name
+                GitDownState.openDiffWithHead(node(sha = parentSha))
+
+                // HEAD~1 against HEAD still differs by a single file...
+                GitDownState.quickViewDiffTree.value.fileDeltaNodes shouldHaveSize 1
+            }
+
+            it("diffs the parent against HEAD, not the quick view's first-parent diff") {
+                val headSha = GitDownState.git.value.repository.resolve("HEAD").name
+                // ...but the same commit against its own parent (quick view) versus
+                // against HEAD (itself) differ: a quick view of HEAD shows one delta,
+                // a HEAD-vs-HEAD diff shows none.
+                GitDownState.openDiffWithHead(node(sha = headSha))
+
+                GitDownState.quickViewDiffTree.value.fileDeltaNodes shouldHaveSize 0
+            }
+
+            it("returns to the quick view diff after reopening a quick view") {
+                val headSha = GitDownState.git.value.repository.resolve("HEAD").name
+                GitDownState.openDiffWithHead(node(sha = headSha))
+                GitDownState.openQuickView(node(sha = headSha))
+
+                GitDownState.quickViewDiffTree.value.fileDeltaNodes shouldHaveSize 1
             }
         }
     }


### PR DESCRIPTION
Adds service-layer support for diffing a selected commit against the
current HEAD and surfaces it through the existing Quick View diff view.

## What changed
- `Git.getCommitDiffAgainstHead(sha)` scans HEAD's tree to the selected
  commit's tree, returning the same read-only `FileDelta` shape the quick
  view already renders. The shared tree-scan-and-format step is extracted
  into `diffTrees` so the first-parent diff and the HEAD diff reuse it.
- `GitDownState.openDiffWithHead(commit)` plus a `quickViewAgainstHead`
  flag let the same ephemeral diff view render either a commit's
  first-parent diff (Quick View, #254) or its diff against HEAD (#280).
  Opening a plain quick view or closing it resets the flag.
- The commit context menu's "Diff with HEAD..." item and the `I` shortcut
  on a selected map node both call `openDiffWithHead`, mirroring how Quick
  View binds to Space.

## Diff direction
base = HEAD tree, target = selected commit tree — consistent with the
existing parent-relative quick view (base = parent, target = commit). A
commit identical to HEAD, an unresolvable ref, or a repo with no HEAD all
yield an empty diff.

## Testing
CI is the execution gate: this environment has no working JVM/JDK and a
read-only nix store (no daemon/sudo), so gradle tests could not be run
locally. Added `CommitDiffAgainstHeadSpec` (single delta, removed-line
assertion proving HEAD-vs-parent distinction, HEAD-vs-HEAD empty, unknown
ref empty) and extended `QuickViewStateSpec` (open/reset flag, diff-against-
HEAD vs first-parent contrast).

Closes #280