### PR TITLE
fix: quick view diff activation, layout, and selection (#290)

### DIFF
--- a/src/main/kotlin/com/codymikol/state/MapState.kt
+++ b/src/main/kotlin/com/codymikol/state/MapState.kt
@@ -25,6 +25,12 @@ object MapState {
     private var walker: CommitHistoryWalker? = null
     private var laneAssigner = LaneAssigner()
 
+    // The git directory whose history is currently loaded, or null before anything has
+    // loaded. Lets resetForDirectory() tell a genuine project switch (which must clear
+    // the map) apart from merely re-entering the Map tab (which must not), so the
+    // selected node survives a round-trip through the quick view (see issue #290).
+    private var loadedDirectory: String? = null
+
     val commits = mutableStateListOf<CommitGraphNode>()
 
     val lanesBySha = mutableStateMapOf<String, Int>()
@@ -133,5 +139,19 @@ object MapState {
         lanesBySha.clear()
         hasMore = true
         selectedNodeSha.value = null
+        loadedDirectory = null
+    }
+
+    /**
+     * Resets the map only when [directory] differs from the one already loaded (see
+     * issue #290). Re-entering the Map tab - for instance on returning from the quick
+     * view - re-runs the Map view's launch effect with the same directory, and must
+     * leave the loaded commits and the selected node untouched; only a real project
+     * switch clears them.
+     */
+    fun resetForDirectory(directory: String) {
+        if (directory == loadedDirectory) return
+        reset()
+        loadedDirectory = directory
     }
 }

--- a/src/main/kotlin/com/codymikol/state/state.kt
+++ b/src/main/kotlin/com/codymikol/state/state.kt
@@ -208,8 +208,13 @@ object GitDownState {
      * Closes the current project and returns to the splash / project selection
      * screen (see issue #265). Clearing [gitDirectory] flips [isValidGitDirectory]
      * back to false, which App observes to swap GitDown out for DirectorySelector.
+     *
+     * Also resets the map: the Map view's launch effect only refreshes when the git
+     * directory changes (see issue #290), so without clearing MapState here, reopening
+     * the same repository would keep the stale commit graph and leak the open walker.
      */
     fun returnToProjectSelection() {
+        MapState.reset()
         gitDirectory.value = ""
     }
 

--- a/src/main/kotlin/com/codymikol/views/MapView.kt
+++ b/src/main/kotlin/com/codymikol/views/MapView.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.PointerMatcher
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.*
@@ -79,8 +78,11 @@ private val PillMaxWidth = 80.dp
 @Preview
 fun MapView() {
 
+    // Reset only on a genuine project switch, not on every re-entry into the Map tab:
+    // returning from the quick view re-runs this effect with the same directory and must
+    // preserve the loaded commits and the selected node (see issue #290).
     LaunchedEffect(GitDownState.gitDirectory.value) {
-        MapState.reset()
+        MapState.resetForDirectory(GitDownState.gitDirectory.value)
     }
 
     when (MapState.branches.value.isEmpty()) {
@@ -250,7 +252,11 @@ private fun CommitNode(
             // The selected node draws above its siblings so its card, which is taller
             // than one row, floats over the neighbouring nodes rather than under them.
             .zIndex(if (isSelected) 1f else 0f)
-            .clickable { onClick() }
+            // A mouse-only primary click (not .clickable) so the node never takes
+            // keyboard focus: a focused .clickable swallows the Space key and toggles
+            // itself instead of letting the window-level shortcut open the quick view
+            // for the selected node (see issue #290 / #254).
+            .onClick(matcher = PointerMatcher.mouse(PointerButton.Primary)) { onClick() }
             // Right-clicking opens the context menu and always leaves this node
             // selected (see issue #253) - selectNode, not the click toggle.
             .onClick(matcher = PointerMatcher.mouse(PointerButton.Secondary)) {

--- a/src/main/kotlin/com/codymikol/views/QuickView.kt
+++ b/src/main/kotlin/com/codymikol/views/QuickView.kt
@@ -51,6 +51,10 @@ import com.codymikol.data.map.QuickViewCommitDetails
 import com.codymikol.state.GitDownState
 import java.util.Date
 
+// The commit details are capped at this height and scroll past it (see issue #290) so a
+// long commit message never crowds out the file list that fills the space below them.
+private val CommitDetailsMaxHeight = 240.dp
+
 /**
  * The quick view (see issue #254): an ephemeral overlay launched against a single
  * commit. Its commit details sit on the left and the commit's diff (reusing the
@@ -98,21 +102,24 @@ private fun ColumnScope.QuickViewDetailPanel(diffListState: LazyListState) {
 }
 
 /**
- * The list of files changed in the quick view's commit (see issue #278), drawn beneath
- * the commit details behind a top border. Selecting a file highlights it and scrolls the
- * diff so its header is at the top; the highlight also tracks whichever header is sticky.
+ * The list of files changed in the quick view's commit (see issue #278), drawn directly
+ * beneath the commit details behind a thin themed separator and filling the rest of the
+ * panel (see issue #290). Selecting a file highlights it and scrolls the diff so its
+ * header is at the top; the highlight also tracks whichever header is sticky.
  */
 @Composable
-private fun QuickViewFileList(diffListState: LazyListState) {
+private fun ColumnScope.QuickViewFileList(diffListState: LazyListState) {
     val nodes = GitDownState.quickViewDiffTree.value.fileDeltaNodes
     if (nodes.isEmpty()) return
 
     val selectedPath = GitDownState.quickViewSelectedFilePath.value
     val selectedIndex = nodes.indexOfFirst { it.getPath() == selectedPath }.coerceAtLeast(0)
 
-    Box(modifier = Modifier.fillMaxWidth().height(1.dp).background(Color.Black))
+    // A thin themed separator between the commit details above and the file list, rather
+    // than a hard black line (see issue #290).
+    Box(modifier = Modifier.fillMaxWidth().height(1.dp).background(Colors.LightGrayBackground))
 
-    LazyColumn(modifier = Modifier.fillMaxWidth().heightIn(max = 220.dp)) {
+    LazyColumn(modifier = Modifier.fillMaxWidth().weight(1f)) {
         itemsIndexed(nodes) { index, node ->
             QuickViewFileRow(
                 node = node,
@@ -148,13 +155,17 @@ private fun QuickViewFileRow(node: FileDeltaNode, selected: Boolean, onClick: ()
 }
 
 @Composable
-private fun ColumnScope.CommitDetails(commit: CommitGraphNode) {
+private fun CommitDetails(commit: CommitGraphNode) {
     val now = remember(commit.sha) { Date() }
 
+    // Wrap-content (no weight) so the details sit directly under the subheader at the
+    // top of the panel rather than stretching and pushing the file list to the bottom
+    // (see issue #290). Capped and scrollable so a long commit message can never starve
+    // the file list that fills the space below it.
     Column(
         modifier = Modifier
-            .weight(1f)
             .fillMaxWidth()
+            .heightIn(max = CommitDetailsMaxHeight)
             .verticalScroll(rememberScrollState())
             .padding(16.dp)
     ) {

--- a/src/test/kotlin/com/codymikol/state/GitDownStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/GitDownStateSpec.kt
@@ -1,6 +1,7 @@
 package com.codymikol.state
 
 import com.codymikol.data.diff.LineType
+import com.codymikol.data.map.CommitGraphNode
 import com.codymikol.extensions.discardAllWorkingDirectory
 import com.codymikol.extensions.stageAll
 import com.codymikol.extensions.stageSelectedLines
@@ -882,6 +883,30 @@ class GitDownStateSpec : DescribeSpec({
 
                     GitDownState.gitDirectory.value shouldBe ""
                     GitDownState.isValidGitDirectory.value shouldBe false
+                }
+
+                it("should reset the map so re-opening the same repo reloads it (#290)") {
+                    MapState.reset()
+                    MapState.resetForDirectory("/repo")
+                    MapState.commits.addAll(
+                        listOf(
+                            CommitGraphNode(
+                                sha = "sha1",
+                                shortSha = "sha1",
+                                shortMessage = "commit 1",
+                                authorName = "author",
+                                authorEmail = "author@example.com",
+                                date = java.util.Date(),
+                                parentShas = emptyList(),
+                            )
+                        )
+                    )
+                    MapState.selectNode("sha1")
+
+                    GitDownState.returnToProjectSelection()
+
+                    MapState.commits.isEmpty() shouldBe true
+                    MapState.selectedNodeSha.value shouldBe null
                 }
 
             }

--- a/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
@@ -257,6 +257,48 @@ class MapStateSpec : DescribeSpec({
             }
         }
 
+        describe("resetForDirectory") {
+
+            it("clears the loaded map when the directory changes") {
+                MapState.reset()
+                MapState.commits.addAll(dummyCommits(3))
+                MapState.selectNode("sha2")
+
+                MapState.resetForDirectory("/some/other/repo")
+
+                MapState.commits.isEmpty() shouldBe true
+                MapState.selectedNodeSha.value shouldBe null
+            }
+
+            it("keeps the selected node when the directory is unchanged (#290)") {
+                MapState.reset()
+                MapState.resetForDirectory("/same/repo")
+                MapState.commits.addAll(dummyCommits(3))
+                MapState.selectNode("sha2")
+
+                MapState.resetForDirectory("/same/repo")
+
+                MapState.commits shouldHaveSize 3
+                MapState.selectedNodeSha.value shouldBe "sha2"
+            }
+
+            it("refreshes again for the same directory after a reset (project re-open)") {
+                MapState.reset()
+                MapState.resetForDirectory("/repo")
+                MapState.commits.addAll(dummyCommits(3))
+                MapState.selectNode("sha2")
+
+                // A project close (returnToProjectSelection) resets the map, so
+                // re-opening the very same repository must reload rather than keep the
+                // stale graph and leak the walker.
+                MapState.reset()
+                MapState.resetForDirectory("/repo")
+
+                MapState.commits.isEmpty() shouldBe true
+                MapState.selectedNodeSha.value shouldBe null
+            }
+        }
+
         describe("branchTipsBySha") {
 
             autoClose(


### PR DESCRIPTION
Fixes the three quick view diff bugs in #290.

## A — Space no longer opens the quick view
A selected map node's own `Modifier.clickable` took keyboard focus on click and swallowed the Space key, toggling the node off instead of letting the window-level shortcut open the quick view. The node's primary click is now a mouse-only `PointerMatcher` (matching the existing right-click handler), so it never grabs focus and Space reaches the window handler. This also unblocks the sibling Enter → "Checkout Detached HEAD" shortcut, which shared the same latent focus problem.

## B — file list bottom-aligned in the left panel
`CommitDetails` carried `weight(1f)`, stretching to fill the panel and pushing the changed-file list to the very bottom. The details now wrap their content at the top (capped and scrollable so a long message can't starve the list), the file list takes the remaining space directly below, and the hard black separator is retinted to the themed `Colors.LightGrayBackground`.

## C — selected node forgotten on exit
The Map view's launch effect called `MapState.reset()` on every entry into the tab, so returning from the quick view wiped the loaded commits and the selection. Reset now runs only on a genuine directory change via `resetForDirectory()`; re-entering the tab with the same directory is a no-op. `returnToProjectSelection()` explicitly resets the map so re-opening the same repository still reloads (and closes the walker) rather than showing a stale graph.

## Tests
State-level Kotest coverage added: `MapStateSpec` (`resetForDirectory` change/unchanged/re-open cases) and `GitDownStateSpec` (`returnToProjectSelection` clears the map). The Space/layout fixes are Compose UI wiring; this project has no Compose UI test harness, so they are verified by review and CI build.

Note: local `./gradlew build` was not runnable in the agent sandbox (no JDK / non-writable nix store); CI is the validating gate.

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)