### PR TITLE
feat(map): render tip nodes and fork connectors with a debug menu

### DIFF
--- a/src/main/kotlin/com/codymikol/data/map/BranchTipNode.kt
+++ b/src/main/kotlin/com/codymikol/data/map/BranchTipNode.kt
@@ -1,0 +1,8 @@
+package com.codymikol.data.map
+
+/**
+ * A branch tip drawn as a node pinned to the top row of the map grid (see issue #291),
+ * sitting in [lane] - the same lane its commit [sha] occupies in the graph below - so
+ * the lanes visibly start at the top and cascade down into the mainline.
+ */
+data class BranchTipNode(val sha: String, val lane: Int)

--- a/src/main/kotlin/com/codymikol/data/map/MapDimensions.kt
+++ b/src/main/kotlin/com/codymikol/data/map/MapDimensions.kt
@@ -1,0 +1,63 @@
+package com.codymikol.data.map
+
+/**
+ * Every tunable "magic number" the map view draws with (see issue #291), collected in
+ * one place so the debug menu (ctrl+shift+d) can adjust them live. Values are plain
+ * Float magnitudes - dp for lengths, sp for font sizes, px for stroke widths - so a
+ * slider can drive them directly; the map view applies the right unit at each use.
+ */
+data class MapDimensions(
+    val laneWidth: Float = 180f,
+    val nodeRadius: Float = 5f,
+    val gutterX: Float = 20f,
+    val rowHeight: Float = 48f,
+    val connectorStrokeWidth: Float = 2f,
+    val cardTabSize: Float = 22f,
+    val cardHoleSize: Float = 8f,
+    val cardCorner: Float = 10f,
+    val cardMaxWidth: Float = 150f,
+    val pillCorner: Float = 8f,
+    val pillFontSize: Float = 10f,
+    val pillSpacing: Float = 4f,
+    val pillMaxWidth: Float = 80f,
+    // #291: how far above a node the incoming vertical connector stops, so the final
+    // bezier fork slants down into the node rather than meeting it dead vertical.
+    val mainlineGap: Float = 24f,
+    // #291: sharpness of the fork's bezier, 0 (a straight diagonal) .. 1 (a crisp
+    // right-angle corner). Higher reads as the "somewhat sharp" curve the issue asks for.
+    val forkCurveTension: Float = 0.85f,
+) {
+
+    /**
+     * One adjustable dimension as the debug menu sees it: a label, the inclusive slider
+     * range, and pure get/set lenses over [MapDimensions] so the menu never has to know
+     * which field it is driving.
+     */
+    data class Slider(
+        val label: String,
+        val min: Float,
+        val max: Float,
+        val get: (MapDimensions) -> Float,
+        val set: (MapDimensions, Float) -> MapDimensions,
+    )
+
+    companion object {
+        val sliders: List<Slider> = listOf(
+            Slider("laneWidth", 60f, 320f, { it.laneWidth }, { d, v -> d.copy(laneWidth = v) }),
+            Slider("nodeRadius", 2f, 16f, { it.nodeRadius }, { d, v -> d.copy(nodeRadius = v) }),
+            Slider("gutterX", 4f, 80f, { it.gutterX }, { d, v -> d.copy(gutterX = v) }),
+            Slider("rowHeight", 24f, 96f, { it.rowHeight }, { d, v -> d.copy(rowHeight = v) }),
+            Slider("connectorStrokeWidth", 1f, 8f, { it.connectorStrokeWidth }, { d, v -> d.copy(connectorStrokeWidth = v) }),
+            Slider("cardTabSize", 10f, 40f, { it.cardTabSize }, { d, v -> d.copy(cardTabSize = v) }),
+            Slider("cardHoleSize", 2f, 20f, { it.cardHoleSize }, { d, v -> d.copy(cardHoleSize = v) }),
+            Slider("cardCorner", 2f, 24f, { it.cardCorner }, { d, v -> d.copy(cardCorner = v) }),
+            Slider("cardMaxWidth", 80f, 320f, { it.cardMaxWidth }, { d, v -> d.copy(cardMaxWidth = v) }),
+            Slider("pillCorner", 2f, 20f, { it.pillCorner }, { d, v -> d.copy(pillCorner = v) }),
+            Slider("pillFontSize", 6f, 20f, { it.pillFontSize }, { d, v -> d.copy(pillFontSize = v) }),
+            Slider("pillSpacing", 1f, 16f, { it.pillSpacing }, { d, v -> d.copy(pillSpacing = v) }),
+            Slider("pillMaxWidth", 40f, 200f, { it.pillMaxWidth }, { d, v -> d.copy(pillMaxWidth = v) }),
+            Slider("mainlineGap", 0f, 64f, { it.mainlineGap }, { d, v -> d.copy(mainlineGap = v) }),
+            Slider("forkCurveTension", 0f, 1f, { it.forkCurveTension }, { d, v -> d.copy(forkCurveTension = v) }),
+        )
+    }
+}

--- a/src/main/kotlin/com/codymikol/data/map/MapPoint.kt
+++ b/src/main/kotlin/com/codymikol/data/map/MapPoint.kt
@@ -1,0 +1,8 @@
+package com.codymikol.data.map
+
+/**
+ * A plain x/y point in the map canvas's pixel space. Kept free of Compose's Offset so
+ * the connector geometry (see issue #291) stays pure and unit-testable; the map view
+ * converts these to Offset at draw time.
+ */
+data class MapPoint(val x: Float, val y: Float)

--- a/src/main/kotlin/com/codymikol/services/BranchTipNodes.kt
+++ b/src/main/kotlin/com/codymikol/services/BranchTipNodes.kt
@@ -1,0 +1,22 @@
+package com.codymikol.services
+
+import com.codymikol.data.map.BranchTipNode
+
+/**
+ * Places branch-tip nodes across the top row of the map (see issue #291). Each ordered
+ * tip is pinned to the lane its commit already occupies in the graph, so the top nodes
+ * line up with the lanes cascading down into the mainline. Tips whose commit pagination
+ * hasn't loaded yet have no lane and are skipped; if two tips resolve to the same lane
+ * only the first (mainline-priority) one is kept so a lane never gets two top nodes.
+ */
+object BranchTipNodes {
+
+    fun place(tips: List<OrderedBranchTip>, lanesBySha: Map<String, Int>): List<BranchTipNode> {
+        val seenLanes = mutableSetOf<Int>()
+        return tips.mapNotNull { tip ->
+            val lane = lanesBySha[tip.sha] ?: return@mapNotNull null
+            if (!seenLanes.add(lane)) return@mapNotNull null
+            BranchTipNode(tip.sha, lane)
+        }
+    }
+}

--- a/src/main/kotlin/com/codymikol/services/ConnectorGeometry.kt
+++ b/src/main/kotlin/com/codymikol/services/ConnectorGeometry.kt
@@ -1,0 +1,60 @@
+package com.codymikol.services
+
+import com.codymikol.data.map.MapPoint
+
+/**
+ * The four points a single map connector is drawn from (see issue #291): rather than a
+ * straight diagonal between two nodes, a connector runs straight down the child's lane
+ * to a synthetic [bend] node, then a quadratic bezier ([control] is its control point)
+ * forks across into the parent's lane. A same-lane connector's points all share the
+ * child's x, so the bezier collapses to the plain vertical it used to be.
+ */
+data class ConnectorPath(
+    val start: MapPoint,
+    val bend: MapPoint,
+    val control: MapPoint,
+    val end: MapPoint,
+    val isSameLane: Boolean,
+)
+
+object ConnectorGeometry {
+
+    /**
+     * Builds the [ConnectorPath] for a connector whose child node is at ([childX],
+     * [childY]) and parent node at ([parentX], [parentY]). The vertical stops
+     * [mainlineGap] px above the parent (never rising above the child), and the fork's
+     * bezier control slides from the segment midpoint ([forkCurveTension] 0, a straight
+     * diagonal) toward the crisp corner ([forkCurveTension] 1, a right angle).
+     */
+    fun path(
+        childX: Float,
+        childY: Float,
+        parentX: Float,
+        parentY: Float,
+        mainlineGap: Float,
+        forkCurveTension: Float,
+    ): ConnectorPath {
+        val bendY = maxOf(childY, parentY - mainlineGap)
+        val bend = MapPoint(childX, bendY)
+        val end = MapPoint(parentX, parentY)
+
+        // Sharp corner (straight down, then a right angle into the parent's row) vs. the
+        // plain midpoint of the fork segment; tension blends between the two.
+        val corner = MapPoint(childX, parentY)
+        val mid = MapPoint((bend.x + end.x) / 2f, (bend.y + end.y) / 2f)
+        val control = MapPoint(
+            lerp(mid.x, corner.x, forkCurveTension),
+            lerp(mid.y, corner.y, forkCurveTension),
+        )
+
+        return ConnectorPath(
+            start = MapPoint(childX, childY),
+            bend = bend,
+            control = control,
+            end = end,
+            isSameLane = childX == parentX,
+        )
+    }
+
+    private fun lerp(from: Float, to: Float, t: Float) = from + (to - from) * t
+}

--- a/src/main/kotlin/com/codymikol/state/MapDebugState.kt
+++ b/src/main/kotlin/com/codymikol/state/MapDebugState.kt
@@ -1,0 +1,30 @@
+package com.codymikol.state
+
+import androidx.compose.runtime.mutableStateOf
+import com.codymikol.data.map.MapDimensions
+
+/**
+ * Transient, map-only state for the #291 debug menu: the live [MapDimensions] the map
+ * draws with and whether the menu overlay is open. Kept out of GitDownState - these are
+ * throwaway tuning knobs, not project state - and toggled with ctrl+shift+d.
+ */
+object MapDebugState {
+
+    val dimensions = mutableStateOf(MapDimensions())
+
+    val isOpen = mutableStateOf(false)
+
+    fun toggle() {
+        isOpen.value = !isOpen.value
+    }
+
+    /** Drives a single dimension from its slider, leaving every other value untouched. */
+    fun set(slider: MapDimensions.Slider, value: Float) {
+        dimensions.value = slider.set(dimensions.value, value)
+    }
+
+    fun reset() {
+        dimensions.value = MapDimensions()
+        isOpen.value = false
+    }
+}

--- a/src/main/kotlin/com/codymikol/views/MapDebugMenu.kt
+++ b/src/main/kotlin/com/codymikol/views/MapDebugMenu.kt
@@ -1,0 +1,84 @@
+package com.codymikol.views
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Slider
+import androidx.compose.material.SliderDefaults
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.codymikol.data.Colors
+import com.codymikol.data.map.MapDimensions
+import com.codymikol.state.MapDebugState
+
+/**
+ * The map's live-tuning overlay (see issue #291), toggled with ctrl+shift+d. One slider
+ * per parametrized "magic number", each driving [MapDebugState] so the map redraws as
+ * the value moves - a scratch pad for dialling the graph in, not persisted anywhere.
+ */
+@Composable
+fun MapDebugMenu(modifier: Modifier = Modifier) {
+    val dimensions = MapDebugState.dimensions.value
+
+    Column(
+        modifier = modifier
+            .width(280.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(Colors.MediumGrayBackground)
+            .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Text(
+            text = "Map debug (ctrl+shift+d)",
+            color = Color.White,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(bottom = 4.dp),
+        )
+
+        LazyColumn(
+            modifier = Modifier.heightIn(max = 420.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+            contentPadding = PaddingValues(vertical = 2.dp),
+        ) {
+            items(MapDimensions.sliders) { slider ->
+                val value = slider.get(dimensions)
+
+                Text(
+                    text = "${slider.label}: ${formatValue(value)}",
+                    color = Colors.LightGrayText,
+                    fontSize = 10.sp,
+                )
+                Slider(
+                    value = value,
+                    onValueChange = { MapDebugState.set(slider, it) },
+                    valueRange = slider.min..slider.max,
+                    colors = SliderDefaults.colors(
+                        thumbColor = Colors.FileAdded,
+                        activeTrackColor = Colors.FileAdded,
+                        inactiveTrackColor = MaterialTheme.colors.onSurface.copy(alpha = 0.24f),
+                    ),
+                )
+            }
+        }
+    }
+}
+
+private fun formatValue(value: Float): String {
+    val rounded = Math.round(value * 100f) / 100f
+    return if (rounded % 1f == 0f) rounded.toInt().toString() else rounded.toString()
+}

--- a/src/main/kotlin/com/codymikol/views/MapView.kt
+++ b/src/main/kotlin/com/codymikol/views/MapView.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -43,36 +44,21 @@ import com.codymikol.components.menu.MenuColors
 import com.codymikol.components.menu.ThemedDropdownMenu
 import com.codymikol.components.menu.ThemedDropdownMenuItem
 import com.codymikol.data.Colors
+import com.codymikol.data.map.BranchTipNode
 import com.codymikol.data.map.CommitCard
 import com.codymikol.data.map.CommitContextMenu as CommitContextMenuModel
 import com.codymikol.data.map.CommitGraphNode
 import com.codymikol.data.map.MapConnector
+import com.codymikol.data.map.MapDimensions
+import com.codymikol.services.BranchTipNodes
+import com.codymikol.services.ConnectorGeometry
 import com.codymikol.services.MapConnectors
 import com.codymikol.services.OrderedBranchTip
 import com.codymikol.state.GitDownState
+import com.codymikol.state.MapDebugState
 import com.codymikol.state.MapState
 import kotlinx.coroutines.launch
 import java.util.Date
-
-private val LaneWidth = 180.dp
-private val NodeRadius = 5.dp
-private val GutterX = 20.dp
-private val RowHeight = 48.dp
-private const val ConnectorStrokeWidth = 2f
-
-// The dog-tag detail card shown when a node is clicked (#252): a rounded-rectangle
-// body with a protruding round tab holding a punched hole, sitting over the node.
-private val CardTabSize = 22.dp
-private val CardHoleSize = 8.dp
-private val CardCorner = 10.dp
-private val CardMaxWidth = 150.dp
-
-// Branch-name pills for each branch tip (#272), pinned to a row at the top of the
-// map (#277) and colored by the same rule as the node they label.
-private val PillCorner = 8.dp
-private val PillFontSize = 10.sp
-private val PillSpacing = 4.dp
-private val PillMaxWidth = 80.dp
 
 @Composable
 @Preview
@@ -96,6 +82,11 @@ private fun Map() {
     val commits = MapState.commits
     val lazyListState = rememberLazyListState()
 
+    // Every "magic number" the map draws with is now parametrized (#291) and adjustable
+    // live through the ctrl+shift+d debug menu, so the whole view reads its dimensions
+    // from this single source and redraws when a slider moves.
+    val dimensions = MapDebugState.dimensions.value
+
     val lastVisibleIndex by remember {
         derivedStateOf { lazyListState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: -1 }
     }
@@ -117,19 +108,32 @@ private fun Map() {
     // its own draw phase, so scrolling never triggers recomposition of this list.
     val connectors by remember { derivedStateOf { MapConnectors.compute(commits, MapState.lanesBySha) } }
 
+    // The branch-tip nodes pinned to the top row of the grid (#291), each in the lane its
+    // commit occupies below, so the lanes visibly start at the top and cascade into the
+    // mainline as history runs downwards.
+    val tipNodes by remember {
+        derivedStateOf { BranchTipNodes.place(MapState.orderedBranchTips.value, MapState.lanesBySha) }
+    }
+
+    // Like connectors, recomputed only on page load - never per scroll frame - so the
+    // Canvas can look a tip's row up without rebuilding this map every draw.
+    val indexBySha by remember {
+        derivedStateOf { commits.withIndex().associate { (index, commit) -> commit.sha to index } }
+    }
+
     Column(modifier = Modifier.fillMaxSize().background(Colors.DarkGrayBackground)) {
         // Branch tips are pinned here at the top of the grid (#277), ordered
         // left-to-right so the mainline everything merges into leads and the side
         // branches follow by how soon they rejoin it - rather than scattered down
         // the history at each tip commit's chronological row.
-        BranchPillRow(MapState.orderedBranchTips.value)
+        BranchPillRow(MapState.orderedBranchTips.value, dimensions)
 
         Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
             // A single overlay pass over the currently-visible rows (#271): an individual
             // commit row's own draw bounds are clipped to that row, so a diagonal line
             // reaching into a neighbouring row/lane can only be drawn here, not per-node.
             Canvas(modifier = Modifier.fillMaxSize()) {
-                drawConnectors(connectors, lazyListState)
+                drawConnectors(connectors, tipNodes, commits, indexBySha, lazyListState, dimensions)
             }
 
             LazyColumn(
@@ -144,9 +148,16 @@ private fun Map() {
                         commit = commit,
                         isSelected = MapState.selectedNodeSha.value == commit.sha,
                         onClick = { MapState.toggleSelectedNode(commit.sha) },
-                        modifier = Modifier.offset(x = LaneWidth * lane).width(LaneWidth),
+                        dimensions = dimensions,
+                        modifier = Modifier.offset(x = dimensions.laneWidth.dp * lane).width(dimensions.laneWidth.dp),
                     )
                 }
+            }
+
+            // The tuning overlay (#291), toggled with ctrl+shift+d, floats over the top
+            // corner of the graph so its sliders don't disturb the map's own layout.
+            if (MapDebugState.isOpen.value) {
+                MapDebugMenu(modifier = Modifier.align(Alignment.TopEnd).padding(8.dp))
             }
         }
     }
@@ -156,7 +167,7 @@ private fun Map() {
 // branch name in merge-proximity order. A tip shared by several branches lays its
 // names out together, and a merge-commit tip is blued to match its node.
 @Composable
-private fun BranchPillRow(tips: List<OrderedBranchTip>) {
+private fun BranchPillRow(tips: List<OrderedBranchTip>, dimensions: MapDimensions) {
     if (tips.isEmpty()) return
 
     Row(
@@ -165,11 +176,11 @@ private fun BranchPillRow(tips: List<OrderedBranchTip>) {
             // Scroll rather than wrap or clip: the tips stay on one top row even when
             // there are more branches than fit across the map.
             .horizontalScroll(rememberScrollState())
-            .padding(horizontal = GutterX, vertical = PillSpacing * 2),
-        horizontalArrangement = Arrangement.spacedBy(PillSpacing),
+            .padding(horizontal = dimensions.gutterX.dp, vertical = dimensions.pillSpacing.dp * 2),
+        horizontalArrangement = Arrangement.spacedBy(dimensions.pillSpacing.dp),
     ) {
         tips.forEach { tip ->
-            tip.branchNames.forEach { branchName -> BranchPill(branchName, tipColor(tip)) }
+            tip.branchNames.forEach { branchName -> BranchPill(branchName, tipColor(tip), dimensions) }
         }
     }
 }
@@ -185,10 +196,20 @@ private fun tipColor(tip: OrderedBranchTip): Color {
 // first visible row - true for every loaded row, not just the ones currently in
 // layoutInfo.visibleItemsInfo, which is what lets a connector reach into a
 // neighbouring row without that row needing to be measured this frame.
-private fun DrawScope.drawConnectors(connectors: List<MapConnector>, lazyListState: LazyListState) {
-    val rowHeightPx = RowHeight.toPx()
-    val gutterXPx = GutterX.toPx()
-    val laneWidthPx = LaneWidth.toPx()
+private fun DrawScope.drawConnectors(
+    connectors: List<MapConnector>,
+    tipNodes: List<BranchTipNode>,
+    commits: List<CommitGraphNode>,
+    indexBySha: Map<String, Int>,
+    lazyListState: LazyListState,
+    dimensions: MapDimensions,
+) {
+    val rowHeightPx = dimensions.rowHeight.dp.toPx()
+    val gutterXPx = dimensions.gutterX.dp.toPx()
+    val laneWidthPx = dimensions.laneWidth.dp.toPx()
+    val strokeWidth = dimensions.connectorStrokeWidth
+    val mainlineGap = dimensions.mainlineGap.dp.toPx()
+    val forkTension = dimensions.forkCurveTension
     val firstIndex = lazyListState.firstVisibleItemIndex
     val firstOffset = lazyListState.firstVisibleItemScrollOffset
 
@@ -197,6 +218,20 @@ private fun DrawScope.drawConnectors(connectors: List<MapConnector>, lazyListSta
 
     val visibleTop = -rowHeightPx
     val visibleBottom = size.height + rowHeightPx
+
+    fun drawConnector(childX: Float, childY: Float, parentX: Float, parentY: Float, color: Color) {
+        // A synthetic bend node (#291): the line runs straight down the child's lane and
+        // stops mainlineGap px above the parent, then a sharp bezier forks across into
+        // the parent's lane. A same-lane connector's points share an x, so this collapses
+        // to the plain vertical it used to be.
+        val geometry = ConnectorGeometry.path(childX, childY, parentX, parentY, mainlineGap, forkTension)
+        val path = Path().apply {
+            moveTo(geometry.start.x, geometry.start.y)
+            lineTo(geometry.bend.x, geometry.bend.y)
+            quadraticTo(geometry.control.x, geometry.control.y, geometry.end.x, geometry.end.y)
+        }
+        drawPath(path, color = color, style = Stroke(width = strokeWidth))
+    }
 
     connectors.forEach { connector ->
         val childY = rowCenterY(connector.childIndex)
@@ -208,12 +243,37 @@ private fun DrawScope.drawConnectors(connectors: List<MapConnector>, lazyListSta
         // merge node so the line reads as distinct from a same-lane continuation,
         // rather than relying on the diagonal angle alone.
         val sameLane = connector.childLane == connector.parentLane
-        drawLine(
+        drawConnector(
+            childX = laneCenterX(connector.childLane),
+            childY = childY,
+            parentX = laneCenterX(connector.parentLane),
+            parentY = parentY,
             color = if (sameLane) Colors.LightGrayText else Colors.FileModified,
-            start = Offset(laneCenterX(connector.childLane), childY),
-            end = Offset(laneCenterX(connector.parentLane), parentY),
-            strokeWidth = ConnectorStrokeWidth,
         )
+    }
+
+    // Draw each branch-tip node pinned to the top row (#291), plus a vertical connector
+    // down its lane to that tip's commit, so every lane visibly starts at the top of the
+    // grid and cascades into the mainline.
+    val topY = rowHeightPx / 2f
+    tipNodes.forEach { tip ->
+        val laneX = laneCenterX(tip.lane)
+        val tipIndex = indexBySha[tip.sha]
+        val commit = tipIndex?.let { commits[it] }
+        val color = commit?.let(::nodeColor) ?: Colors.FileAdded
+
+        if (tipIndex != null) {
+            val commitY = rowCenterY(tipIndex)
+            if (commitY > topY) {
+                drawConnector(laneX, topY, laneX, commitY, Colors.LightGrayText)
+            }
+        }
+
+        val radius = dimensions.nodeRadius.dp.toPx()
+        when (commit?.isMergeCommit) {
+            true -> drawDiamond(center = Offset(laneX, topY), radius = radius, color = color)
+            else -> drawCircle(color = color, radius = radius, center = Offset(laneX, topY))
+        }
     }
 }
 
@@ -241,6 +301,7 @@ private fun CommitNode(
     commit: CommitGraphNode,
     isSelected: Boolean,
     onClick: () -> Unit,
+    dimensions: MapDimensions,
     modifier: Modifier = Modifier,
 ) {
     var menuExpanded by remember { mutableStateOf(false) }
@@ -248,7 +309,7 @@ private fun CommitNode(
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .height(RowHeight)
+            .height(dimensions.rowHeight.dp)
             // The selected node draws above its siblings so its card, which is taller
             // than one row, floats over the neighbouring nodes rather than under them.
             .zIndex(if (isSelected) 1f else 0f)
@@ -263,15 +324,16 @@ private fun CommitNode(
                 MapState.selectNode(commit.sha)
                 menuExpanded = true
             }
-            .drawBehind { drawCommitNode(commit) }
+            .drawBehind { drawCommitNode(commit, dimensions) }
     ) {
         if (isSelected) {
             CommitDetailCard(
                 commit = commit,
                 color = nodeColor(commit),
+                dimensions = dimensions,
                 modifier = Modifier
                     .align(Alignment.CenterStart)
-                    .padding(start = GutterX - CardTabSize / 2)
+                    .padding(start = dimensions.gutterX.dp - dimensions.cardTabSize.dp / 2)
             )
         } else if (commit.sha == MapState.headSha.value) {
             // The current HEAD is labelled on its node (#282) so the user can see
@@ -279,9 +341,10 @@ private fun CommitNode(
             // takes the same spot over the node instead.
             HeadLabel(
                 color = nodeColor(commit),
+                dimensions = dimensions,
                 modifier = Modifier
                     .align(Alignment.CenterStart)
-                    .padding(start = GutterX + NodeRadius + PillSpacing)
+                    .padding(start = dimensions.gutterX.dp + dimensions.nodeRadius.dp + dimensions.pillSpacing.dp)
             )
         }
 
@@ -295,18 +358,18 @@ private fun CommitNode(
 
 // A small labeled pill naming a local branch, rendered in the top pill row (#277).
 @Composable
-private fun BranchPill(branchName: String, color: Color) {
+private fun BranchPill(branchName: String, color: Color, dimensions: MapDimensions) {
     Box(
         modifier = Modifier
-            .widthIn(max = PillMaxWidth)
-            .clip(RoundedCornerShape(PillCorner))
+            .widthIn(max = dimensions.pillMaxWidth.dp)
+            .clip(RoundedCornerShape(dimensions.pillCorner.dp))
             .background(color)
             .padding(horizontal = 6.dp, vertical = 2.dp),
     ) {
         Text(
             text = branchName,
             color = Color.White,
-            fontSize = PillFontSize,
+            fontSize = dimensions.pillFontSize.sp,
             fontWeight = FontWeight.Bold,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
@@ -318,17 +381,17 @@ private fun BranchPill(branchName: String, color: Color) {
 // the node dot. Mirrors the branch pill: a rounded box in the node's own colour
 // with bold white text, so HEAD reads consistently with the branch tips it labels.
 @Composable
-private fun HeadLabel(color: Color, modifier: Modifier = Modifier) {
+private fun HeadLabel(color: Color, dimensions: MapDimensions, modifier: Modifier = Modifier) {
     Box(
         modifier = modifier
-            .clip(RoundedCornerShape(PillCorner))
+            .clip(RoundedCornerShape(dimensions.pillCorner.dp))
             .background(color)
             .padding(horizontal = 6.dp, vertical = 2.dp),
     ) {
         Text(
             text = "HEAD",
             color = Color.White,
-            fontSize = PillFontSize,
+            fontSize = dimensions.pillFontSize.sp,
             fontWeight = FontWeight.Bold,
             maxLines = 1,
         )
@@ -383,24 +446,25 @@ private fun CommitContextMenu(
 private fun CommitDetailCard(
     commit: CommitGraphNode,
     color: Color,
+    dimensions: MapDimensions,
     modifier: Modifier = Modifier,
 ) {
     val now = remember(commit.sha) { Date() }
 
     Row(
-        modifier = modifier.widthIn(max = CardMaxWidth),
+        modifier = modifier.widthIn(max = dimensions.cardMaxWidth.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Box(
             modifier = Modifier
-                .size(CardTabSize)
+                .size(dimensions.cardTabSize.dp)
                 .clip(CircleShape)
                 .background(color),
             contentAlignment = Alignment.Center,
         ) {
             Box(
                 modifier = Modifier
-                    .size(CardHoleSize)
+                    .size(dimensions.cardHoleSize.dp)
                     .clip(CircleShape)
                     .background(Colors.DarkGrayBackground)
             )
@@ -409,10 +473,10 @@ private fun CommitDetailCard(
         // Tucked left under the tab so the tab's hole end protrudes past the body.
         Column(
             modifier = Modifier
-                .offset(x = -CardCorner)
-                .clip(RoundedCornerShape(CardCorner))
+                .offset(x = -dimensions.cardCorner.dp)
+                .clip(RoundedCornerShape(dimensions.cardCorner.dp))
                 .background(color)
-                .padding(start = CardCorner + 6.dp, top = 6.dp, end = 10.dp, bottom = 6.dp),
+                .padding(start = dimensions.cardCorner.dp + 6.dp, top = 6.dp, end = 10.dp, bottom = 6.dp),
         ) {
             CardLine(CommitCard.title(commit), FontWeight.Bold)
             CardLine(CommitCard.author(commit), FontWeight.Normal)
@@ -437,13 +501,14 @@ private fun CardLine(text: String, fontWeight: FontWeight) {
 private fun nodeColor(commit: CommitGraphNode): Color =
     if (commit.isMergeCommit) Colors.FileModified else Colors.FileAdded
 
-private fun DrawScope.drawCommitNode(commit: CommitGraphNode) {
-    val x = GutterX.toPx()
+private fun DrawScope.drawCommitNode(commit: CommitGraphNode, dimensions: MapDimensions) {
+    val x = dimensions.gutterX.dp.toPx()
     val centerY = size.height / 2f
+    val radius = dimensions.nodeRadius.dp.toPx()
 
     when (commit.isMergeCommit) {
-        true -> drawDiamond(center = Offset(x, centerY), radius = NodeRadius.toPx(), color = nodeColor(commit))
-        false -> drawCircle(color = nodeColor(commit), radius = NodeRadius.toPx(), center = Offset(x, centerY))
+        true -> drawDiamond(center = Offset(x, centerY), radius = radius, color = nodeColor(commit))
+        false -> drawCircle(color = nodeColor(commit), radius = radius, center = Offset(x, centerY))
     }
 }
 

--- a/src/main/kotlin/com/codymikol/windows/GitDown.kt
+++ b/src/main/kotlin/com/codymikol/windows/GitDown.kt
@@ -44,6 +44,7 @@ import com.codymikol.gitdown.generated.resources.stash_white
 import com.codymikol.services.WindowSizeService
 import com.codymikol.state.GitDownState
 import com.codymikol.state.Keys
+import com.codymikol.state.MapDebugState
 import com.codymikol.state.MapState
 import com.codymikol.tabs.Tab
 import com.codymikol.views.CommitView
@@ -94,6 +95,11 @@ fun GitDown(applicationScope: ApplicationScope) {
             val checkoutDetachedTarget = if (isDown && it.key == Key.Enter && tab == Tab.Map)
                 MapState.selectedNode() else null
 
+            // Ctrl+Shift+D on the map toggles the debug menu that tunes the map's
+            // "magic number" dimensions live (#291).
+            val isMapDebugToggle = isDown && tab == Tab.Map &&
+                it.isCtrlPressed && it.isShiftPressed && it.key == Key.D
+
             // Space or Escape closes the quick view while it is open.
             val shouldCloseQuickView = isDown && tab == Tab.QuickView &&
                 (it.key == Key.Spacebar || it.key == Key.Escape)
@@ -103,6 +109,10 @@ fun GitDown(applicationScope: ApplicationScope) {
                 (it.key == Key.DirectionUp || it.key == Key.DirectionDown)
 
             when {
+                isMapDebugToggle -> {
+                    MapDebugState.toggle()
+                    true
+                }
                 isFileSelectionArrow -> {
                     GitDownState.selectAdjacentFile(if (it.key == Key.DirectionUp) -1 else 1)
                     true

--- a/src/test/kotlin/com/codymikol/services/BranchTipNodesSpec.kt
+++ b/src/test/kotlin/com/codymikol/services/BranchTipNodesSpec.kt
@@ -1,0 +1,51 @@
+package com.codymikol.services
+
+import com.codymikol.data.map.BranchTipNode
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class BranchTipNodesSpec : DescribeSpec({
+
+    describe("BranchTipNodes") {
+
+        describe("place") {
+
+            it("places each ordered tip in the lane its loaded commit occupies") {
+                val tips = listOf(
+                    OrderedBranchTip("A", listOf("main")),
+                    OrderedBranchTip("B", listOf("foo")),
+                )
+                val lanesBySha = mapOf("A" to 0, "B" to 1)
+
+                BranchTipNodes.place(tips, lanesBySha) shouldBe listOf(
+                    BranchTipNode("A", 0),
+                    BranchTipNode("B", 1),
+                )
+            }
+
+            it("skips a tip whose commit pagination has not loaded yet") {
+                val tips = listOf(
+                    OrderedBranchTip("A", listOf("main")),
+                    OrderedBranchTip("C", listOf("bar")),
+                )
+                val lanesBySha = mapOf("A" to 0)
+
+                BranchTipNodes.place(tips, lanesBySha) shouldBe listOf(
+                    BranchTipNode("A", 0),
+                )
+            }
+
+            it("keeps only the first tip when two share a lane, preserving mainline priority") {
+                val tips = listOf(
+                    OrderedBranchTip("A", listOf("main")),
+                    OrderedBranchTip("B", listOf("foo")),
+                )
+                val lanesBySha = mapOf("A" to 0, "B" to 0)
+
+                BranchTipNodes.place(tips, lanesBySha) shouldBe listOf(
+                    BranchTipNode("A", 0),
+                )
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/codymikol/services/ConnectorGeometrySpec.kt
+++ b/src/test/kotlin/com/codymikol/services/ConnectorGeometrySpec.kt
@@ -1,0 +1,73 @@
+package com.codymikol.services
+
+import com.codymikol.data.map.MapPoint
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class ConnectorGeometrySpec : DescribeSpec({
+
+    describe("ConnectorGeometry") {
+
+        describe("path") {
+
+            it("runs the vertical down the child lane and stops the mainline gap above the parent") {
+                val path = ConnectorGeometry.path(
+                    childX = 20f, childY = 24f,
+                    parentX = 200f, parentY = 120f,
+                    mainlineGap = 24f, forkCurveTension = 1f,
+                )
+
+                path.start shouldBe MapPoint(20f, 24f)
+                // synthetic node: still in the child's lane, 24px above the parent node
+                path.bend shouldBe MapPoint(20f, 96f)
+                path.end shouldBe MapPoint(200f, 120f)
+            }
+
+            it("puts the bezier control at the sharp corner when tension is full") {
+                val path = ConnectorGeometry.path(
+                    childX = 20f, childY = 24f,
+                    parentX = 200f, parentY = 120f,
+                    mainlineGap = 24f, forkCurveTension = 1f,
+                )
+
+                // a crisp right-angle: the bend continues straight down to the parent's row
+                path.control shouldBe MapPoint(20f, 120f)
+            }
+
+            it("relaxes the bezier control toward the midpoint as tension drops to zero") {
+                val path = ConnectorGeometry.path(
+                    childX = 20f, childY = 24f,
+                    parentX = 200f, parentY = 120f,
+                    mainlineGap = 24f, forkCurveTension = 0f,
+                )
+
+                // midpoint of the fork segment (bend -> end): ((20+200)/2, (96+120)/2)
+                path.control shouldBe MapPoint(110f, 108f)
+                path.isSameLane shouldBe false
+            }
+
+            it("degenerates to a straight vertical for a same-lane connector") {
+                val path = ConnectorGeometry.path(
+                    childX = 20f, childY = 24f,
+                    parentX = 20f, parentY = 120f,
+                    mainlineGap = 24f, forkCurveTension = 0.85f,
+                )
+
+                path.isSameLane shouldBe true
+                path.control.x shouldBe 20f
+                path.bend shouldBe MapPoint(20f, 96f)
+            }
+
+            it("never lets the vertical rise above the child when the gap exceeds the row span") {
+                val path = ConnectorGeometry.path(
+                    childX = 20f, childY = 100f,
+                    parentX = 200f, parentY = 120f,
+                    mainlineGap = 64f, forkCurveTension = 1f,
+                )
+
+                // parentY - gap = 56 would sit above the child at y=100; clamp to childY
+                path.bend shouldBe MapPoint(20f, 100f)
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/codymikol/state/MapDebugStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/MapDebugStateSpec.kt
@@ -1,0 +1,50 @@
+package com.codymikol.state
+
+import com.codymikol.data.map.MapDimensions
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class MapDebugStateSpec : DescribeSpec({
+
+    describe("MapDebugState") {
+
+        beforeEach {
+            MapDebugState.reset()
+        }
+
+        it("starts closed with the default dimensions") {
+            MapDebugState.isOpen.value shouldBe false
+            MapDebugState.dimensions.value shouldBe MapDimensions()
+        }
+
+        it("toggles the menu open and closed") {
+            MapDebugState.toggle()
+            MapDebugState.isOpen.value shouldBe true
+
+            MapDebugState.toggle()
+            MapDebugState.isOpen.value shouldBe false
+        }
+
+        it("updates a single dimension through a slider without touching the rest") {
+            val slider = MapDimensions.sliders.first { it.label == "mainlineGap" }
+
+            MapDebugState.set(slider, 40f)
+
+            MapDebugState.dimensions.value.mainlineGap shouldBe 40f
+            // every other value is still its default
+            MapDebugState.dimensions.value.copy(mainlineGap = MapDimensions().mainlineGap) shouldBe
+                MapDimensions()
+        }
+
+        it("resets the dimensions back to their defaults") {
+            val slider = MapDimensions.sliders.first { it.label == "laneWidth" }
+            MapDebugState.set(slider, 300f)
+            MapDebugState.toggle()
+
+            MapDebugState.reset()
+
+            MapDebugState.dimensions.value shouldBe MapDimensions()
+            MapDebugState.isOpen.value shouldBe false
+        }
+    }
+})


### PR DESCRIPTION
Closes #291

## What

Follows up #287 (branch pills pinned to the top of the map) by making the
map's lanes visibly start at the top and cascade into the mainline, and by
cleaning up how cross-lane connectors are drawn.

- **Tip nodes at the top of the grid.** Each ordered branch tip now renders as
  a node pinned to the top row, in the same lane its commit occupies in the
  graph below, with a connector cascading down to that commit.
- **Synthetic-node connectors.** A cross-lane connector no longer draws a bare
  diagonal. It runs straight down the child's lane to a synthetic bend node,
  stopping `mainlineGap` (default 24px) above the target node so it slants
  down, then a "somewhat sharp" quadratic bezier forks into the parent's lane.
  Same-lane connectors collapse back to the plain vertical.
- **Parametrized magic numbers + debug menu.** Every map dimension lives in
  `MapDimensions`, each exposed as a labelled slider with a range. Press
  **ctrl+shift+d** on the map to open a live tuning overlay (`MapDebugMenu`)
  backed by `MapDebugState`; the map redraws as sliders move.

## How

- `ConnectorGeometry.path(...)` — pure function turning a child/parent pair into
  start / synthetic-bend / bezier-control / end points; tension slides the
  control from the segment midpoint (straight diagonal) to a crisp corner.
- `BranchTipNodes.place(...)` — maps ordered tips to `(sha, lane)` for loaded
  tips, deduping by lane so a lane never gets two top nodes.
- `MapView` reads all dimensions from `MapDebugState` instead of file-level
  constants; connectors and the top-row tip nodes are drawn in the existing
  single Canvas overlay pass. A memoized `indexBySha` avoids per-frame rebuilds.
- `GitDown` wires ctrl+shift+d (map tab) to `MapDebugState.toggle`.

## Tests

- `ConnectorGeometrySpec` — bend/gap/clamp, bezier-control tension endpoints,
  same-lane degeneration.
- `BranchTipNodesSpec` — lane placement, skipping unloaded tips, lane dedupe.
- `MapDebugStateSpec` — default/open state, single-dimension slider updates, reset.

## Notes for reviewer

- No JDK/Gradle in the agent environment (nix store read-only), so these
  changes were validated by CI rather than locally — same constraint as #287.
- The vertical gap stops above whichever node an edge connects *into* (the
  parent). For a branch converging into mainline that is the mainline node the
  issue emphasizes; the rule is applied generically to every cross-lane edge.
- Tip nodes are pinned at a fixed top row (they don't scroll), so the cascade
  connector lengthens as you scroll — intentional per "nodes at the top of the
  grid ... cascade downwards".