### PR TITLE
feat: quick view files

### DIFF
--- a/src/main/kotlin/com/codymikol/components/commit/diff/Diff.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/diff/Diff.kt
@@ -44,9 +44,12 @@ private val logger = LoggerFactory.getLogger("com.codymikol.components.commit.di
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun Diff(fileDeltaNodes: List<FileDeltaNode>, showActions: Boolean = true) {
+fun Diff(
+    fileDeltaNodes: List<FileDeltaNode>,
+    showActions: Boolean = true,
+    listState: LazyListState = rememberLazyListState(),
+) {
     val dragState = remember { DragSelectionState() }
-    val listState = rememberLazyListState()
     val diffItems by remember(fileDeltaNodes) {
         derivedStateOf { buildDiffItems(fileDeltaNodes) }
     }
@@ -283,13 +286,13 @@ private class DragSelectionState {
     }
 }
 
-private sealed class DiffItem {
+internal sealed class DiffItem {
     data class FileHeaderItem(val fileDeltaNode: FileDeltaNode) : DiffItem()
     data class HunkHeaderItem(val hunk: Hunk) : DiffItem()
     data class LineItem(val lineNode: LineNode, val parentFileNode: FileDeltaNode) : DiffItem()
 }
 
-private fun buildDiffItems(fileDeltaNodes: List<FileDeltaNode>): List<DiffItem> {
+internal fun buildDiffItems(fileDeltaNodes: List<FileDeltaNode>): List<DiffItem> {
     val items = ArrayList<DiffItem>()
     fileDeltaNodes.forEach { fileDeltaNode ->
         items.add(DiffItem.FileHeaderItem(fileDeltaNode))

--- a/src/main/kotlin/com/codymikol/components/commit/diff/DiffFileIndex.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/diff/DiffFileIndex.kt
@@ -1,0 +1,28 @@
+package com.codymikol.components.commit.diff
+
+import com.codymikol.data.diff.FileDeltaNode
+
+/**
+ * The flat LazyColumn item index of each file's sticky header, mirroring the layout
+ * built by the Diff component: one item per file header, then per hunk one hunk header
+ * followed by one item per line. Used by the quick view (see issue #278) to scroll the
+ * diff so a selected file's header lands at the top.
+ */
+fun fileHeaderItemIndices(fileDeltaNodes: List<FileDeltaNode>): List<Int> {
+    val indices = ArrayList<Int>(fileDeltaNodes.size)
+    var running = 0
+    fileDeltaNodes.forEach { node ->
+        indices.add(running)
+        running += 1
+        node.hunkNodes.forEach { hunk -> running += 1 + hunk.lineNodes.size }
+    }
+    return indices
+}
+
+/**
+ * The index of the file whose header is currently sticky at the top of the diff - the
+ * last file header at or above [firstVisibleItemIndex] - or -1 when there are no files.
+ * [fileHeaderIndices] is the output of [fileHeaderItemIndices].
+ */
+fun stickyFileIndex(firstVisibleItemIndex: Int, fileHeaderIndices: List<Int>): Int =
+    fileHeaderIndices.indexOfLast { it <= firstVisibleItemIndex }

--- a/src/main/kotlin/com/codymikol/state/state.kt
+++ b/src/main/kotlin/com/codymikol/state/state.kt
@@ -99,6 +99,11 @@ object GitDownState {
         DiffTree.make(deltas)
     }
 
+    // The path of the file highlighted in the quick view file list (see issue #278),
+    // or null when nothing is explicitly selected - in which case the first file (the
+    // one whose header is sticky at the top of the diff) is treated as the selection.
+    val quickViewSelectedFilePath = mutableStateOf<String?>(null)
+
     // The tab to return to when the quick view is dismissed. Only captured on the way
     // in so reopening the quick view for a different commit keeps the original.
     private var tabBeforeQuickView: Tab = Tab.Map
@@ -219,6 +224,7 @@ object GitDownState {
         if (currentTab.value != Tab.QuickView) tabBeforeQuickView = currentTab.value
         quickViewCommit.value = commit
         quickViewAgainstHead.value = false
+        quickViewSelectedFilePath.value = null
         selectTab(Tab.QuickView)
     }
 
@@ -231,6 +237,7 @@ object GitDownState {
         if (currentTab.value != Tab.QuickView) tabBeforeQuickView = currentTab.value
         quickViewCommit.value = commit
         quickViewAgainstHead.value = true
+        quickViewSelectedFilePath.value = null
         selectTab(Tab.QuickView)
     }
 
@@ -238,7 +245,28 @@ object GitDownState {
     fun closeQuickView() {
         quickViewCommit.value = null
         quickViewAgainstHead.value = false
+        quickViewSelectedFilePath.value = null
         selectTab(tabBeforeQuickView)
+    }
+
+    /** Highlights [path] in the quick view file list (see issue #278). */
+    fun selectQuickViewFile(path: String) {
+        quickViewSelectedFilePath.value = path
+    }
+
+    /**
+     * Moves the quick view file selection by [offset] (see issue #278), clamped to the
+     * commit's file list. With nothing selected the first file - the one sticky at the
+     * top of the diff - is treated as the current selection.
+     */
+    fun selectAdjacentQuickViewFile(offset: Int) {
+        val paths = quickViewDiffTree.value.fileDeltaNodes.map { it.getPath() }
+        if (paths.isEmpty()) return
+
+        val currentIndex = paths.indexOf(quickViewSelectedFilePath.value).coerceAtLeast(0)
+        val nextIndex = (currentIndex + offset).coerceIn(paths.indices)
+
+        quickViewSelectedFilePath.value = paths[nextIndex]
     }
 
     fun selectAdjacentFile(offset: Int) {

--- a/src/main/kotlin/com/codymikol/views/QuickView.kt
+++ b/src/main/kotlin/com/codymikol/views/QuickView.kt
@@ -3,6 +3,7 @@ package com.codymikol.views
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,15 +13,22 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -29,9 +37,15 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.codymikol.components.ReversedEllipsisText
 import com.codymikol.components.Subheader
+import com.codymikol.components.commit.FileIcon
+import com.codymikol.components.commit.changedFileDisplayText
 import com.codymikol.components.commit.diff.Diff
+import com.codymikol.components.commit.diff.fileHeaderItemIndices
+import com.codymikol.components.commit.diff.stickyFileIndex
 import com.codymikol.data.Colors
+import com.codymikol.data.diff.FileDeltaNode
 import com.codymikol.data.map.CommitGraphNode
 import com.codymikol.data.map.QuickViewCommitDetails
 import com.codymikol.state.GitDownState
@@ -45,6 +59,10 @@ import java.util.Date
 @Composable
 @Preview
 fun QuickView() {
+    // The diff's list state is hoisted here so the left panel's file list can scroll the
+    // right panel to a clicked file and observe which file header is sticky at its top.
+    val diffListState = rememberLazyListState()
+
     Row(modifier = Modifier.fillMaxWidth().fillMaxHeight()) {
         Column(
             modifier = Modifier
@@ -53,7 +71,7 @@ fun QuickView() {
                 .fillMaxHeight()
                 .border(width = 1.dp, color = Color.Black)
         ) {
-            QuickViewDetailPanel()
+            QuickViewDetailPanel(diffListState)
         }
         Column(
             modifier = Modifier
@@ -62,17 +80,70 @@ fun QuickView() {
                 .background(Colors.DarkGrayBackground)
                 .border(width = 1.dp, color = Color.Black)
         ) {
-            QuickViewDiffPanel()
+            QuickViewDiffPanel(diffListState)
         }
     }
 }
 
 @Composable
-private fun ColumnScope.QuickViewDetailPanel() {
+private fun ColumnScope.QuickViewDetailPanel(diffListState: LazyListState) {
     Subheader("Commit")
     when (val commit = GitDownState.quickViewCommit.value) {
         null -> QuickViewEmptyState("No commit selected")
-        else -> CommitDetails(commit)
+        else -> {
+            CommitDetails(commit)
+            QuickViewFileList(diffListState)
+        }
+    }
+}
+
+/**
+ * The list of files changed in the quick view's commit (see issue #278), drawn beneath
+ * the commit details behind a top border. Selecting a file highlights it and scrolls the
+ * diff so its header is at the top; the highlight also tracks whichever header is sticky.
+ */
+@Composable
+private fun QuickViewFileList(diffListState: LazyListState) {
+    val nodes = GitDownState.quickViewDiffTree.value.fileDeltaNodes
+    if (nodes.isEmpty()) return
+
+    val selectedPath = GitDownState.quickViewSelectedFilePath.value
+    val selectedIndex = nodes.indexOfFirst { it.getPath() == selectedPath }.coerceAtLeast(0)
+
+    Box(modifier = Modifier.fillMaxWidth().height(1.dp).background(Color.Black))
+
+    LazyColumn(modifier = Modifier.fillMaxWidth().heightIn(max = 220.dp)) {
+        itemsIndexed(nodes) { index, node ->
+            QuickViewFileRow(
+                node = node,
+                selected = index == selectedIndex,
+                onClick = { GitDownState.selectQuickViewFile(node.getPath()) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun QuickViewFileRow(node: FileDeltaNode, selected: Boolean, onClick: () -> Unit) {
+    val background = if (selected) Color(0, 89, 207) else Color.Transparent
+
+    Row(
+        modifier = Modifier
+            .clickable { onClick() }
+            .fillMaxWidth()
+            .height(18.dp)
+            .background(background),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Spacer(modifier = Modifier.width(12.dp))
+        FileIcon(fileDelta = node.fileDelta)
+        ReversedEllipsisText(
+            text = changedFileDisplayText(node.fileDelta),
+            modifier = Modifier.weight(1f).padding(6.dp, 0.dp, 0.dp, 0.dp),
+            color = Color.White,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Normal
+        )
     }
 }
 
@@ -134,11 +205,48 @@ private fun CommitterAvatar(commit: CommitGraphNode) {
 }
 
 @Composable
-private fun QuickViewDiffPanel() = when (GitDownState.quickViewCommit.value) {
+private fun QuickViewDiffPanel(diffListState: LazyListState) = when (GitDownState.quickViewCommit.value) {
     null -> Column { QuickViewEmptyState("No commit selected") }
-    else -> when (GitDownState.quickViewDiffTree.value.fileDeltaNodes.isNotEmpty()) {
-        true -> Diff(GitDownState.quickViewDiffTree.value.fileDeltaNodes, showActions = false)
-        false -> Column { QuickViewEmptyState("No changes in commit") }
+    else -> {
+        val nodes = GitDownState.quickViewDiffTree.value.fileDeltaNodes
+        when (nodes.isNotEmpty()) {
+            true -> {
+                QuickViewDiffSync(nodes, diffListState)
+                Diff(nodes, showActions = false, listState = diffListState)
+            }
+            false -> Column { QuickViewEmptyState("No changes in commit") }
+        }
+    }
+}
+
+/**
+ * Keeps the quick view file selection (see issue #278) and the diff scroll position in
+ * sync: scrolling updates the selection to whichever file header is sticky at the top,
+ * and selecting a different file scrolls its header to the top.
+ */
+@Composable
+private fun QuickViewDiffSync(nodes: List<FileDeltaNode>, diffListState: LazyListState) {
+    // Scroll -> selection: the sticky top header is the highlighted file.
+    LaunchedEffect(nodes, diffListState) {
+        val headerIndices = fileHeaderItemIndices(nodes)
+        snapshotFlow { diffListState.firstVisibleItemIndex }.collect { firstVisible ->
+            val stickyIndex = stickyFileIndex(firstVisible, headerIndices)
+            if (stickyIndex < 0) return@collect
+            val path = nodes[stickyIndex].getPath()
+            if (GitDownState.quickViewSelectedFilePath.value != path) GitDownState.selectQuickViewFile(path)
+        }
+    }
+
+    // Selection -> scroll: only when the selected file is not already the sticky one, so
+    // selection updates that come from a manual scroll do not fight the user's scroll.
+    val selectedPath = GitDownState.quickViewSelectedFilePath.value
+    LaunchedEffect(selectedPath, nodes) {
+        if (selectedPath == null) return@LaunchedEffect
+        val selectedIndex = nodes.indexOfFirst { it.getPath() == selectedPath }
+        if (selectedIndex < 0) return@LaunchedEffect
+        val headerIndices = fileHeaderItemIndices(nodes)
+        val stickyIndex = stickyFileIndex(diffListState.firstVisibleItemIndex, headerIndices)
+        if (selectedIndex != stickyIndex) diffListState.scrollToItem(headerIndices[selectedIndex])
     }
 }
 

--- a/src/main/kotlin/com/codymikol/windows/GitDown.kt
+++ b/src/main/kotlin/com/codymikol/windows/GitDown.kt
@@ -89,9 +89,17 @@ fun GitDown(applicationScope: ApplicationScope) {
             val shouldCloseQuickView = isDown && tab == Tab.QuickView &&
                 (it.key == Key.Spacebar || it.key == Key.Escape)
 
+            // Up/Down selects the previous/next file in the quick view (#278).
+            val isQuickViewFileArrow = isDown && tab == Tab.QuickView &&
+                (it.key == Key.DirectionUp || it.key == Key.DirectionDown)
+
             when {
                 isFileSelectionArrow -> {
                     GitDownState.selectAdjacentFile(if (it.key == Key.DirectionUp) -1 else 1)
+                    true
+                }
+                isQuickViewFileArrow -> {
+                    GitDownState.selectAdjacentQuickViewFile(if (it.key == Key.DirectionUp) -1 else 1)
                     true
                 }
                 shouldCloseQuickView -> {

--- a/src/test/kotlin/com/codymikol/components/commit/diff/DiffFileIndexSpec.kt
+++ b/src/test/kotlin/com/codymikol/components/commit/diff/DiffFileIndexSpec.kt
@@ -1,0 +1,64 @@
+package com.codymikol.components.commit.diff
+
+import com.codymikol.data.diff.DiffTree
+import com.codymikol.extensions.getCommitDiff
+import com.codymikol.repository.TestRepository.Companion.createTestRepository
+import com.codymikol.state.GitDownState
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class DiffFileIndexSpec : DescribeSpec({
+
+    describe("fileHeaderItemIndices") {
+
+        beforeContainer { GitDownState.git.value.close() }
+
+        autoClose(
+            createTestRepository()
+                .addFile("a.txt", "l1\nl2\nl3\nl4\nl5\n")
+                .addFile("b.txt", "one\n")
+                .stageAll()
+                .commitAll("init")
+                .appendToFile("a.txt", "l6\n")
+                .appendToFile("b.txt", "two\n")
+                .stageAll()
+                .commitAll("edit both")
+                .transferIntoGitDownState()
+        )
+
+        it("points at every file header in the built diff item list") {
+            val headSha = GitDownState.git.value.repository.resolve("HEAD").name
+            val nodes = DiffTree.make(GitDownState.git.value.getCommitDiff(headSha)).fileDeltaNodes
+
+            val expected = buildDiffItems(nodes)
+                .mapIndexedNotNull { index, item -> if (item is DiffItem.FileHeaderItem) index else null }
+
+            fileHeaderItemIndices(nodes) shouldBe expected
+        }
+    }
+
+    describe("stickyFileIndex") {
+
+        val headerIndices = listOf(0, 5, 12)
+
+        it("returns -1 when there are no files") {
+            stickyFileIndex(0, emptyList()) shouldBe -1
+        }
+
+        it("returns the first file at the very top") {
+            stickyFileIndex(0, headerIndices) shouldBe 0
+        }
+
+        it("stays on a file while its lines are the first visible item") {
+            stickyFileIndex(3, headerIndices) shouldBe 0
+        }
+
+        it("advances to the next file once its header is the first visible item") {
+            stickyFileIndex(5, headerIndices) shouldBe 1
+        }
+
+        it("advances to the last file when scrolled past its header") {
+            stickyFileIndex(20, headerIndices) shouldBe 2
+        }
+    }
+})

--- a/src/test/kotlin/com/codymikol/state/QuickViewStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/QuickViewStateSpec.kt
@@ -123,5 +123,81 @@ class QuickViewStateSpec : DescribeSpec({
                 GitDownState.quickViewDiffTree.value.fileDeltaNodes shouldHaveSize 1
             }
         }
+
+        describe("quick view file selection") {
+
+            beforeContainer { GitDownState.git.value.close() }
+
+            autoClose(
+                createTestRepository()
+                    .addFile("a.txt", "one\n")
+                    .addFile("b.txt", "one\n")
+                    .stageAll()
+                    .commitAll("init")
+                    .appendToFile("a.txt", "two\n")
+                    .appendToFile("b.txt", "two\n")
+                    .stageAll()
+                    .commitAll("edit both")
+                    .transferIntoGitDownState()
+            )
+
+            fun paths() = GitDownState.quickViewDiffTree.value.fileDeltaNodes.map { it.getPath() }
+
+            it("has no file selected when the quick view opens") {
+                val headSha = GitDownState.git.value.repository.resolve("HEAD").name
+                GitDownState.openQuickView(node(sha = headSha))
+
+                GitDownState.quickViewSelectedFilePath.value shouldBe null
+            }
+
+            it("selects a specific file by path") {
+                val headSha = GitDownState.git.value.repository.resolve("HEAD").name
+                GitDownState.openQuickView(node(sha = headSha))
+
+                val target = paths()[1]
+                GitDownState.selectQuickViewFile(target)
+
+                GitDownState.quickViewSelectedFilePath.value shouldBe target
+            }
+
+            it("moves to the next file, treating no selection as the first file") {
+                val headSha = GitDownState.git.value.repository.resolve("HEAD").name
+                GitDownState.openQuickView(node(sha = headSha))
+
+                GitDownState.selectAdjacentQuickViewFile(1)
+
+                GitDownState.quickViewSelectedFilePath.value shouldBe paths()[1]
+            }
+
+            it("moves to the previous file") {
+                val headSha = GitDownState.git.value.repository.resolve("HEAD").name
+                GitDownState.openQuickView(node(sha = headSha))
+                GitDownState.selectQuickViewFile(paths()[1])
+
+                GitDownState.selectAdjacentQuickViewFile(-1)
+
+                GitDownState.quickViewSelectedFilePath.value shouldBe paths()[0]
+            }
+
+            it("clamps at the last file") {
+                val headSha = GitDownState.git.value.repository.resolve("HEAD").name
+                GitDownState.openQuickView(node(sha = headSha))
+                GitDownState.selectQuickViewFile(paths().last())
+
+                GitDownState.selectAdjacentQuickViewFile(1)
+
+                GitDownState.quickViewSelectedFilePath.value shouldBe paths().last()
+            }
+
+            it("clears the selected file when reopening the quick view") {
+                val headSha = GitDownState.git.value.repository.resolve("HEAD").name
+                GitDownState.openQuickView(node(sha = headSha))
+                GitDownState.selectQuickViewFile(paths()[1])
+
+                GitDownState.openQuickView(node(sha = headSha))
+
+                GitDownState.quickViewSelectedFilePath.value shouldBe null
+            }
+        }
     }
 })


### PR DESCRIPTION
Implements #278.

## What changed
- **Quick view file list** — beneath the commit details in the left panel, behind a top border, the quick view now lists the files changed in the commit, reusing the commit view's file icon and path rendering (`FileIcon` + `ReversedEllipsisText` + `changedFileDisplayText`).
- **Click to select + scroll** — clicking a file highlights it and scrolls the right diff panel so that file's header lands at the top.
- **Arrow keys** — Up/Down select the previous/next file while the quick view is open.
- **Sticky header drives selection** — scrolling the diff so a different file header becomes sticky at the top updates the highlighted file to match.

## How
- `GitDownState` gains `quickViewSelectedFilePath` plus `selectQuickViewFile` / `selectAdjacentQuickViewFile`; the selection resets on open/close.
- `Diff` now accepts an optional hoisted `LazyListState` (default unchanged for existing callers) so the quick view can drive and observe its scroll.
- Two pure helpers, `fileHeaderItemIndices` and `stickyFileIndex`, mirror the diff's LazyColumn layout to map file ↔ scroll position; a regression test ties `fileHeaderItemIndices` to the real `buildDiffItems` output.
- The left↔right sync is two guarded `LaunchedEffect`s: scroll→selection follows the sticky header, and selection→scroll only fires when the selected file is not already sticky, so a manual scroll is never snapped.

## Notes for reviewers
- State logic and the pure index helpers are covered by Kotest specs. The Compose sync effects have no unit coverage — the repo has no Compose UI-test harness.
- Local build/test could not be run in the agent sandbox (read-only nix store, no JDK); relying on CI (`./gradlew build`).
- Trailing files whose diff is too short to reach the top can't become the sticky top header, so per the spec's "sticky top header is the selection" rule their highlight tracks the sticky file rather than sticking — intentional and spec-faithful.