### PR TITLE
feat: stash view key shortcuts

### DIFF
--- a/src/main/kotlin/com/codymikol/components/stash/StashBottomToolbar.kt
+++ b/src/main/kotlin/com/codymikol/components/stash/StashBottomToolbar.kt
@@ -9,8 +9,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -36,9 +34,13 @@ fun applyStashConfirmationMessage(description: String): String =
 @Preview
 fun StashBottomToolbar() {
     val scope = rememberCoroutineScope()
-    var isSavingStash by remember { mutableStateOf(false) }
-    var isConfirmingDrop by remember { mutableStateOf(false) }
-    var isConfirmingApply by remember { mutableStateOf(false) }
+
+    // All three dialog flags live in GitDownState so the key shortcuts (see issue #296)
+    // can open the same apply dialog as the "Apply" button and stand down while any of
+    // these dialogs is open.
+    var isSavingStash by GitDownState.isSavingStash
+    var isConfirmingDrop by GitDownState.isConfirmingDropStash
+    var isConfirmingApply by GitDownState.isConfirmingApplyStash
 
     val selectedStash = GitDownState.selectedStash.value
 

--- a/src/main/kotlin/com/codymikol/state/state.kt
+++ b/src/main/kotlin/com/codymikol/state/state.kt
@@ -90,6 +90,21 @@ object GitDownState {
 
     val selectedStash = mutableStateOf<StashListItem?>(null)
 
+    // Visibility of the stash view's three modal dialogs. Held here rather than as
+    // local StashBottomToolbar state so the Enter shortcut can open the same apply
+    // dialog the toolbar's "Apply" button opens (see issue #296), and so the key
+    // handler can tell when a dialog is open and stand its shortcuts down.
+    val isSavingStash = mutableStateOf(false)
+    val isConfirmingDropStash = mutableStateOf(false)
+    val isConfirmingApplyStash = mutableStateOf(false)
+
+    // True while any stash dialog is open. The stash view key shortcuts (see issue
+    // #296) suppress themselves while it is true so a keystroke can't mutate or drop
+    // the selected stash from under an open dialog.
+    val isStashDialogOpen = derivedStateOf {
+        isSavingStash.value || isConfirmingDropStash.value || isConfirmingApplyStash.value
+    }
+
     // The commit the quick view (see issue #254) is launched against, or null when
     // the quick view is closed. Held here rather than read from MapState so the view
     // survives the map scrolling or resetting out from under it.
@@ -228,7 +243,18 @@ object GitDownState {
      */
     fun returnToProjectSelection() {
         MapState.reset()
+        // These flags now outlive the StashBottomToolbar composable (they moved to this
+        // singleton for issue #296), so a project switch has to abandon any open stash
+        // dialog itself or a stale one would reappear on the next repo (see issue #296).
+        closeStashDialogs()
         gitDirectory.value = ""
+    }
+
+    // Hides all three stash view dialogs (see issue #296).
+    private fun closeStashDialogs() {
+        isSavingStash.value = false
+        isConfirmingDropStash.value = false
+        isConfirmingApplyStash.value = false
     }
 
     fun selectTab(tab: Tab) {
@@ -236,6 +262,10 @@ object GitDownState {
 
         if (tab == Tab.Stash) {
             selectedStash.value = stashes.value.firstOrNull()
+        } else {
+            // Leaving the stash view abandons any open stash dialog (see issue #296) so
+            // one doesn't silently reappear the next time the stash view is shown.
+            closeStashDialogs()
         }
 
         if (tab == Tab.Commit && selectedFiles.isEmpty()) {
@@ -372,6 +402,31 @@ object GitDownState {
                 return
             }
         }
+    }
+
+    /**
+     * Moves the stash selection by [offset] (see issue #296), clamped to the stash
+     * list. With nothing selected (or a stale selection no longer in the list) both
+     * Up and Down land on the first stash. No-op when there are no stashes.
+     */
+    fun selectAdjacentStash(offset: Int) {
+        val stashList = stashes.value
+        if (stashList.isEmpty()) return
+
+        // indexOf returns -1 when nothing is selected: Down (+1) then lands on the
+        // first stash, and Up (-1) clamps up to it too - so either arrow enters the list.
+        val currentIndex = stashList.indexOf(selectedStash.value)
+        val nextIndex = (currentIndex + offset).coerceIn(stashList.indices)
+
+        selectedStash.value = stashList[nextIndex]
+    }
+
+    /**
+     * Opens the apply-stash confirmation prompt (Enter on the stash view, see issue
+     * #296) when a stash is selected; otherwise does nothing.
+     */
+    fun promptApplyStash() {
+        if (selectedStash.value != null) isConfirmingApplyStash.value = true
     }
 
     fun selectAdjacentFile(offset: Int) {

--- a/src/main/kotlin/com/codymikol/windows/GitDown.kt
+++ b/src/main/kotlin/com/codymikol/windows/GitDown.kt
@@ -42,6 +42,7 @@ import com.codymikol.gitdown.generated.resources.map
 import com.codymikol.gitdown.generated.resources.map_white
 import com.codymikol.gitdown.generated.resources.stash
 import com.codymikol.gitdown.generated.resources.stash_white
+import com.codymikol.services.StashService
 import com.codymikol.services.WindowSizeService
 import com.codymikol.state.GitDownState
 import com.codymikol.state.Keys
@@ -59,6 +60,7 @@ import org.koin.java.KoinJavaComponent.inject
 import java.awt.Dimension
 
 private val windowSizeService: WindowSizeService by inject(WindowSizeService::class.java)
+private val stashService: StashService by inject(StashService::class.java)
 
 @Preview
 @Composable
@@ -132,6 +134,23 @@ fun GitDown(applicationScope: ApplicationScope) {
                 (it.key == Key.DirectionUp || it.key == Key.DirectionDown ||
                     it.key == Key.DirectionLeft || it.key == Key.DirectionRight)
 
+            // Stash shortcuts (#296) stand down while any stash dialog is open, so a
+            // keystroke can't mutate the selection or silently drop a stash from under
+            // an open save/apply/drop dialog.
+            val isStashTab = tab == Tab.Stash && !GitDownState.isStashDialogOpen.value
+
+            // Up/Down selects the previous/next stash on the stash view (#296).
+            val isStashArrow = isDown && isStashTab &&
+                (it.key == Key.DirectionUp || it.key == Key.DirectionDown)
+
+            // Delete drops the selected stash on the stash view (#296).
+            val stashDeleteTarget = if (isDown && it.key == Key.Delete && isStashTab)
+                GitDownState.selectedStash.value else null
+
+            // Enter prompts to confirm applying the selected stash (#296).
+            val shouldPromptApplyStash = isDown && isStashTab &&
+                it.key == Key.Enter && GitDownState.selectedStash.value != null
+
             when {
                 isMapDebugToggle -> {
                     MapDebugState.toggle()
@@ -152,6 +171,18 @@ fun GitDown(applicationScope: ApplicationScope) {
                         Key.DirectionLeft -> MapState.selectAdjacentNode(0, -1)
                         Key.DirectionRight -> MapState.selectAdjacentNode(0, 1)
                     }
+                    true
+                }
+                isStashArrow -> {
+                    GitDownState.selectAdjacentStash(if (it.key == Key.DirectionUp) -1 else 1)
+                    true
+                }
+                stashDeleteTarget != null -> {
+                    scope.launch { stashService.dropStash(stashDeleteTarget) }
+                    true
+                }
+                shouldPromptApplyStash -> {
+                    GitDownState.promptApplyStash()
                     true
                 }
                 shouldCloseQuickView -> {

--- a/src/test/kotlin/com/codymikol/state/GitDownStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/GitDownStateSpec.kt
@@ -848,6 +848,143 @@ class GitDownStateSpec : DescribeSpec({
 
         }
 
+        describe("selectAdjacentStash") {
+
+            describe("when there are multiple stashes") {
+
+                autoClose(
+                    createTestRepository()
+                        .addFile("foo.txt", "one\n")
+                        .stageAll()
+                        .commitAll("init")
+                        .appendToFile("foo.txt", "two\n")
+                        .stashCreate("first")
+                        .appendToFile("foo.txt", "three\n")
+                        .stashCreate("second")
+                        .appendToFile("foo.txt", "four\n")
+                        .stashCreate("third")
+                        .transferIntoGitDownState()
+                )
+
+                val stashes = GitDownState.stashes.value
+
+                it("should select the next stash when moving down") {
+                    GitDownState.selectedStash.value = stashes[0]
+
+                    GitDownState.selectAdjacentStash(1)
+
+                    GitDownState.selectedStash.value shouldBe stashes[1]
+                }
+
+                it("should select the previous stash when moving up") {
+                    GitDownState.selectedStash.value = stashes[1]
+
+                    GitDownState.selectAdjacentStash(-1)
+
+                    GitDownState.selectedStash.value shouldBe stashes[0]
+                }
+
+                it("should stay on the first stash when moving up from the top") {
+                    GitDownState.selectedStash.value = stashes[0]
+
+                    GitDownState.selectAdjacentStash(-1)
+
+                    GitDownState.selectedStash.value shouldBe stashes[0]
+                }
+
+                it("should stay on the last stash when moving down from the bottom") {
+                    GitDownState.selectedStash.value = stashes.last()
+
+                    GitDownState.selectAdjacentStash(1)
+
+                    GitDownState.selectedStash.value shouldBe stashes.last()
+                }
+
+                it("should select the first stash when moving down from no selection") {
+                    GitDownState.selectedStash.value = null
+
+                    GitDownState.selectAdjacentStash(1)
+
+                    GitDownState.selectedStash.value shouldBe stashes[0]
+                }
+
+                it("should select the first stash when moving up from no selection") {
+                    GitDownState.selectedStash.value = null
+
+                    GitDownState.selectAdjacentStash(-1)
+
+                    GitDownState.selectedStash.value shouldBe stashes[0]
+                }
+
+            }
+
+            describe("when there are no stashes") {
+
+                autoClose(
+                    createTestRepository()
+                        .addFile("foo.txt", "Foo")
+                        .transferIntoGitDownState()
+                )
+
+                it("should leave no stash selected") {
+                    GitDownState.selectedStash.value = null
+
+                    GitDownState.selectAdjacentStash(1)
+
+                    GitDownState.selectedStash.value shouldBe null
+                }
+
+            }
+
+        }
+
+        describe("promptApplyStash") {
+
+            describe("when a stash is selected") {
+
+                autoClose(
+                    createTestRepository()
+                        .addFile("foo.txt", "one\n")
+                        .stageAll()
+                        .commitAll("init")
+                        .appendToFile("foo.txt", "two\n")
+                        .stashCreate("my stash")
+                        .transferIntoGitDownState()
+                )
+
+                it("should mark the apply confirmation visible") {
+                    GitDownState.selectedStash.value = GitDownState.stashes.value.first()
+                    GitDownState.isConfirmingApplyStash.value = false
+
+                    GitDownState.promptApplyStash()
+
+                    GitDownState.isConfirmingApplyStash.value shouldBe true
+                    GitDownState.isStashDialogOpen.value shouldBe true
+                }
+
+            }
+
+            describe("when no stash is selected") {
+
+                autoClose(
+                    createTestRepository()
+                        .addFile("foo.txt", "Foo")
+                        .transferIntoGitDownState()
+                )
+
+                it("should leave the apply confirmation hidden") {
+                    GitDownState.selectedStash.value = null
+                    GitDownState.isConfirmingApplyStash.value = false
+
+                    GitDownState.promptApplyStash()
+
+                    GitDownState.isConfirmingApplyStash.value shouldBe false
+                }
+
+            }
+
+        }
+
         describe("selectTab") {
 
             describe("when switching to the Stash tab and stashes exist") {
@@ -906,6 +1043,16 @@ class GitDownStateSpec : DescribeSpec({
 
                     GitDownState.currentTab.value shouldBe Tab.Commit
                     GitDownState.selectedStash.value shouldBe null
+                }
+
+                it("should abandon any open stash dialog") {
+                    GitDownState.isSavingStash.value = true
+                    GitDownState.isConfirmingDropStash.value = true
+                    GitDownState.isConfirmingApplyStash.value = true
+
+                    GitDownState.selectTab(Tab.Commit)
+
+                    GitDownState.isStashDialogOpen.value shouldBe false
                 }
 
             }
@@ -1046,6 +1193,16 @@ class GitDownStateSpec : DescribeSpec({
 
                     MapState.commits.isEmpty() shouldBe true
                     MapState.selectedNodeSha.value shouldBe null
+                }
+
+                it("should abandon any open stash dialog (#296)") {
+                    GitDownState.isSavingStash.value = true
+                    GitDownState.isConfirmingDropStash.value = true
+                    GitDownState.isConfirmingApplyStash.value = true
+
+                    GitDownState.returnToProjectSelection()
+
+                    GitDownState.isStashDialogOpen.value shouldBe false
                 }
 
             }


### PR DESCRIPTION
Implements keyboard shortcuts on the Stash view (issue #296).

## Shortcuts (Stash tab)
- **Up / Down** — select the previous / next stash for viewing
- **Delete** — drop the selected stash
- **Enter** — prompt to confirm applying the selected stash

## How
- `GitDownState.selectAdjacentStash(offset)` moves the selection clamped to
  the stash list; with no (or a stale) selection either arrow lands on the
  first stash. `promptApplyStash()` opens the apply confirmation when a stash
  is selected.
- The three stash-dialog visibility flags (`isSavingStash`,
  `isConfirmingDropStash`, `isConfirmingApplyStash`) are lifted into
  `GitDownState` so the Enter shortcut opens the same dialog as the toolbar
  "Apply" button, and so the window key handler can suppress every stash
  shortcut while any dialog is open (`isStashDialogOpen`). Without this a
  keystroke could mutate the selection — or silently drop a stash — from under
  an open dialog. A shared `closeStashDialogs()` helper clears the flags both
  when `selectTab` leaves the Stash tab and when `returnToProjectSelection`
  switches projects (the flags now outlive the toolbar composable, so a stale
  dialog would otherwise reappear on the next repo).
- Shortcuts are wired in `GitDown.kt`'s window `onKeyEvent`, mirroring the
  existing map / quick-view shortcut branches.

## Tests
State-level behavior is unit-tested in `GitDownStateSpec`
(`selectAdjacentStash` boundary/empty/no-selection cases, `promptApplyStash`,
and the tab-leave / project-return dialog resets). The window `onKeyEvent`
handler itself is not unit-tested, consistent with the repo's existing
shortcut wiring (map / quick-view branches are equally untested).

## For reviewer decision
- Per the issue's literal wording ("Delete: Delete the selected stash" vs
  "Enter: Prompt to confirm application"), **Delete drops immediately without
  a confirmation**, whereas the toolbar "-" button routes through a
  ConfirmDialog. Intentional, but a single-keystroke destructive action —
  flagging in case a confirmation is preferred.
- After a keyboard Delete the view lands on no selection (no adjacent stash is
  reselected), matching the existing toolbar "-" button behavior. Left as-is
  for consistency.

## Note
Local gradle/JDK was unavailable in the build environment (read-only nix
store, no daemon), so the suite was validated by inspection and relies on CI.

Closes #296