### PR TITLE
feat(map): pin branch pills to the top of the grid

### DIFF
--- a/src/main/kotlin/com/codymikol/services/BranchTipOrderer.kt
+++ b/src/main/kotlin/com/codymikol/services/BranchTipOrderer.kt
@@ -1,0 +1,74 @@
+package com.codymikol.services
+
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.lib.ObjectId
+import org.eclipse.jgit.lib.Ref
+import org.eclipse.jgit.lib.Repository
+import org.eclipse.jgit.revwalk.RevWalk
+import org.eclipse.jgit.revwalk.filter.RevFilter
+
+/**
+ * One branch tip as shown by a map pill (see issue #277): the tip commit's sha and
+ * the name(s) of every branch pointing at it, so a shared tip renders a single pill
+ * carrying all of its names.
+ */
+data class OrderedBranchTip(val sha: String, val branchNames: List<String>)
+
+/**
+ * Orders the branch tips whose pills sit along the top of the map (see issue #277).
+ * The default branch's tip comes first - it is the mainline everything merges back
+ * into - and every other tip follows ordered by how soon it rejoins that mainline:
+ * the fewer commits the mainline has gained since the two histories last shared a
+ * commit (their merge base), the nearer the tip sits to the mainline. Ties, and any
+ * tip with no shared history, fall back to branch name so the order is stable.
+ */
+object BranchTipOrderer {
+
+    fun order(git: Git, defaultBranchName: String?, branches: List<Ref>): List<OrderedBranchTip> {
+        if (branches.isEmpty()) return emptyList()
+
+        val tips = branches
+            .groupBy({ it.objectId.name }, { it.name.removePrefix("refs/heads/") })
+            .map { (sha, names) -> OrderedBranchTip(sha, names.sorted()) }
+
+        val repo = git.repository
+        val defaultSha = branches
+            .firstOrNull { it.name.removePrefix("refs/heads/") == defaultBranchName }
+            ?.objectId?.name
+        val defaultId = defaultSha?.let { repo.resolve(it) }
+
+        fun mainlineDistance(tip: OrderedBranchTip): Int {
+            if (defaultId == null || tip.sha == defaultSha) return 0
+            val tipId = repo.resolve(tip.sha) ?: return Int.MAX_VALUE
+            val base = mergeBase(repo, defaultId, tipId) ?: return Int.MAX_VALUE
+            return countAhead(repo, defaultId, base)
+        }
+
+        val distances = tips.associateWith(::mainlineDistance)
+
+        return tips.sortedWith(
+            compareByDescending<OrderedBranchTip> { it.sha == defaultSha }
+                .thenBy { distances.getValue(it) }
+                .thenBy { it.branchNames.firstOrNull() ?: "" }
+        )
+    }
+
+    private fun mergeBase(repo: Repository, a: ObjectId, b: ObjectId): ObjectId? =
+        RevWalk(repo).use { walk ->
+            walk.revFilter = RevFilter.MERGE_BASE
+            walk.markStart(walk.parseCommit(a))
+            walk.markStart(walk.parseCommit(b))
+            walk.next()?.id
+        }
+
+    // Commits reachable from [tip] but not from [base]: how far the mainline has
+    // advanced since it last shared history with the branch.
+    private fun countAhead(repo: Repository, tip: ObjectId, base: ObjectId): Int =
+        RevWalk(repo).use { walk ->
+            walk.markStart(walk.parseCommit(tip))
+            walk.markUninteresting(walk.parseCommit(base))
+            var count = 0
+            while (walk.next() != null) count++
+            count
+        }
+}

--- a/src/main/kotlin/com/codymikol/state/MapState.kt
+++ b/src/main/kotlin/com/codymikol/state/MapState.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableStateOf
 import com.codymikol.data.map.CommitGraphNode
 import com.codymikol.data.map.CommitHistoryWalker
 import com.codymikol.extensions.listLocalBranches
+import com.codymikol.services.BranchTipOrderer
 import com.codymikol.services.LaneAssigner
 
 /**
@@ -75,6 +76,20 @@ object MapState {
         branches.value.groupBy(
             keySelector = { it.objectId.name },
             valueTransform = { it.name.removePrefix("refs/heads/") }
+        )
+    }
+
+    /**
+     * Every branch tip ordered for the pill row pinned to the top of the map (see
+     * issue #277): the default branch first, then each side branch by how soon it
+     * merges back into the default tip. Left-to-right this reads as the lanes
+     * cleanly converging on the mainline.
+     */
+    val orderedBranchTips = derivedStateOf {
+        BranchTipOrderer.order(
+            GitDownState.git.value,
+            GitDownState.git.value.repository.branch,
+            branches.value,
         )
     }
 

--- a/src/main/kotlin/com/codymikol/views/MapView.kt
+++ b/src/main/kotlin/com/codymikol/views/MapView.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.PointerMatcher
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -46,6 +48,7 @@ import com.codymikol.data.map.CommitContextMenu as CommitContextMenuModel
 import com.codymikol.data.map.CommitGraphNode
 import com.codymikol.data.map.MapConnector
 import com.codymikol.services.MapConnectors
+import com.codymikol.services.OrderedBranchTip
 import com.codymikol.state.GitDownState
 import com.codymikol.state.MapState
 import java.util.Date
@@ -63,12 +66,11 @@ private val CardHoleSize = 8.dp
 private val CardCorner = 10.dp
 private val CardMaxWidth = 150.dp
 
-// Branch-name pills shown on tip commits (#272), colored the same as the node they
-// label so they read as an extension of it rather than an unrelated UI element.
+// Branch-name pills for each branch tip (#272), pinned to a row at the top of the
+// map (#277) and colored by the same rule as the node they label.
 private val PillCorner = 8.dp
 private val PillFontSize = 10.sp
 private val PillSpacing = 4.dp
-private val PillEndPadding = 12.dp
 private val PillMaxWidth = 80.dp
 
 @Composable
@@ -111,31 +113,68 @@ private fun Map() {
     // its own draw phase, so scrolling never triggers recomposition of this list.
     val connectors by remember { derivedStateOf { MapConnectors.compute(commits, MapState.lanesBySha) } }
 
-    Box(modifier = Modifier.fillMaxSize().background(Colors.DarkGrayBackground)) {
-        // A single overlay pass over the currently-visible rows (#271): an individual
-        // commit row's own draw bounds are clipped to that row, so a diagonal line
-        // reaching into a neighbouring row/lane can only be drawn here, not per-node.
-        Canvas(modifier = Modifier.fillMaxSize()) {
-            drawConnectors(connectors, lazyListState)
-        }
+    Column(modifier = Modifier.fillMaxSize().background(Colors.DarkGrayBackground)) {
+        // Branch tips are pinned here at the top of the grid (#277), ordered
+        // left-to-right so the mainline everything merges into leads and the side
+        // branches follow by how soon they rejoin it - rather than scattered down
+        // the history at each tip commit's chronological row.
+        BranchPillRow(MapState.orderedBranchTips.value)
 
-        LazyColumn(
-            state = lazyListState,
-            modifier = Modifier.fillMaxSize(),
-        ) {
-            items(commits.size, key = { commits[it].sha }) { index ->
-                val commit = commits[index]
-                val lane = MapState.lanesBySha[commit.sha] ?: 0
+        Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+            // A single overlay pass over the currently-visible rows (#271): an individual
+            // commit row's own draw bounds are clipped to that row, so a diagonal line
+            // reaching into a neighbouring row/lane can only be drawn here, not per-node.
+            Canvas(modifier = Modifier.fillMaxSize()) {
+                drawConnectors(connectors, lazyListState)
+            }
 
-                CommitNode(
-                    commit = commit,
-                    isSelected = MapState.selectedNodeSha.value == commit.sha,
-                    onClick = { MapState.toggleSelectedNode(commit.sha) },
-                    modifier = Modifier.offset(x = LaneWidth * lane).width(LaneWidth),
-                )
+            LazyColumn(
+                state = lazyListState,
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                items(commits.size, key = { commits[it].sha }) { index ->
+                    val commit = commits[index]
+                    val lane = MapState.lanesBySha[commit.sha] ?: 0
+
+                    CommitNode(
+                        commit = commit,
+                        isSelected = MapState.selectedNodeSha.value == commit.sha,
+                        onClick = { MapState.toggleSelectedNode(commit.sha) },
+                        modifier = Modifier.offset(x = LaneWidth * lane).width(LaneWidth),
+                    )
+                }
             }
         }
     }
+}
+
+// The row of branch-name pills pinned to the top of the map (#277), one pill per
+// branch name in merge-proximity order. A tip shared by several branches lays its
+// names out together, and a merge-commit tip is blued to match its node.
+@Composable
+private fun BranchPillRow(tips: List<OrderedBranchTip>) {
+    if (tips.isEmpty()) return
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            // Scroll rather than wrap or clip: the tips stay on one top row even when
+            // there are more branches than fit across the map.
+            .horizontalScroll(rememberScrollState())
+            .padding(horizontal = GutterX, vertical = PillSpacing * 2),
+        horizontalArrangement = Arrangement.spacedBy(PillSpacing),
+    ) {
+        tips.forEach { tip ->
+            tip.branchNames.forEach { branchName -> BranchPill(branchName, tipColor(tip)) }
+        }
+    }
+}
+
+// A tip pill takes the same colour rule as its node (nodeColor). The tip may not be
+// among the loaded commits yet, in which case it defaults to the non-merge colour.
+private fun tipColor(tip: OrderedBranchTip): Color {
+    val commit = MapState.commits.firstOrNull { it.sha == tip.sha } ?: return Colors.FileAdded
+    return nodeColor(commit)
 }
 
 // Row height is fixed, so a row's on-screen y-offset is a straight formula from the
@@ -201,7 +240,6 @@ private fun CommitNode(
     modifier: Modifier = Modifier,
 ) {
     var menuExpanded by remember { mutableStateOf(false) }
-    val tipBranches = MapState.branchTipsBySha.value[commit.sha] ?: emptyList()
 
     Box(
         modifier = modifier
@@ -229,20 +267,6 @@ private fun CommitNode(
             )
         }
 
-        // Hidden while the detail card is showing: the card (up to CardMaxWidth,
-        // leading) and a full row of pills (up to PillMaxWidth each, trailing) can
-        // together exceed LaneWidth, so they'd otherwise risk overlapping.
-        if (tipBranches.isNotEmpty() && !isSelected) {
-            Row(
-                modifier = Modifier
-                    .align(Alignment.CenterEnd)
-                    .padding(end = PillEndPadding),
-                horizontalArrangement = Arrangement.spacedBy(PillSpacing),
-            ) {
-                tipBranches.forEach { branchName -> BranchPill(branchName, nodeColor(commit)) }
-            }
-        }
-
         CommitContextMenu(
             commit = commit,
             expanded = menuExpanded,
@@ -251,8 +275,7 @@ private fun CommitNode(
     }
 }
 
-// A small labeled pill naming a local branch whose tip is this commit (#272); shown
-// instead of the old per-column branch header now that it labels a node directly.
+// A small labeled pill naming a local branch, rendered in the top pill row (#277).
 @Composable
 private fun BranchPill(branchName: String, color: Color) {
     Box(

--- a/src/test/kotlin/com/codymikol/services/BranchTipOrdererSpec.kt
+++ b/src/test/kotlin/com/codymikol/services/BranchTipOrdererSpec.kt
@@ -1,0 +1,114 @@
+package com.codymikol.services
+
+import com.codymikol.extensions.listLocalBranches
+import com.codymikol.repository.TestRepository.Companion.createTestRepository
+import com.codymikol.state.GitDownState
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class BranchTipOrdererSpec : DescribeSpec({
+
+    describe("BranchTipOrderer") {
+
+        beforeContainer {
+            GitDownState.git.value.close()
+        }
+
+        describe("a default branch and two side branches") {
+
+            // early/ diverges at the root, so mainline has gained two commits since
+            // their shared history; late/ diverges at the mainline tip, gaining none.
+            // Ordered by that gap, late/ sits nearer the mainline than early/.
+            val initial = createTestRepository()
+                .addFile("a.txt", "a")
+                .stageAll()
+                .commitAll("root")
+
+            val defaultBranchName = initial.git.repository.branch
+
+            autoClose(
+                initial
+                    .createBranch("early")
+                    .checkout("early")
+                    .appendToFile("a.txt", "early")
+                    .stageAll()
+                    .commitAll("early-1")
+                    .checkout(defaultBranchName)
+                    .appendToFile("a.txt", "b")
+                    .stageAll()
+                    .commitAll("main-2")
+                    .appendToFile("a.txt", "c")
+                    .stageAll()
+                    .commitAll("main-3")
+                    .createBranch("late")
+                    .checkout("late")
+                    .appendToFile("a.txt", "late")
+                    .stageAll()
+                    .commitAll("late-1")
+                    .checkout(defaultBranchName)
+                    .transferIntoGitDownState()
+            )
+
+            it("puts the default tip first, then side tips by merge proximity") {
+                val git = GitDownState.git.value
+
+                val order = BranchTipOrderer.order(
+                    git,
+                    defaultBranchName,
+                    git.listLocalBranches(),
+                )
+
+                order.map { it.branchNames } shouldBe listOf(
+                    listOf(defaultBranchName),
+                    listOf("late"),
+                    listOf("early"),
+                )
+            }
+
+            it("falls back to branch-name order when no branch matches the default") {
+                val git = GitDownState.git.value
+
+                val order = BranchTipOrderer.order(git, "does-not-exist", git.listLocalBranches())
+
+                order.map { it.branchNames.first() } shouldBe listOf(defaultBranchName, "early", "late").sorted()
+            }
+        }
+
+        describe("two branches sharing a tip") {
+
+            val initial = createTestRepository()
+                .addFile("a.txt", "a")
+                .stageAll()
+                .commitAll("root")
+
+            val defaultBranchName = initial.git.repository.branch
+
+            autoClose(
+                initial
+                    .createBranch("alias")
+                    .transferIntoGitDownState()
+            )
+
+            it("collects every branch name on the one shared tip") {
+                val git = GitDownState.git.value
+
+                val order = BranchTipOrderer.order(
+                    git,
+                    defaultBranchName,
+                    git.listLocalBranches(),
+                )
+
+                order.map { it.branchNames } shouldBe listOf(
+                    listOf("alias", defaultBranchName).sorted(),
+                )
+            }
+        }
+
+        describe("no branches") {
+
+            it("returns an empty ordering") {
+                BranchTipOrderer.order(GitDownState.git.value, "main", emptyList()) shouldBe emptyList()
+            }
+        }
+    }
+})


### PR DESCRIPTION
Closes #277

## What

Branch-tip "pills" no longer render inline on each tip commit's scattered
chronological row. They are now pinned to a single row at the **top of the
map grid**, ordered left-to-right by how soon each branch merges back into the
mainline, so the lanes read as cleanly converging on the default branch.

## How

- `services/BranchTipOrderer` orders the branch tips: the default branch's tip
  leads (the mainline everything merges into), and every other tip follows by
  how few commits the mainline has gained since their merge base. Ties, and
  tips with no shared history, fall back to branch name for a stable order.
- `MapState.orderedBranchTips` exposes that order as derived state.
- `MapView` restructures `Map()` into a `Column`: a pinned, horizontally
  scrollable `BranchPillRow` on top and the connector `Canvas` + `LazyColumn`
  graph in a weighted `Box` below (their shared row-offset math is unchanged
  since they stay together in the graph area).

## Tests

- `BranchTipOrdererSpec`: default-first + merge-proximity ordering, a tip
  shared by multiple branches, no branches, and the no-matching-default
  fallback.

## Notes for reviewer

- "Default" branch is taken as `repository.branch` (current HEAD branch) —
  the app has no repo-wide default-branch concept; this matches how the
  existing map tests treat the default.
- The build/test toolchain (JDK/Gradle) was not available in the agent
  environment, so these changes were validated by CI rather than locally.