### PR TITLE
fix(windows): return to splash on exit from git-down screens

### DIFF
--- a/src/main/kotlin/com/codymikol/state/state.kt
+++ b/src/main/kotlin/com/codymikol/state/state.kt
@@ -198,6 +198,15 @@ object GitDownState {
     //todo(mikol): this is not ideal, work out a better way to manage this...
     val lastRequestedUpdateTimestamp = mutableStateOf(System.currentTimeMillis())
 
+    /**
+     * Closes the current project and returns to the splash / project selection
+     * screen (see issue #265). Clearing [gitDirectory] flips [isValidGitDirectory]
+     * back to false, which App observes to swap GitDown out for DirectorySelector.
+     */
+    fun returnToProjectSelection() {
+        gitDirectory.value = ""
+    }
+
     fun selectTab(tab: Tab) {
         currentTab.value = tab
 

--- a/src/main/kotlin/com/codymikol/windows/DirectorySelector.kt
+++ b/src/main/kotlin/com/codymikol/windows/DirectorySelector.kt
@@ -267,7 +267,10 @@ fun handleDirectorySelection(dir: String) {
 }
 
 @Composable
-fun ExitButton(applicationScope: ApplicationScope) {
+fun ExitButton(
+    applicationScope: ApplicationScope,
+    onClick: () -> Unit = { applicationScope.exitApplication() }
+) {
 
     val exitButtonSize = 64.dp
 
@@ -284,7 +287,7 @@ fun ExitButton(applicationScope: ApplicationScope) {
     ) {
         Box(modifier = Modifier.fillMaxSize()
             .clickable {
-                applicationScope.exitApplication()
+                onClick()
             }
             .align(Alignment.Center)
             .background(ExitButtonColor)

--- a/src/main/kotlin/com/codymikol/windows/GitDown.kt
+++ b/src/main/kotlin/com/codymikol/windows/GitDown.kt
@@ -110,7 +110,7 @@ fun GitDown(applicationScope: ApplicationScope) {
             }
         },
         onCloseRequest = {
-            GitDownState.gitDirectory.value = ""
+            GitDownState.returnToProjectSelection()
         },
         title = GitDownState.projectName.value,
         icon = painterResource(Res.drawable.icon),
@@ -190,7 +190,10 @@ fun GitDown(applicationScope: ApplicationScope) {
                                 )
                             }
                             Spacer(modifier = Modifier.weight(1f))
-                            ExitButton(applicationScope)
+                            // On the commit / map / stash screens exit returns to the
+                            // splash / project selection screen rather than quitting the
+                            // whole app (see issue #265).
+                            ExitButton(applicationScope) { GitDownState.returnToProjectSelection() }
                         }
                     }
                 }

--- a/src/test/kotlin/com/codymikol/state/GitDownStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/GitDownStateSpec.kt
@@ -869,5 +869,24 @@ class GitDownStateSpec : DescribeSpec({
 
         }
 
+        describe("returnToProjectSelection") {
+
+            describe("when a project is open") {
+
+                autoClose(createTestRepository().transferIntoGitDownState())
+
+                it("should clear the git directory so the splash screen is shown again") {
+                    GitDownState.isValidGitDirectory.value shouldBe true
+
+                    GitDownState.returnToProjectSelection()
+
+                    GitDownState.gitDirectory.value shouldBe ""
+                    GitDownState.isValidGitDirectory.value shouldBe false
+                }
+
+            }
+
+        }
+
     }
 })


### PR DESCRIPTION
## What

Pressing the exit button on the commit / map / stash screen now returns to
the splash / project-selection screen instead of quitting the whole app,
restoring the pre-regression behavior.

Closes #265

## Why

`ExitButton` is shared between the splash screen and the in-project screens
but unconditionally called `applicationScope.exitApplication()`, so exiting
from inside a project killed the app rather than returning to project
selection.

## How

- `GitDownState.returnToProjectSelection()` clears `gitDirectory`, flipping
  `isValidGitDirectory` back to false so `App` swaps `GitDown` out for
  `DirectorySelector`.
- `ExitButton` gains an `onClick` param defaulting to
  `applicationScope.exitApplication()` — the splash call-site is unchanged
  and still quits the app.
- `GitDown` passes `returnToProjectSelection()`; `onCloseRequest` now uses
  the same function so the title-bar close and exit button behave identically
  (matching prior behavior).

## Tests

Added a `GitDownStateSpec` case asserting `returnToProjectSelection()` clears
the directory and reports it invalid.

> Note: this container has no JDK and its nix store is not writable by the
> agent user, so the Gradle/Kotlin suite could not be executed locally — it
> is left to CI to validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)