### PR TITLE
feat(map): traverse the commit grid with arrow keys

### DIFF
--- a/src/main/kotlin/com/codymikol/state/MapState.kt
+++ b/src/main/kotlin/com/codymikol/state/MapState.kt
@@ -9,6 +9,7 @@ import com.codymikol.data.map.CommitHistoryWalker
 import com.codymikol.extensions.listLocalBranches
 import com.codymikol.services.BranchTipOrderer
 import com.codymikol.services.LaneAssigner
+import kotlin.math.abs
 
 /**
  * Backs the Map view. Every local branch tip is walked in one merged RevWalk (see
@@ -56,6 +57,48 @@ object MapState {
      */
     fun selectNode(sha: String) {
         selectedNodeSha.value = sha
+    }
+
+    /**
+     * Moves the map selection one step across the commit grid (see issue #295), so the
+     * whole map is reachable from the keyboard.
+     *
+     * [rowOffset] walks the ordered commit list up (-1) or down (+1), clamped to the
+     * loaded window - a vertical step follows the commit order regardless of lane.
+     * [laneOffset] steps to the adjacent lane (-1 left, +1 right) by selecting the
+     * commit in that lane nearest the current row, preferring the earlier (upward) row
+     * on a tie, and does nothing when that lane holds no loaded commit - lanes are
+     * sparse, so not every lane exists at every row.
+     *
+     * With nothing selected (or the selected node scrolled out of the loaded window) the
+     * first loaded commit becomes the selection, giving the arrow keys a starting point.
+     */
+    fun selectAdjacentNode(rowOffset: Int, laneOffset: Int) {
+        if (commits.isEmpty()) return
+
+        val currentIndex = commits.indexOfFirst { it.sha == selectedNodeSha.value }
+        if (currentIndex < 0) {
+            selectedNodeSha.value = commits.first().sha
+            return
+        }
+
+        if (rowOffset != 0) {
+            val nextIndex = (currentIndex + rowOffset).coerceIn(commits.indices)
+            selectedNodeSha.value = commits[nextIndex].sha
+            return
+        }
+
+        if (laneOffset != 0) {
+            val currentLane = lanesBySha[selectedNodeSha.value] ?: return
+            val targetLane = currentLane + laneOffset
+
+            val nearest = commits.withIndex()
+                .filter { lanesBySha[it.value.sha] == targetLane }
+                .minByOrNull { abs(it.index - currentIndex) }
+                ?: return
+
+            selectedNodeSha.value = nearest.value.sha
+        }
     }
 
     /**

--- a/src/main/kotlin/com/codymikol/views/MapView.kt
+++ b/src/main/kotlin/com/codymikol/views/MapView.kt
@@ -91,6 +91,19 @@ private fun Map() {
         derivedStateOf { lazyListState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: -1 }
     }
 
+    // Keep the keyboard-driven selection (#295) on screen: when arrow keys move it out
+    // of the visible rows, scroll it into view (aligned to the top). Keyed on the
+    // selected sha alone - the effect only scrolls, never mutates the selection, so it
+    // can't relaunch itself the way keying on a mutated value once did (see #256).
+    val selectedSha = MapState.selectedNodeSha.value
+    LaunchedEffect(selectedSha) {
+        if (selectedSha == null) return@LaunchedEffect
+        val index = commits.indexOfFirst { it.sha == selectedSha }
+        if (index < 0) return@LaunchedEffect
+        val isVisible = lazyListState.layoutInfo.visibleItemsInfo.any { it.index == index }
+        if (!isVisible) lazyListState.animateScrollToItem(index)
+    }
+
     // shouldLoadMore() is true before anything has loaded, so this effect also covers
     // the very first page - no separate initial-load effect needed. It's keyed on the
     // scroll-derived lastVisibleIndex, never on commits.size or hasMore, which

--- a/src/main/kotlin/com/codymikol/windows/GitDown.kt
+++ b/src/main/kotlin/com/codymikol/windows/GitDown.kt
@@ -108,6 +108,12 @@ fun GitDown(applicationScope: ApplicationScope) {
             val isQuickViewFileArrow = isDown && tab == Tab.QuickView &&
                 (it.key == Key.DirectionUp || it.key == Key.DirectionDown)
 
+            // Arrow keys walk the map grid (#295): up/down step through the commit rows,
+            // left/right step to the adjacent lane.
+            val isMapNavArrow = isDown && tab == Tab.Map &&
+                (it.key == Key.DirectionUp || it.key == Key.DirectionDown ||
+                    it.key == Key.DirectionLeft || it.key == Key.DirectionRight)
+
             when {
                 isMapDebugToggle -> {
                     MapDebugState.toggle()
@@ -119,6 +125,15 @@ fun GitDown(applicationScope: ApplicationScope) {
                 }
                 isQuickViewFileArrow -> {
                     GitDownState.selectAdjacentQuickViewFile(if (it.key == Key.DirectionUp) -1 else 1)
+                    true
+                }
+                isMapNavArrow -> {
+                    when (it.key) {
+                        Key.DirectionUp -> MapState.selectAdjacentNode(-1, 0)
+                        Key.DirectionDown -> MapState.selectAdjacentNode(1, 0)
+                        Key.DirectionLeft -> MapState.selectAdjacentNode(0, -1)
+                        Key.DirectionRight -> MapState.selectAdjacentNode(0, 1)
+                    }
                     true
                 }
                 shouldCloseQuickView -> {

--- a/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
@@ -257,6 +257,123 @@ class MapStateSpec : DescribeSpec({
             }
         }
 
+        describe("adjacent node traversal") {
+
+            // A four-commit grid two lanes wide: rows 0/2 sit in lane 0, rows 1/3 in
+            // lane 1, so both a same-lane and a cross-lane neighbour exist to move to.
+            fun loadTwoLaneGrid() {
+                MapState.reset()
+                MapState.commits.addAll(dummyCommits(4))
+                listOf("sha1" to 0, "sha2" to 1, "sha3" to 0, "sha4" to 1)
+                    .forEach { (sha, lane) -> MapState.lanesBySha[sha] = lane }
+            }
+
+            it("selects the first commit when an arrow is pressed with no selection") {
+                MapState.reset()
+                MapState.commits.addAll(dummyCommits(3))
+
+                MapState.selectAdjacentNode(1, 0)
+
+                MapState.selectedNodeSha.value shouldBe "sha1"
+            }
+
+            it("does nothing when no commits are loaded") {
+                MapState.reset()
+
+                MapState.selectAdjacentNode(1, 0)
+
+                MapState.selectedNodeSha.value shouldBe null
+            }
+
+            it("moves the selection down to the next commit") {
+                MapState.reset()
+                MapState.commits.addAll(dummyCommits(3))
+                MapState.selectNode("sha1")
+
+                MapState.selectAdjacentNode(1, 0)
+
+                MapState.selectedNodeSha.value shouldBe "sha2"
+            }
+
+            it("moves the selection up to the previous commit") {
+                MapState.reset()
+                MapState.commits.addAll(dummyCommits(3))
+                MapState.selectNode("sha2")
+
+                MapState.selectAdjacentNode(-1, 0)
+
+                MapState.selectedNodeSha.value shouldBe "sha1"
+            }
+
+            it("clamps at the last commit when moving down past the end") {
+                MapState.reset()
+                MapState.commits.addAll(dummyCommits(3))
+                MapState.selectNode("sha3")
+
+                MapState.selectAdjacentNode(1, 0)
+
+                MapState.selectedNodeSha.value shouldBe "sha3"
+            }
+
+            it("clamps at the first commit when moving up past the start") {
+                MapState.reset()
+                MapState.commits.addAll(dummyCommits(3))
+                MapState.selectNode("sha1")
+
+                MapState.selectAdjacentNode(-1, 0)
+
+                MapState.selectedNodeSha.value shouldBe "sha1"
+            }
+
+            it("re-anchors to the first commit when the selection is not loaded") {
+                MapState.reset()
+                MapState.commits.addAll(dummyCommits(3))
+                MapState.selectNode("sha-missing")
+
+                MapState.selectAdjacentNode(1, 0)
+
+                MapState.selectedNodeSha.value shouldBe "sha1"
+            }
+
+            it("moves right to the nearest commit in the next lane") {
+                loadTwoLaneGrid()
+                MapState.selectNode("sha1")
+
+                MapState.selectAdjacentNode(0, 1)
+
+                MapState.selectedNodeSha.value shouldBe "sha2"
+            }
+
+            it("moves left to the nearest commit in the previous lane") {
+                loadTwoLaneGrid()
+                MapState.selectNode("sha2")
+
+                MapState.selectAdjacentNode(0, -1)
+
+                MapState.selectedNodeSha.value shouldBe "sha1"
+            }
+
+            it("prefers the earlier row when two lane neighbours are equidistant") {
+                // sha3 sits at row 2 in lane 0; lane 1's sha2 (row 1) and sha4 (row 3)
+                // are both one row away, so the upward neighbour wins the tie.
+                loadTwoLaneGrid()
+                MapState.selectNode("sha3")
+
+                MapState.selectAdjacentNode(0, 1)
+
+                MapState.selectedNodeSha.value shouldBe "sha2"
+            }
+
+            it("does nothing when the target lane holds no loaded commit") {
+                loadTwoLaneGrid()
+                MapState.selectNode("sha4")
+
+                MapState.selectAdjacentNode(0, 1)
+
+                MapState.selectedNodeSha.value shouldBe "sha4"
+            }
+        }
+
         describe("resetForDirectory") {
 
             it("clears the loaded map when the directory changes") {


### PR DESCRIPTION
## Summary

Adds keyboard traversal of the map's commit grid (issue #295): the arrow
keys now move the map selection across the grid.

- **Up / Down** walk the ordered commit rows (clamped to the loaded
  window), following commit order regardless of lane.
- **Left / Right** step to the adjacent lane, selecting the commit in that
  lane nearest the current row (preferring the earlier row on a tie), and
  do nothing when that lane holds no loaded commit — lanes are sparse.
- With nothing selected, the first arrow anchors to the first loaded
  commit.

Implemented as `MapState.selectAdjacentNode(rowOffset, laneOffset)` (the
testable core), wired to Up/Down/Left/Right on the Map tab in
`GitDown.kt`, plus a `LaunchedEffect` in `MapView.kt` that scrolls the
selected node back into view when traversal moves it off the fold.

## Tests

Added `MapStateSpec` cases covering vertical steps, boundary clamping,
the no-selection / not-loaded anchor behaviour, left/right lane steps,
the equidistant tie-break, and the empty-target-lane no-op.

## Note to reviewer

The nix devShell toolchain could not be provisioned in the agent
environment (read-only nix store, offline, no JDK/gradle/kotlin present),
so the gradle suite was not run locally — CI validates the build and
tests.

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)