### PR TITLE
feat(map): label the current HEAD node

### DIFF
--- a/src/main/kotlin/com/codymikol/state/MapState.kt
+++ b/src/main/kotlin/com/codymikol/state/MapState.kt
@@ -80,6 +80,17 @@ object MapState {
     }
 
     /**
+     * Sha of the commit the current HEAD points at, or null when the repository has
+     * no commits yet (an unresolvable HEAD). Backs the "HEAD" label drawn on that
+     * node in the map (see issue #282) so the user can see where HEAD sits. Keyed on
+     * GitDownState.git like the other tip state, so it recomputes after a checkout
+     * moves HEAD.
+     */
+    val headSha = derivedStateOf {
+        GitDownState.git.value.repository.resolve("HEAD")?.name
+    }
+
+    /**
      * Every branch tip ordered for the pill row pinned to the top of the map (see
      * issue #277): the default branch first, then each side branch by how soon it
      * merges back into the default tip. Left-to-right this reads as the lanes

--- a/src/main/kotlin/com/codymikol/views/MapView.kt
+++ b/src/main/kotlin/com/codymikol/views/MapView.kt
@@ -265,6 +265,16 @@ private fun CommitNode(
                     .align(Alignment.CenterStart)
                     .padding(start = GutterX - CardTabSize / 2)
             )
+        } else if (commit.sha == MapState.headSha.value) {
+            // The current HEAD is labelled on its node (#282) so the user can see
+            // where it sits. Hidden while this node is selected, when its detail card
+            // takes the same spot over the node instead.
+            HeadLabel(
+                color = nodeColor(commit),
+                modifier = Modifier
+                    .align(Alignment.CenterStart)
+                    .padding(start = GutterX + NodeRadius + PillSpacing)
+            )
         }
 
         CommitContextMenu(
@@ -292,6 +302,27 @@ private fun BranchPill(branchName: String, color: Color) {
             fontWeight = FontWeight.Bold,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+// The "HEAD" label pinned to the current HEAD node (#282), sitting just right of
+// the node dot. Mirrors the branch pill: a rounded box in the node's own colour
+// with bold white text, so HEAD reads consistently with the branch tips it labels.
+@Composable
+private fun HeadLabel(color: Color, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(PillCorner))
+            .background(color)
+            .padding(horizontal = 6.dp, vertical = 2.dp),
+    ) {
+        Text(
+            text = "HEAD",
+            color = Color.White,
+            fontSize = PillFontSize,
+            fontWeight = FontWeight.Bold,
+            maxLines = 1,
         )
     }
 }

--- a/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
@@ -300,6 +300,38 @@ class MapStateSpec : DescribeSpec({
             }
         }
 
+        describe("headSha") {
+
+            autoClose(
+                createTestRepository()
+                    .addFile("a.txt", "a")
+                    .stageAll()
+                    .commitAll("commit 1")
+                    .appendToFile("a.txt", "b")
+                    .stageAll()
+                    .commitAll("commit 2")
+                    .transferIntoGitDownState()
+            )
+
+            it("resolves to the sha of the commit the current HEAD points at") {
+                val tipSha = MapState.branches.value.single().objectId.name
+
+                MapState.headSha.value shouldBe tipSha
+            }
+        }
+
+        describe("headSha with no commits") {
+
+            autoClose(
+                createTestRepository()
+                    .transferIntoGitDownState()
+            )
+
+            it("resolves to null when HEAD points at an unborn branch") {
+                MapState.headSha.value shouldBe null
+            }
+        }
+
         describe("more commits than one page") {
 
             val repo = createTestRepository().addFile("a.txt", "0").stageAll().commitAll("commit 0")


### PR DESCRIPTION
## What

Renders a **HEAD** label on the map-view node the current HEAD points at, so the user can see where HEAD sits (#282).

- `MapState.headSha` — a `derivedStateOf` resolving `HEAD` (`repository.resolve("HEAD")?.name`), keyed on the same `GitDownState.git` state as the branch tips so it recomputes after a checkout. Null on an unborn branch (empty repo).
- `HeadLabel` composable in `MapView` — a rounded pill in the node's own colour with bold white "HEAD" text, mirroring the existing branch-tip pill so it reads consistently. Sits just right of the node dot. Hidden while the node is selected, when its detail card occupies the same spot.

## Tests

- `MapStateSpec`: `headSha` resolves to the HEAD commit sha; resolves to null on an unborn branch.
- No Compose UI rendering tests exist in this repo; the label wiring mirrors the untested `BranchPill` pattern, and `headSha` is the unit under test.

## Note

This environment has no JDK and a read-only nix store (no daemon), so `./gradlew test` could not be run locally — CI is the validation gate for compilation and tests.

Closes #282