### PR TITLE
feat: implement "Checkout Detached HEAD"

### DIFF
--- a/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
+++ b/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
@@ -554,6 +554,21 @@ suspend fun Git.discardAllWorkingDirectory(): Git = command {
 
 }
 
+/**
+ * Detaches HEAD at the commit [sha] resolves to (any ref or object-id string jgit
+ * can resolve), backing the map view's "Checkout Detached HEAD" action (see issue
+ * #279). jgit's checkout detaches HEAD whenever the name is a commit-ish that is
+ * not a branch, so the working tree is moved to that commit without any branch ref
+ * being created or moved.
+ */
+suspend fun Git.checkoutDetachedHead(sha: String): Git = command {
+    this@checkoutDetachedHead
+        .checkout()
+        .setName(sha)
+        .call()
+        .also { logger.info("Checking out $sha as detached HEAD") }
+}
+
 suspend fun Git.stageFile(fileDeltaNode: FileDeltaNode): Git = command {
 
     val shouldSetUpdate = fileDeltaNode.fileDelta is WorkingDirectory.FileDeleted

--- a/src/main/kotlin/com/codymikol/state/state.kt
+++ b/src/main/kotlin/com/codymikol/state/state.kt
@@ -8,6 +8,7 @@ import com.codymikol.data.file.Status
 import com.codymikol.data.file.WorkingDirectory
 import com.codymikol.data.map.CommitGraphNode
 import com.codymikol.data.stash.StashListItem
+import com.codymikol.extensions.checkoutDetachedHead
 import com.codymikol.extensions.getCommitDiff
 import com.codymikol.extensions.getCommitDiffAgainstHead
 import com.codymikol.extensions.getCurrentRefCommitCount
@@ -232,6 +233,15 @@ object GitDownState {
         quickViewCommit.value = commit
         quickViewAgainstHead.value = true
         selectTab(Tab.QuickView)
+    }
+
+    /**
+     * Checks [commit] out as a detached HEAD (see issue #279): the working tree is
+     * moved to that commit without creating or moving any branch. Backs the map
+     * view's "Checkout Detached HEAD" action.
+     */
+    suspend fun checkoutDetachedHead(commit: CommitGraphNode) {
+        git.value.checkoutDetachedHead(commit.sha)
     }
 
     /** Closes the quick view, clearing its commit and restoring the prior tab. */

--- a/src/main/kotlin/com/codymikol/views/MapView.kt
+++ b/src/main/kotlin/com/codymikol/views/MapView.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -48,6 +49,7 @@ import com.codymikol.data.map.MapConnector
 import com.codymikol.services.MapConnectors
 import com.codymikol.state.GitDownState
 import com.codymikol.state.MapState
+import kotlinx.coroutines.launch
 import java.util.Date
 
 private val LaneWidth = 180.dp
@@ -275,15 +277,17 @@ private fun BranchPill(branchName: String, color: Color) {
 
 // The right-click context menu for a commit node (#253). Its actions are grouped
 // by CommitContextMenu, with a divider drawn between each group. Quick View (#254)
-// launches the quick view for this commit and Diff with HEAD (#280) diffs it
-// against the current HEAD; the remaining behaviours are wired up in follow-up
-// issues, so those items only dismiss for now.
+// launches the quick view for this commit, Diff with HEAD (#280) diffs it against
+// the current HEAD, and Checkout Detached HEAD (#279) checks it out detached; the
+// remaining behaviours are wired up in follow-up issues, so those items only
+// dismiss for now.
 @Composable
 private fun CommitContextMenu(
     commit: CommitGraphNode,
     expanded: Boolean,
     onDismiss: () -> Unit,
 ) {
+    val scope = rememberCoroutineScope()
     ThemedDropdownMenu(
         expanded = expanded,
         onDismissRequest = onDismiss,
@@ -300,6 +304,9 @@ private fun CommitContextMenu(
                         }
                         "Diff with HEAD..." -> {
                             { GitDownState.openDiffWithHead(commit); onDismiss() }
+                        }
+                        "Checkout Detached HEAD" -> {
+                            { scope.launch { GitDownState.checkoutDetachedHead(commit) }; onDismiss() }
                         }
                         else -> onDismiss
                     },

--- a/src/main/kotlin/com/codymikol/windows/GitDown.kt
+++ b/src/main/kotlin/com/codymikol/windows/GitDown.kt
@@ -10,6 +10,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -50,6 +51,7 @@ import com.codymikol.views.isCommitMessageFocused
 import com.codymikol.views.MapView
 import com.codymikol.views.QuickView
 import com.codymikol.views.StashView
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.painterResource
 import org.koin.java.KoinJavaComponent.inject
 import java.awt.Dimension
@@ -61,6 +63,8 @@ private val windowSizeService: WindowSizeService by inject(WindowSizeService::cl
 fun GitDown(applicationScope: ApplicationScope) {
 
     val defaultWindowSize = windowSizeService.getDefaultWindowSize()
+
+    val scope = rememberCoroutineScope()
 
     Window(
         onKeyEvent = {
@@ -85,6 +89,11 @@ fun GitDown(applicationScope: ApplicationScope) {
             val diffWithHeadTarget = if (isDown && it.key == Key.I && tab == Tab.Map)
                 MapState.selectedNode() else null
 
+            // Enter on the map with a node selected checks that node out as a
+            // detached HEAD (#279).
+            val checkoutDetachedTarget = if (isDown && it.key == Key.Enter && tab == Tab.Map)
+                MapState.selectedNode() else null
+
             // Space or Escape closes the quick view while it is open.
             val shouldCloseQuickView = isDown && tab == Tab.QuickView &&
                 (it.key == Key.Spacebar || it.key == Key.Escape)
@@ -104,6 +113,10 @@ fun GitDown(applicationScope: ApplicationScope) {
                 }
                 diffWithHeadTarget != null -> {
                     GitDownState.openDiffWithHead(diffWithHeadTarget)
+                    true
+                }
+                checkoutDetachedTarget != null -> {
+                    scope.launch { GitDownState.checkoutDetachedHead(checkoutDetachedTarget) }
                     true
                 }
                 else -> false

--- a/src/test/kotlin/com/codymikol/extensions/CheckoutDetachedHeadSpec.kt
+++ b/src/test/kotlin/com/codymikol/extensions/CheckoutDetachedHeadSpec.kt
@@ -1,0 +1,42 @@
+package com.codymikol.extensions
+
+import com.codymikol.repository.TestRepository.Companion.createTestRepository
+import com.codymikol.state.GitDownState
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.eclipse.jgit.lib.ObjectId
+
+class CheckoutDetachedHeadSpec : DescribeSpec({
+
+    describe("Git.checkoutDetachedHead") {
+
+        describe("checking out an earlier commit") {
+
+            autoClose(
+                createTestRepository()
+                    .addFile("foo.txt", "one\n")
+                    .stageAll()
+                    .commitAll("init")
+                    .appendToFile("foo.txt", "two\n")
+                    .stageAll()
+                    .commitAll("add two")
+                    .transferIntoGitDownState()
+            )
+
+            it("detaches HEAD at the requested commit") {
+                val git = GitDownState.git.value
+                // The production caller passes a raw object-id sha (CommitGraphNode.sha),
+                // so exercise that path rather than a symbolic ref.
+                val target = git.repository.resolve("HEAD~1")
+
+                git.checkoutDetachedHead(target.name)
+
+                val repo = git.repository
+                // A detached HEAD reports its object id as the "branch" name rather
+                // than a symbolic refs/heads/ ref.
+                ObjectId.isId(repo.branch) shouldBe true
+                repo.resolve("HEAD") shouldBe target
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/codymikol/state/CheckoutDetachedHeadStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/CheckoutDetachedHeadStateSpec.kt
@@ -1,0 +1,47 @@
+package com.codymikol.state
+
+import com.codymikol.data.map.CommitGraphNode
+import com.codymikol.repository.TestRepository.Companion.createTestRepository
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.eclipse.jgit.lib.ObjectId
+import java.util.Date
+
+class CheckoutDetachedHeadStateSpec : DescribeSpec({
+
+    fun node(sha: String) = CommitGraphNode(
+        sha = sha,
+        shortSha = sha.take(7),
+        shortMessage = "do a thing",
+        authorName = "Ada Lovelace",
+        authorEmail = "ada@example.com",
+        date = Date(),
+        parentShas = emptyList(),
+    )
+
+    describe("GitDownState.checkoutDetachedHead") {
+
+        beforeContainer { GitDownState.git.value.close() }
+
+        autoClose(
+            createTestRepository()
+                .addFile("foo.txt", "one\n")
+                .stageAll()
+                .commitAll("init")
+                .appendToFile("foo.txt", "two\n")
+                .stageAll()
+                .commitAll("add two")
+                .transferIntoGitDownState()
+        )
+
+        it("detaches HEAD at the given commit") {
+            val parent = GitDownState.git.value.repository.resolve("HEAD~1")
+
+            GitDownState.checkoutDetachedHead(node(parent.name))
+
+            val repo = GitDownState.git.value.repository
+            ObjectId.isId(repo.branch) shouldBe true
+            repo.resolve("HEAD") shouldBe parent
+        }
+    }
+})


### PR DESCRIPTION
Implements the map view's "Checkout Detached HEAD" action (issue #279).

## What changed
- **Service layer** — `Git.checkoutDetachedHead(sha)` in `GitExtensions.kt`,
  routed through the shared `command` wrapper so jgit detaches HEAD at the
  resolved commit and the UI scan/refresh fires afterward. jgit detaches
  whenever the name is a commit-ish that isn't a branch, so no branch ref is
  created or moved.
- **State layer** — `GitDownState.checkoutDetachedHead(commit)` wraps the
  extension, mirroring the `openQuickView` / `openDiffWithHead` seam.
- **Wiring** — the "Checkout Detached HEAD" context-menu item and the `Enter`
  shortcut on a selected map node both dispatch to the state action from a
  remembered coroutine scope (the checkout suspends).

## Tests
- `CheckoutDetachedHeadSpec` — exercises the extension against a two-commit
  repo, passing a raw object-id sha (the production caller's shape) and
  asserting HEAD is detached at the target.
- `CheckoutDetachedHeadStateSpec` — covers the state action end-to-end.

## Notes for reviewers
- Local checks could not be run in-container: `NIX_STORE_WRITABLE=false` with a
  root-owned store and no baked JDK, so `nix develop`/gradle cannot execute
  here. Relying on CI to run the gate.
- Like the existing checkout-based extensions (`discardFile`,
  `discardAllWorkingDirectory`), a jgit `CheckoutConflictException` on a dirty
  tree propagates through the fire-and-forget `scope.launch` with no user-facing
  surfacing. Left consistent with current behavior; surfacing checkout failures
  is a broader cross-cutting concern worth a dedicated issue.

Closes #279