### PR TITLE
fix(map): stop tab buttons from trapping map shortcuts

### DIFF
--- a/src/main/kotlin/com/codymikol/components/TabButton.kt
+++ b/src/main/kotlin/com/codymikol/components/TabButton.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.*
+import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.unit.dp
 import com.codymikol.data.Colors
 import com.codymikol.gitdown.generated.resources.Res
@@ -71,6 +72,7 @@ private fun getTabButtonShape(location: TabButtonLocation): AbsoluteRoundedCorne
         )
     }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun tabButton(
     location: TabButtonLocation,
@@ -83,7 +85,11 @@ fun tabButton(
         modifier = Modifier
             .width(38.dp)
             .height(28.dp)
-            .clickable { GitDownState.selectTab(tab) }
+            // A mouse-only primary click (not .clickable) so the tab button never takes
+            // keyboard focus: a focused .clickable swallows keys like Space and fires the
+            // button instead of letting the window-level map shortcut open the quick view
+            // (see issue #306, same trap fixed for the commit node in #290/#254).
+            .onClick(matcher = PointerMatcher.mouse(PointerButton.Primary)) { GitDownState.selectTab(tab) }
             .clip(getTabButtonShape(location))
     ) {
         Box(


### PR DESCRIPTION
## Summary

On the Map view, the tab buttons (open map / commit / stash view) used
`.clickable`, which grants keyboard focus on click and consumes keys such
as Space before the window-level shortcut handler runs. A focused tab
button therefore turned Space into a button click instead of opening the
quick view for the selected node.

This swaps the tab button's primary click to a mouse-only
`PointerMatcher.mouse(PointerButton.Primary)` `onClick`, so the button
never takes keyboard focus and Space falls through to the map shortcut.
All three tab buttons render through the single `tabButton` composable, so
one change covers them all.

Mirrors the same fix already applied to the commit node in #290/#254
(commit `2df47e4`) — the established codebase idiom for a clickable-but-
non-focusable control.

## Testing

No unit test added: this is a Compose modifier-only change with no pure
logic seam, and the repo has no Compose UI test harness (kotest, pure
logic only). This matches precedent `2df47e4`, which shipped the identical
modifier swap for the commit node without a UI test. Verified against CI
(`./gradlew build`).

## Notes for reviewer

- Local build/test could not be run in the agent container (no JDK/gradle
  on PATH; `nix develop` is blocked by a read-only Nix store). Relying on
  CI to gate compilation.
- Out of scope: `ExitButton`/`SocialButton` on the DirectorySelector splash
  screen keep `.clickable`; they are not on the Map view and don't trap the
  reported Space shortcut.

Closes #306