### PR TITLE
feat: commit view tab cycling

### DIFF
--- a/src/main/kotlin/com/codymikol/components/commit/ChangedFile.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/ChangedFile.kt
@@ -13,7 +13,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.codymikol.components.ReversedEllipsisText
 import com.codymikol.data.file.FileDelta
+import com.codymikol.data.file.Status
 import com.codymikol.data.file.WorkingDirectory
+import com.codymikol.state.CommitFocus
 import com.codymikol.state.GitDownState
 import com.codymikol.state.Keys
 import java.nio.file.Path
@@ -32,6 +34,12 @@ fun ChangedFile(fileDelta: FileDelta) {
         .clickable {
             if (!Keys.isShiftPressed.value) GitDownState.selectedFiles.clear()
             GitDownState.selectedFiles.add(fileDelta)
+            // Keep Tab cycling (#298) anchored to the pane the user clicked into.
+            when (fileDelta.type) {
+                Status.WORKING_DIRECTORY -> GitDownState.commitFocus.value = CommitFocus.WorkingDirectory
+                Status.INDEX -> GitDownState.commitFocus.value = CommitFocus.Index
+                Status.STASH -> Unit
+            }
         }
         .fillMaxWidth()
         .height(18.dp)

--- a/src/main/kotlin/com/codymikol/state/state.kt
+++ b/src/main/kotlin/com/codymikol/state/state.kt
@@ -21,6 +21,13 @@ import java.io.File
 import java.nio.file.Path
 
 
+/**
+ * The three areas the commit view cycles focus through with Tab / Shift+Tab
+ * (see issue #298), in forward order: the Working Directory file list, the
+ * Index file list, then the commit message input.
+ */
+enum class CommitFocus { WorkingDirectory, Index, Message }
+
 object GitDownState {
 
     val currentTab: MutableState<Tab> = mutableStateOf(Tab.Commit)
@@ -291,6 +298,54 @@ object GitDownState {
         val nextIndex = (currentIndex + offset).coerceIn(paths.indices)
 
         quickViewSelectedFilePath.value = paths[nextIndex]
+    }
+
+    /**
+     * Which of the commit view's three areas currently holds focus for Tab
+     * cycling (see issue #298).
+     */
+    val commitFocus: MutableState<CommitFocus> = mutableStateOf(CommitFocus.WorkingDirectory)
+
+    private fun isCommitPaneAvailable(pane: CommitFocus) = when (pane) {
+        CommitFocus.WorkingDirectory -> !workingDirectoryIsEmpty.value
+        CommitFocus.Index -> !indexIsEmpty.value
+        CommitFocus.Message -> true
+    }
+
+    /**
+     * Moves focus to [pane], selecting its first file when the pane is a file
+     * list so cycling into it lands on a concrete selection (see issue #298).
+     */
+    private fun focusCommitPane(pane: CommitFocus) {
+        commitFocus.value = pane
+        when (pane) {
+            CommitFocus.WorkingDirectory -> workingDirectory.value.firstOrNull()
+            CommitFocus.Index -> index.value.firstOrNull()
+            CommitFocus.Message -> null
+        }?.let {
+            selectedFiles.clear()
+            selectedFiles.add(it)
+        }
+    }
+
+    /**
+     * Cycles commit view focus through Working Directory -> Index -> Message
+     * (or the reverse when [forward] is false), wrapping at the ends and
+     * skipping empty file panes since there is nothing to select in them
+     * (see issue #298). The message pane is always available.
+     */
+    fun cycleCommitFocus(forward: Boolean) {
+        val order = listOf(CommitFocus.WorkingDirectory, CommitFocus.Index, CommitFocus.Message)
+        val step = if (forward) 1 else -1
+        var idx = order.indexOf(commitFocus.value).coerceAtLeast(0)
+        repeat(order.size) {
+            idx = ((idx + step) % order.size + order.size) % order.size
+            val candidate = order[idx]
+            if (isCommitPaneAvailable(candidate)) {
+                focusCommitPane(candidate)
+                return
+            }
+        }
     }
 
     fun selectAdjacentFile(offset: Int) {

--- a/src/main/kotlin/com/codymikol/views/CommitView.kt
+++ b/src/main/kotlin/com/codymikol/views/CommitView.kt
@@ -13,7 +13,10 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.*
 import androidx.compose.ui.graphics.drawscope.DrawScope
@@ -40,6 +43,7 @@ import com.codymikol.data.diff.*
 import com.codymikol.data.file.FileDelta
 import com.codymikol.data.file.Status
 import com.codymikol.extensions.*
+import com.codymikol.state.CommitFocus
 import com.codymikol.state.GitDownState
 import com.codymikol.state.Keys
 import com.codymikol.typography.GitDownTypography
@@ -120,11 +124,28 @@ fun DrawScope.drawCommitGuideline(xOffset: Float, lineHeight: Float, spaceHeight
 
 @Composable
 private fun CommitMessageInput() {
-    var textFieldValue by remember { mutableStateOf(TextFieldValue(commitMessage.value)) }
+    val focusRequester = remember { FocusRequester() }
+    val focusManager = LocalFocusManager.current
+
+    // Start the caret at the end so cycling into an unfocused message pane lands
+    // at the end of the text (#298); once focused the field tracks its own caret.
+    var textFieldValue by remember {
+        mutableStateOf(TextFieldValue(commitMessage.value, TextRange(commitMessage.value.length)))
+    }
 
     // commitMessage can be mutated externally (amend, post-commit clear); resync when it drifts.
     if (textFieldValue.text != commitMessage.value) {
         textFieldValue = TextFieldValue(commitMessage.value, TextRange(commitMessage.value.length))
+    }
+
+    // Tab cycling (#298) drives focus through commitFocus: grab focus when the
+    // message pane becomes active, release it when a file pane takes over.
+    LaunchedEffect(GitDownState.commitFocus.value) {
+        if (GitDownState.commitFocus.value == CommitFocus.Message) {
+            focusRequester.requestFocus()
+        } else if (isCommitMessageFocused.value) {
+            focusManager.clearFocus()
+        }
     }
 
     BasicTextField(
@@ -134,6 +155,7 @@ private fun CommitMessageInput() {
             .fillMaxSize()
             .padding(top = 8.dp, start = 8.dp, bottom = 0.dp, end = 8.dp)
             .background(Colors.DarkGrayBackground)
+            .focusRequester(focusRequester)
             .onFocusChanged { isCommitMessageFocused.value = it.isFocused }
             .onPreviewKeyEvent { event ->
                 val isShiftEnter = event.type == KeyEventType.KeyDown &&

--- a/src/main/kotlin/com/codymikol/windows/GitDown.kt
+++ b/src/main/kotlin/com/codymikol/windows/GitDown.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isAltPressed
 import androidx.compose.ui.input.key.isCtrlPressed
 import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
@@ -68,6 +69,23 @@ fun GitDown(applicationScope: ApplicationScope) {
     val scope = rememberCoroutineScope()
 
     Window(
+        // Tab / Shift+Tab cycles focus through the commit view's three areas
+        // (#298). Handled in the preview phase so it fires even while the commit
+        // message text field holds focus, where it would otherwise be consumed
+        // for default focus traversal.
+        onPreviewKeyEvent = {
+            val isCommitTabCycle = it.type == KeyEventType.KeyDown &&
+                it.key == Key.Tab &&
+                !it.isCtrlPressed && !it.isAltPressed &&
+                GitDownState.currentTab.value == Tab.Commit
+
+            if (isCommitTabCycle) {
+                GitDownState.cycleCommitFocus(forward = !it.isShiftPressed)
+                true
+            } else {
+                false
+            }
+        },
         onKeyEvent = {
             Keys.isShiftPressed.value = it.isShiftPressed
             Keys.isCtrlPressed.value = it.isCtrlPressed

--- a/src/test/kotlin/com/codymikol/state/GitDownStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/GitDownStateSpec.kt
@@ -709,6 +709,145 @@ class GitDownStateSpec : DescribeSpec({
 
         }
 
+        describe("cycleCommitFocus") {
+
+            describe("when both the working directory and index have files") {
+
+                autoClose(
+                    createTestRepository()
+                        .addFile("staged.txt", "S")
+                        .stageAll()
+                        .addFile("unstaged.txt", "U")
+                        .transferIntoGitDownState()
+                )
+
+                val workingFile = GitDownState.workingDirectory.value.first()
+                val indexFile = GitDownState.index.value.first()
+
+                it("should cycle forward WorkingDirectory -> Index -> Message -> WorkingDirectory") {
+                    GitDownState.commitFocus.value = CommitFocus.WorkingDirectory
+
+                    GitDownState.cycleCommitFocus(forward = true)
+                    GitDownState.commitFocus.value shouldBe CommitFocus.Index
+
+                    GitDownState.cycleCommitFocus(forward = true)
+                    GitDownState.commitFocus.value shouldBe CommitFocus.Message
+
+                    GitDownState.cycleCommitFocus(forward = true)
+                    GitDownState.commitFocus.value shouldBe CommitFocus.WorkingDirectory
+                }
+
+                it("should cycle backward Message -> Index -> WorkingDirectory -> Message") {
+                    GitDownState.commitFocus.value = CommitFocus.Message
+
+                    GitDownState.cycleCommitFocus(forward = false)
+                    GitDownState.commitFocus.value shouldBe CommitFocus.Index
+
+                    GitDownState.cycleCommitFocus(forward = false)
+                    GitDownState.commitFocus.value shouldBe CommitFocus.WorkingDirectory
+
+                    GitDownState.cycleCommitFocus(forward = false)
+                    GitDownState.commitFocus.value shouldBe CommitFocus.Message
+                }
+
+                it("should select the first working directory file when focusing that pane") {
+                    GitDownState.commitFocus.value = CommitFocus.Message
+                    GitDownState.selectedFiles.clear()
+
+                    GitDownState.cycleCommitFocus(forward = false)
+                    GitDownState.cycleCommitFocus(forward = false)
+
+                    GitDownState.commitFocus.value shouldBe CommitFocus.WorkingDirectory
+                    GitDownState.selectedFiles.toList() shouldBe listOf(workingFile)
+                }
+
+                it("should select the first index file when focusing that pane") {
+                    GitDownState.commitFocus.value = CommitFocus.WorkingDirectory
+                    GitDownState.selectedFiles.clear()
+
+                    GitDownState.cycleCommitFocus(forward = true)
+
+                    GitDownState.commitFocus.value shouldBe CommitFocus.Index
+                    GitDownState.selectedFiles.toList() shouldBe listOf(indexFile)
+                }
+
+            }
+
+            describe("when the working directory is empty") {
+
+                autoClose(
+                    createTestRepository()
+                        .addFile("staged.txt", "S")
+                        .stageAll()
+                        .transferIntoGitDownState()
+                )
+
+                it("should skip the empty working directory pane going forward") {
+                    GitDownState.commitFocus.value = CommitFocus.Index
+
+                    GitDownState.cycleCommitFocus(forward = true)
+                    GitDownState.commitFocus.value shouldBe CommitFocus.Message
+
+                    GitDownState.cycleCommitFocus(forward = true)
+                    GitDownState.commitFocus.value shouldBe CommitFocus.Index
+                }
+
+                it("should skip the empty working directory pane going backward") {
+                    GitDownState.commitFocus.value = CommitFocus.Index
+
+                    GitDownState.cycleCommitFocus(forward = false)
+                    GitDownState.commitFocus.value shouldBe CommitFocus.Message
+
+                    GitDownState.cycleCommitFocus(forward = false)
+                    GitDownState.commitFocus.value shouldBe CommitFocus.Index
+                }
+
+            }
+
+            describe("when the index is empty") {
+
+                autoClose(
+                    createTestRepository()
+                        .addFile("unstaged.txt", "U")
+                        .transferIntoGitDownState()
+                )
+
+                it("should skip the empty index pane going forward") {
+                    GitDownState.commitFocus.value = CommitFocus.WorkingDirectory
+
+                    GitDownState.cycleCommitFocus(forward = true)
+                    GitDownState.commitFocus.value shouldBe CommitFocus.Message
+
+                    GitDownState.cycleCommitFocus(forward = true)
+                    GitDownState.commitFocus.value shouldBe CommitFocus.WorkingDirectory
+                }
+
+            }
+
+            describe("when both file panes are empty") {
+
+                autoClose(
+                    createTestRepository()
+                        .addFile("foo.txt", "one\n")
+                        .stageAll()
+                        .commitAll("init")
+                        .transferIntoGitDownState()
+                )
+
+                it("should stay on the Message pane") {
+                    GitDownState.commitFocus.value = CommitFocus.Message
+
+                    GitDownState.cycleCommitFocus(forward = true)
+                    GitDownState.commitFocus.value shouldBe CommitFocus.Message
+
+                    GitDownState.cycleCommitFocus(forward = false)
+                    GitDownState.commitFocus.value shouldBe CommitFocus.Message
+                }
+
+            }
+
+        }
+
         describe("selectTab") {
 
             describe("when switching to the Stash tab and stashes exist") {


### PR DESCRIPTION
Implements Tab / Shift+Tab focus cycling on the commit view (#298).

## Behavior
- **Tab** cycles focus forward: Working Directory → Index → Commit Message → Working Directory.
- **Shift+Tab** cycles in reverse: Commit Message → Index → Working Directory → Commit Message.
- Cycling wraps at both ends.
- Landing on a file pane selects its first file; landing on the message pane focuses the input with the caret at its last position (or the end of the text when never focused).
- Empty file panes are skipped (nothing to select there); the message pane is always available.

## Changes
- `GitDownState.cycleCommitFocus` + `CommitFocus` enum hold the cycling logic (unit tested in `GitDownStateSpec`).
- The window intercepts Tab in the preview key phase on the Commit tab so it works even while the message field holds keyboard focus; Ctrl/Alt+Tab are left alone.
- `CommitMessageInput` grabs/releases focus in response to `commitFocus`.
- Clicking a file anchors `commitFocus` to that pane so the next Tab continues from where the user is.

## Notes for reviewers
- Skipping empty file panes goes slightly beyond the literal `A→B→C` spec, since "select the first one" is a no-op with no files; documented in the code.

## Testing
The nix store is read-only in the CI sandbox used here; tests were run against the flake's pinned Temurin 21 via a writable overlay. All Kotest specs pass.

Closes #298