### PR TITLE
feat: implement edit message

### DIFF
--- a/src/main/kotlin/com/codymikol/components/map/EditMessageDialog.kt
+++ b/src/main/kotlin/com/codymikol/components/map/EditMessageDialog.kt
@@ -1,0 +1,87 @@
+package com.codymikol.components.map
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.codymikol.components.SlimButton
+import com.codymikol.data.Colors
+import com.codymikol.typography.jetbrainsMono
+
+fun canEditMessage(message: String): Boolean = message.isNotBlank()
+
+// The "Edit Message..." modal (see issue #299): a text area pre-populated with the
+// commit's current message, a Cancel button that dismisses, and an Accept button that
+// rewrites the commit with the edited message. Only the local edit buffer lives here;
+// opening/closing and the rewrite itself are driven by the parent through the
+// callbacks, matching how SaveStashDialog is wired.
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun EditMessageDialog(
+    initialMessage: String,
+    onDismiss: () -> Unit,
+    onConfirm: (message: String) -> Unit,
+) {
+    var message by remember { mutableStateOf(initialMessage) }
+
+    AlertDialog(
+        modifier = Modifier.fillMaxWidth().border(1.dp, Color.Black, RoundedCornerShape(4.dp)).padding(bottom = 8.dp),
+        onDismissRequest = { onDismiss() },
+        backgroundColor = Colors.LightGrayBackground,
+        contentColor = Color.White,
+        shape = RoundedCornerShape(4.dp),
+        text = {
+            Column(modifier = Modifier.fillMaxWidth().padding(8.dp)) {
+                Text(
+                    "Edit Message",
+                    modifier = Modifier.padding(vertical = 8.dp),
+                    color = Color.White,
+                    fontFamily = jetbrainsMono(),
+                    style = MaterialTheme.typography.subtitle1
+                )
+
+                BasicTextField(
+                    value = message,
+                    onValueChange = { message = it },
+                    cursorBrush = Brush.verticalGradient(0.00f to Color.White),
+                    textStyle = TextStyle(color = Color.White, fontSize = 12.sp, fontFamily = jetbrainsMono()),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .requiredHeight(120.dp)
+                        .background(Colors.DarkGrayBackground)
+                        .padding(8.dp)
+                )
+            }
+        },
+        dismissButton = {
+            SlimButton("Cancel", onClick = { onDismiss() }, modifier = Modifier.padding(bottom = 8.dp).requiredHeight(28.dp))
+        },
+        confirmButton = {
+            SlimButton(
+                "Accept",
+                disabled = !canEditMessage(message),
+                onClick = { onConfirm(message) },
+                modifier = Modifier.padding(bottom = 8.dp).requiredHeight(28.dp)
+            )
+        }
+    )
+}

--- a/src/main/kotlin/com/codymikol/data/map/CommitGraphNode.kt
+++ b/src/main/kotlin/com/codymikol/data/map/CommitGraphNode.kt
@@ -11,6 +11,10 @@ data class CommitGraphNode(
     val authorEmail: String,
     val date: Date,
     val parentShas: List<String>,
+    // The full, multi-line commit message, used to pre-populate the "Edit Message..."
+    // modal (#299). Defaults to shortMessage so the many single-line test fixtures that
+    // build nodes directly need not supply it.
+    val fullMessage: String = shortMessage,
 ) {
 
     val isMergeCommit: Boolean
@@ -25,6 +29,7 @@ data class CommitGraphNode(
             authorEmail = revCommit.authorIdent?.emailAddress ?: "",
             date = Date(revCommit.commitTime.toLong() * 1000),
             parentShas = revCommit.parents.map { it.name },
+            fullMessage = revCommit.fullMessage,
         )
     }
 }

--- a/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
+++ b/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
@@ -24,11 +24,15 @@ import org.eclipse.jgit.dircache.DirCacheEntry
 import org.eclipse.jgit.dircache.DirCacheIterator
 import org.eclipse.jgit.errors.LockFailedException
 import org.eclipse.jgit.lib.AnyObjectId
+import org.eclipse.jgit.lib.CommitBuilder
+import org.eclipse.jgit.lib.Constants
 import org.eclipse.jgit.lib.Constants.OBJ_BLOB
 import org.eclipse.jgit.lib.FileMode
+import org.eclipse.jgit.lib.ObjectId
 import org.eclipse.jgit.lib.Ref
 import org.eclipse.jgit.lib.Repository
 import org.eclipse.jgit.revwalk.RevCommit
+import org.eclipse.jgit.revwalk.RevSort
 import org.eclipse.jgit.revwalk.RevTree
 import org.eclipse.jgit.revwalk.RevWalk
 import org.eclipse.jgit.treewalk.FileTreeIterator
@@ -615,6 +619,68 @@ suspend fun Git.amendAll(message: String) = command {
         .call()
         .also { logger.info("Amending index") }
         .unit()
+}
+
+/**
+ * Rewrites the message of the commit [sha] resolves to (see issue #299), backing the
+ * map view's "Edit Message..." action. The target commit and every descendant of it
+ * reachable from the current branch are replayed onto rebuilt copies: each rebuilt
+ * commit keeps its original tree, author and committer, so only the target's message
+ * changes and no file content moves. Because a commit's id is a hash of its message
+ * and parents, the target and all of its descendants get fresh ids, so the current
+ * branch (and thus HEAD) is force-updated to the rewritten tip. The working tree is
+ * left untouched since every rebuilt commit reuses its original tree.
+ */
+suspend fun Git.rewriteCommitMessage(sha: String, newMessage: String): Git = command {
+    val repo = repository
+    val targetId = repo.resolve(sha)
+        ?: throw IllegalArgumentException("Cannot resolve commit $sha")
+    val headId = repo.resolve(Constants.HEAD)
+        ?: throw IllegalStateException("Cannot rewrite a message with no HEAD")
+
+    RevWalk(repo).use { walk ->
+        val head = walk.parseCommit(headId)
+        val target = walk.parseCommit(targetId)
+
+        walk.markStart(head)
+        // Leave everything reachable from the target's parents untouched; the walk then
+        // yields exactly the target plus every descendant of it on HEAD's side.
+        target.parents.forEach { walk.markUninteresting(walk.parseCommit(it.id)) }
+        // Reverse-topological order yields parents before children, so each commit's new
+        // parent ids are already known by the time it is rebuilt.
+        walk.sort(RevSort.TOPO, true)
+        walk.sort(RevSort.REVERSE, true)
+        val toReplay = walk.toList()
+
+        val rewritten = HashMap<ObjectId, ObjectId>()
+
+        repo.newObjectInserter().use { inserter ->
+            toReplay.forEach { original ->
+                val builder = CommitBuilder().apply {
+                    setTreeId(original.tree.id)
+                    setParentIds(original.parents.map { rewritten[it.id] ?: it.id })
+                    setAuthor(original.authorIdent)
+                    setCommitter(original.committerIdent)
+                    setEncoding(original.encoding)
+                    setMessage(if (original.id == target.id) newMessage else original.fullMessage)
+                }
+                rewritten[original.id] = inserter.insert(builder)
+            }
+            inserter.flush()
+        }
+
+        val newHead = rewritten[head.id] ?: head.id
+
+        // Updating HEAD (rather than repo.fullBranch) moves the underlying branch when
+        // HEAD is attached and moves HEAD itself when it is detached, so a detached-HEAD
+        // edit still lands rather than leaving the rewritten commits dangling.
+        repo.updateRef(Constants.HEAD).apply {
+            setNewObjectId(newHead)
+            setForceUpdate(true)
+        }.update()
+
+        logger.info("Rewrote message of $sha; HEAD now at ${newHead.name}")
+    }
 }
 
 suspend fun Git.applyStash(stash: StashListItem) = command {

--- a/src/main/kotlin/com/codymikol/state/state.kt
+++ b/src/main/kotlin/com/codymikol/state/state.kt
@@ -14,6 +14,7 @@ import com.codymikol.extensions.getCommitDiffAgainstHead
 import com.codymikol.extensions.getCurrentRefCommitCount
 import com.codymikol.extensions.getStashDiff
 import com.codymikol.extensions.getStashes
+import com.codymikol.extensions.rewriteCommitMessage
 import com.codymikol.tabs.Tab
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder
@@ -86,6 +87,11 @@ object GitDownState {
     // the quick view is closed. Held here rather than read from MapState so the view
     // survives the map scrolling or resetting out from under it.
     val quickViewCommit = mutableStateOf<CommitGraphNode?>(null)
+
+    // The commit whose message the "Edit Message..." modal (see issue #299) is open
+    // for, or null when the modal is closed. The map view renders the modal while this
+    // is non-null and pre-populates it from the commit's full message.
+    val editMessageCommit = mutableStateOf<CommitGraphNode?>(null)
 
     // True when the quick view diffs its commit against HEAD (Diff with HEAD, see
     // issue #280) rather than against the commit's own first parent (the plain quick
@@ -263,6 +269,26 @@ object GitDownState {
      */
     suspend fun checkoutDetachedHead(commit: CommitGraphNode) {
         git.value.checkoutDetachedHead(commit.sha)
+    }
+
+    /** Opens the "Edit Message..." modal (see issue #299) for [commit]. */
+    fun openEditMessage(commit: CommitGraphNode) {
+        editMessageCommit.value = commit
+    }
+
+    /** Dismisses the "Edit Message..." modal (see issue #299) without any change. */
+    fun closeEditMessage() {
+        editMessageCommit.value = null
+    }
+
+    /**
+     * Rewrites [commit]'s message to [newMessage] (see issue #299), replaying it and
+     * its descendants so the change lands in history, then closes the modal. Backs the
+     * modal's Accept button.
+     */
+    suspend fun editCommitMessage(commit: CommitGraphNode, newMessage: String) {
+        git.value.rewriteCommitMessage(commit.sha, newMessage)
+        editMessageCommit.value = null
     }
 
     /** Closes the quick view, clearing its commit and restoring the prior tab. */

--- a/src/main/kotlin/com/codymikol/views/MapView.kt
+++ b/src/main/kotlin/com/codymikol/views/MapView.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
+import com.codymikol.components.map.EditMessageDialog
 import com.codymikol.components.menu.MenuColors
 import com.codymikol.components.menu.ThemedDropdownMenu
 import com.codymikol.components.menu.ThemedDropdownMenuItem
@@ -81,6 +82,7 @@ fun MapView() {
 private fun Map() {
     val commits = MapState.commits
     val lazyListState = rememberLazyListState()
+    val scope = rememberCoroutineScope()
 
     // Every "magic number" the map draws with is now parametrized (#291) and adjustable
     // live through the ctrl+shift+d debug menu, so the whole view reads its dimensions
@@ -158,6 +160,19 @@ private fun Map() {
             // corner of the graph so its sliders don't disturb the map's own layout.
             if (MapDebugState.isOpen.value) {
                 MapDebugMenu(modifier = Modifier.align(Alignment.TopEnd).padding(8.dp))
+            }
+
+            // The "Edit Message..." modal (#299) floats over the map while a commit is
+            // being edited, pre-populated with that commit's full message. Accept rewrites
+            // the commit through history and closes the modal; Cancel just dismisses.
+            GitDownState.editMessageCommit.value?.let { commit ->
+                EditMessageDialog(
+                    initialMessage = commit.fullMessage,
+                    onDismiss = { GitDownState.closeEditMessage() },
+                    onConfirm = { message ->
+                        scope.launch { GitDownState.editCommitMessage(commit, message) }
+                    },
+                )
             }
         }
     }
@@ -430,6 +445,9 @@ private fun CommitContextMenu(
                         }
                         "Checkout Detached HEAD" -> {
                             { scope.launch { GitDownState.checkoutDetachedHead(commit) }; onDismiss() }
+                        }
+                        "Edit Message..." -> {
+                            { GitDownState.openEditMessage(commit); onDismiss() }
                         }
                         else -> onDismiss
                     },

--- a/src/test/kotlin/com/codymikol/extensions/RewriteCommitMessageSpec.kt
+++ b/src/test/kotlin/com/codymikol/extensions/RewriteCommitMessageSpec.kt
@@ -1,0 +1,48 @@
+package com.codymikol.extensions
+
+import com.codymikol.repository.TestRepository.Companion.createTestRepository
+import com.codymikol.state.GitDownState
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class RewriteCommitMessageSpec : DescribeSpec({
+
+    describe("Git.rewriteCommitMessage") {
+
+        describe("rewriting an earlier commit's message") {
+
+            autoClose(
+                createTestRepository()
+                    .addFile("foo.txt", "one\n")
+                    .stageAll()
+                    .commitAll("init")
+                    .appendToFile("foo.txt", "two\n")
+                    .stageAll()
+                    .commitAll("add two")
+                    .transferIntoGitDownState()
+            )
+
+            it("rewrites the message while preserving descendants and content") {
+                val git = GitDownState.git.value
+                val repo = git.repository
+                val target = repo.resolve("HEAD~1")
+                val originalAuthor = repo.parseCommit(target).authorIdent
+
+                git.rewriteCommitMessage(target.name, "renamed init")
+
+                // History still has two commits, no orphaned dangling additions.
+                repo.parseCommit(repo.resolve("HEAD")).shortMessage shouldBe "add two"
+                val rewritten = repo.parseCommit(repo.resolve("HEAD~1"))
+                rewritten.fullMessage shouldBe "renamed init"
+
+                // Only the message changes: authorship is carried over verbatim.
+                rewritten.authorIdent.name shouldBe originalAuthor.name
+                rewritten.authorIdent.emailAddress shouldBe originalAuthor.emailAddress
+
+                // The rewritten commit keeps its original tree, so the tip's tree -
+                // and therefore the working tree content - is unchanged.
+                java.io.File(repo.workTree, "foo.txt").readText() shouldBe "one\ntwo\n"
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/codymikol/state/EditCommitMessageStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/EditCommitMessageStateSpec.kt
@@ -1,0 +1,58 @@
+package com.codymikol.state
+
+import com.codymikol.data.map.CommitGraphNode
+import com.codymikol.repository.TestRepository.Companion.createTestRepository
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.util.Date
+
+class EditCommitMessageStateSpec : DescribeSpec({
+
+    fun node(sha: String) = CommitGraphNode(
+        sha = sha,
+        shortSha = sha.take(7),
+        shortMessage = "do a thing",
+        authorName = "Ada Lovelace",
+        authorEmail = "ada@example.com",
+        date = Date(),
+        parentShas = emptyList(),
+    )
+
+    describe("GitDownState edit message modal") {
+
+        beforeContainer { GitDownState.git.value.close() }
+
+        autoClose(
+            createTestRepository()
+                .addFile("foo.txt", "one\n")
+                .stageAll()
+                .commitAll("init")
+                .appendToFile("foo.txt", "two\n")
+                .stageAll()
+                .commitAll("add two")
+                .transferIntoGitDownState()
+        )
+
+        it("opens and closes the modal for a commit") {
+            val commit = node("abc123")
+
+            GitDownState.openEditMessage(commit)
+            GitDownState.editMessageCommit.value shouldBe commit
+
+            GitDownState.closeEditMessage()
+            GitDownState.editMessageCommit.value shouldBe null
+        }
+
+        it("rewrites the commit message and closes the modal") {
+            val repo = GitDownState.git.value.repository
+            val target = repo.resolve("HEAD~1")
+            GitDownState.openEditMessage(node(target.name))
+
+            GitDownState.editCommitMessage(node(target.name), "renamed init")
+
+            repo.parseCommit(repo.resolve("HEAD~1")).fullMessage shouldBe "renamed init"
+            repo.parseCommit(repo.resolve("HEAD")).shortMessage shouldBe "add two"
+            GitDownState.editMessageCommit.value shouldBe null
+        }
+    }
+})


### PR DESCRIPTION
Implements the map view's "Edit Message..." context-menu action (#299).

## What changed
- **Git op** — `Git.rewriteCommitMessage(sha, newMessage)` replays the target commit and every descendant reachable from the current branch onto rebuilt copies. Each rebuilt commit reuses its original tree, author and committer, so only the target's message changes and no file content moves; HEAD (attached branch, or detached HEAD itself) is force-updated to the rewritten tip.
- **Model** — `CommitGraphNode.fullMessage` (defaults to `shortMessage`) so the modal pre-populates with the complete message.
- **State** — `GitDownState.editMessageCommit` plus `openEditMessage` / `closeEditMessage` / `editCommitMessage`, which rewrites the commit and clears the state to close the modal.
- **UI** — `EditMessageDialog` (text area pre-filled with the message, Cancel dismisses, Accept rewrites and closes), modeled on `SaveStashDialog`. Wired the `"Edit Message..."` context-menu case and rendered the dialog over the map while a commit is being edited.

## Tests
- `RewriteCommitMessageSpec` — rewrites an earlier commit's message, asserting descendants, tree/content and authorship are preserved.
- `EditCommitMessageStateSpec` — modal open/close and the rewrite-then-close flow.

## Reviewer note
The nix store in the agent sandbox is read-only with no JDK available, so `./gradlew`/`nix develop` cannot run locally — the build and both specs are exercised by CI here rather than pre-merge in the container.

Closes #299