### PR TITLE
fix(map): make the collar card fit its content

### DIFF
--- a/src/main/kotlin/com/codymikol/data/map/CommitCard.kt
+++ b/src/main/kotlin/com/codymikol/data/map/CommitCard.kt
@@ -8,7 +8,7 @@ import java.util.Date
  * Formats the three lines shown on the floating card that appears when a commit
  * node is clicked in the map view (see issue #252):
  *
- *   <short sha>: <commit message>
+ *   <short sha>: <first line of commit message>
  *   Author: <name> <<email>>
  *   Date: MM/DD/YY, h:mm AM/PM <relative>
  *
@@ -17,7 +17,9 @@ import java.util.Date
  */
 object CommitCard {
 
-    fun title(node: CommitGraphNode): String = "${node.shortSha}: ${node.shortMessage}"
+    fun title(node: CommitGraphNode): String = "${node.shortSha}: ${firstLine(node.shortMessage)}"
+
+    private fun firstLine(message: String): String = message.lineSequence().firstOrNull().orEmpty()
 
     fun author(node: CommitGraphNode): String = "Author: ${node.authorName} <${node.authorEmail}>"
 

--- a/src/main/kotlin/com/codymikol/views/MapView.kt
+++ b/src/main/kotlin/com/codymikol/views/MapView.kt
@@ -61,7 +61,6 @@ private const val ConnectorStrokeWidth = 2f
 private val CardTabSize = 22.dp
 private val CardHoleSize = 8.dp
 private val CardCorner = 10.dp
-private val CardMaxWidth = 150.dp
 
 // Branch-name pills shown on tip commits (#272), colored the same as the node they
 // label so they read as an extension of it rather than an unrelated UI element.
@@ -229,8 +228,8 @@ private fun CommitNode(
             )
         }
 
-        // Hidden while the detail card is showing: the card (up to CardMaxWidth,
-        // leading) and a full row of pills (up to PillMaxWidth each, trailing) can
+        // Hidden while the detail card is showing: the card sizes to its content
+        // (leading) and a full row of pills (up to PillMaxWidth each, trailing) can
         // together exceed LaneWidth, so they'd otherwise risk overlapping.
         if (tipBranches.isNotEmpty() && !isSelected) {
             Row(
@@ -321,7 +320,7 @@ private fun CommitDetailCard(
     val now = remember(commit.sha) { Date() }
 
     Row(
-        modifier = modifier.widthIn(max = CardMaxWidth),
+        modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Box(

--- a/src/test/kotlin/com/codymikol/data/map/CommitCardSpec.kt
+++ b/src/test/kotlin/com/codymikol/data/map/CommitCardSpec.kt
@@ -34,6 +34,11 @@ class CommitCardSpec : DescribeSpec({
             it("joins the short sha and the commit message") {
                 CommitCard.title(node(shortSha = "abc1234", shortMessage = "fix bug")) shouldBe "abc1234: fix bug"
             }
+
+            it("renders only the first line of a multi-line commit message") {
+                CommitCard.title(node(shortSha = "abc1234", shortMessage = "fix bug\n\nlong body here")) shouldBe
+                    "abc1234: fix bug"
+            }
         }
 
         describe("author") {


### PR DESCRIPTION
Closes #281

The map view floating "collar" detail card (shown when a commit node is
selected) was capped at a fixed 150.dp max width, cutting off its text,
and joined the short sha with the full short message which could span
multiple lines.

## Changes
- `CommitCard.title` now renders only the first line of the commit
  message, so the card never needs to grow vertically.
- The commit detail card drops its `widthIn(max = CardMaxWidth)` cap and
  sizes horizontally to its content; the unused `CardMaxWidth` constant is
  removed.

## Notes for reviewers
- The card is now bounded only by its parent lane; a pathologically long
  first line would still ellipsize at the lane edge (existing `maxLines=1`
  + ellipsis on `CardLine`), which is the sensible bound.
- The local sandbox had no JDK and a read-only nix store with no network,
  so gradle tests could not be run locally — relying on CI to validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)