### PR TITLE
fix(quick-view): keep last-file selection at end of diff

### DIFF
--- a/src/main/kotlin/com/codymikol/components/commit/diff/DiffFileIndex.kt
+++ b/src/main/kotlin/com/codymikol/components/commit/diff/DiffFileIndex.kt
@@ -26,3 +26,28 @@ fun fileHeaderItemIndices(fileDeltaNodes: List<FileDeltaNode>): List<Int> {
  */
 fun stickyFileIndex(firstVisibleItemIndex: Int, fileHeaderIndices: List<Int>): Int =
     fileHeaderIndices.indexOfLast { it <= firstVisibleItemIndex }
+
+/**
+ * The file selection a scroll position should produce in the quick view (see issue
+ * #278), given the file the user currently has selected ([selectedIndex], or a value
+ * outside the file range when nothing is selected) and whether the diff is scrolled to
+ * its very end ([atEnd]).
+ *
+ * Normally this follows the sticky top header. But the last files in a diff can be too
+ * short for their headers to ever reach the top, so once the list is at its end a scroll
+ * reports an earlier file as sticky. Snapping the selection back to that sticky file would
+ * fight a selection the user just placed on one of those trailing files (see issue #308),
+ * so at the end we keep any selection sitting on or below the sticky file instead.
+ * [fileHeaderIndices] is the output of [fileHeaderItemIndices].
+ */
+fun fileSelectionForScroll(
+    firstVisibleItemIndex: Int,
+    fileHeaderIndices: List<Int>,
+    selectedIndex: Int,
+    atEnd: Boolean,
+): Int {
+    val stickyIndex = stickyFileIndex(firstVisibleItemIndex, fileHeaderIndices)
+    if (stickyIndex < 0) return selectedIndex
+    if (atEnd && selectedIndex in (stickyIndex + 1)..fileHeaderIndices.lastIndex) return selectedIndex
+    return stickyIndex
+}

--- a/src/main/kotlin/com/codymikol/views/QuickView.kt
+++ b/src/main/kotlin/com/codymikol/views/QuickView.kt
@@ -43,6 +43,7 @@ import com.codymikol.components.commit.FileIcon
 import com.codymikol.components.commit.changedFileDisplayText
 import com.codymikol.components.commit.diff.Diff
 import com.codymikol.components.commit.diff.fileHeaderItemIndices
+import com.codymikol.components.commit.diff.fileSelectionForScroll
 import com.codymikol.components.commit.diff.stickyFileIndex
 import com.codymikol.data.Colors
 import com.codymikol.data.diff.FileDeltaNode
@@ -237,15 +238,19 @@ private fun QuickViewDiffPanel(diffListState: LazyListState) = when (GitDownStat
  */
 @Composable
 private fun QuickViewDiffSync(nodes: List<FileDeltaNode>, diffListState: LazyListState) {
-    // Scroll -> selection: the sticky top header is the highlighted file.
+    // Scroll -> selection: the sticky top header is the highlighted file, except that a
+    // selection the user placed on a trailing file too short to reach the top stands once
+    // the list is scrolled to its end (see issue #308) rather than snapping back up.
     LaunchedEffect(nodes, diffListState) {
         val headerIndices = fileHeaderItemIndices(nodes)
-        snapshotFlow { diffListState.firstVisibleItemIndex }.collect { firstVisible ->
-            val stickyIndex = stickyFileIndex(firstVisible, headerIndices)
-            if (stickyIndex < 0) return@collect
-            val path = nodes[stickyIndex].getPath()
-            if (GitDownState.quickViewSelectedFilePath.value != path) GitDownState.selectQuickViewFile(path)
-        }
+        snapshotFlow { diffListState.firstVisibleItemIndex to !diffListState.canScrollForward }
+            .collect { (firstVisible, atEnd) ->
+                val selectedPath = GitDownState.quickViewSelectedFilePath.value
+                val selectedIndex = nodes.indexOfFirst { it.getPath() == selectedPath }
+                val targetIndex = fileSelectionForScroll(firstVisible, headerIndices, selectedIndex, atEnd)
+                if (targetIndex < 0 || targetIndex == selectedIndex) return@collect
+                GitDownState.selectQuickViewFile(nodes[targetIndex].getPath())
+            }
     }
 
     // Selection -> scroll: only when the selected file is not already the sticky one, so

--- a/src/test/kotlin/com/codymikol/components/commit/diff/DiffFileIndexSpec.kt
+++ b/src/test/kotlin/com/codymikol/components/commit/diff/DiffFileIndexSpec.kt
@@ -61,4 +61,40 @@ class DiffFileIndexSpec : DescribeSpec({
             stickyFileIndex(20, headerIndices) shouldBe 2
         }
     }
+
+    describe("fileSelectionForScroll") {
+
+        val headerIndices = listOf(0, 5, 12)
+
+        it("follows the sticky file while the list can still scroll") {
+            fileSelectionForScroll(5, headerIndices, selectedIndex = 0, atEnd = false) shouldBe 1
+        }
+
+        it("overrides a below-sticky selection while the list can still scroll") {
+            fileSelectionForScroll(5, headerIndices, selectedIndex = 2, atEnd = false) shouldBe 1
+        }
+
+        it("keeps a selection the user placed on the last file at the end of the list") {
+            // The last file's header can't reach the top, so scroll reports the
+            // second-to-last file as sticky; the user's last-file selection stands
+            // (see issue #308).
+            fileSelectionForScroll(6, headerIndices, selectedIndex = 2, atEnd = true) shouldBe 2
+        }
+
+        it("keeps a selection on any file below the sticky one at the end") {
+            fileSelectionForScroll(0, headerIndices, selectedIndex = 1, atEnd = true) shouldBe 1
+        }
+
+        it("snaps to the sticky file when scrolled to the end past the selection") {
+            fileSelectionForScroll(12, headerIndices, selectedIndex = 0, atEnd = true) shouldBe 2
+        }
+
+        it("follows the sticky file when nothing is selected") {
+            fileSelectionForScroll(6, headerIndices, selectedIndex = -1, atEnd = true) shouldBe 1
+        }
+
+        it("keeps the current selection when there are no files") {
+            fileSelectionForScroll(0, emptyList(), selectedIndex = 3, atEnd = true) shouldBe 3
+        }
+    }
 })


### PR DESCRIPTION
## Summary

Fixes the quick view down-arrow shortcut selecting the wrong file on the
final node (issue #308).

When navigating to the last file, the diff scrolls to the bottom, but a
trailing file too short for its header to reach the top of the viewport
leaves the scroll->selection handler reporting the second-to-last file as
sticky — which then snapped the highlight back to that earlier file. You
navigated to the last file but the second-to-last showed as selected.

## Changes

- Add pure `fileSelectionForScroll` (DiffFileIndex.kt): once the diff is
  scrolled to its end, keep any selection the user placed on or below the
  sticky file rather than snapping back up to the sticky one.
- Route the quick view's scroll->selection `LaunchedEffect` through it,
  keying the `snapshotFlow` on both `firstVisibleItemIndex` and
  `!canScrollForward` (end-of-list). No selection<->scroll ping-pong: the
  selection->scroll effect is keyed only on the selected path.
- Tests for the new function's edge cases, including the #308 case.

## Notes for reviewers

- Local gradle/JDK was unavailable in the build environment (nix store not
  writable, no baked JDK), so tests were not run locally — CI (`./gradlew
  build`) validates. The changed logic is isolated in a pure, unit-tested
  function; the Compose wiring is thin.

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)