### PR TITLE
feat(map): pack lanes tight to the top with fork connectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /out
 harness.env
 logs/
+
+/result

--- a/src/main/kotlin/com/codymikol/data/map/MapConnector.kt
+++ b/src/main/kotlin/com/codymikol/data/map/MapConnector.kt
@@ -1,8 +1,14 @@
 package com.codymikol.data.map
 
+/**
+ * A parent/child edge to draw over the map's lanes. childRow/parentRow are the
+ * commits' packed rows within their lanes (see issue #305 / [com.codymikol.services.LanePacker]),
+ * not their global rows in the merged walk, so a connector reaches the node where
+ * it actually sits after each lane is packed tight to the top.
+ */
 data class MapConnector(
-    val childIndex: Int,
+    val childRow: Int,
     val childLane: Int,
-    val parentIndex: Int,
+    val parentRow: Int,
     val parentLane: Int,
 )

--- a/src/main/kotlin/com/codymikol/services/LanePacker.kt
+++ b/src/main/kotlin/com/codymikol/services/LanePacker.kt
@@ -1,0 +1,34 @@
+package com.codymikol.services
+
+import com.codymikol.data.map.CommitGraphNode
+
+/**
+ * Packs each lane's commits tight to the top of the map (see issue #305). Rather
+ * than positioning a node at its global row in the merged reverse-topological walk
+ * - which leaves gaps wherever a sibling lane's commit sits - every lane's own
+ * commits stack down consecutive rows from row 0, independent of the other lanes.
+ * Connectors (see [MapConnectors]) then bridge a child's packed row to its parent's,
+ * showing which node a commit forks off of.
+ *
+ * Returns the packed row of each commit keyed by sha, walking [commits] in list
+ * (newest-to-oldest) order and giving each the next free row within its assigned
+ * lane. A commit whose parent pagination hasn't reached - and so has no lane in
+ * [lanesBySha] yet - is skipped; it packs in on its own once loadMore() assigns it
+ * a lane, the same way [MapConnectors] defers an unloaded parent.
+ */
+object LanePacker {
+
+    fun pack(commits: List<CommitGraphNode>, lanesBySha: Map<String, Int>): Map<String, Int> {
+        val nextRowByLane = mutableMapOf<Int, Int>()
+        val rowBySha = mutableMapOf<String, Int>()
+
+        commits.forEach { commit ->
+            val lane = lanesBySha[commit.sha] ?: return@forEach
+            val row = nextRowByLane.getOrDefault(lane, 0)
+            rowBySha[commit.sha] = row
+            nextRowByLane[lane] = row + 1
+        }
+
+        return rowBySha
+    }
+}

--- a/src/main/kotlin/com/codymikol/services/MapConnectors.kt
+++ b/src/main/kotlin/com/codymikol/services/MapConnectors.kt
@@ -8,20 +8,27 @@ import com.codymikol.data.map.MapConnector
  * one connector per edge whose parent has already been loaded (and lane-assigned).
  * A parent that pagination hasn't reached yet is simply skipped - the connector
  * appears on its own once loadMore() reaches it, since compute() is re-run off the
- * same commits/lanesBySha it reads from.
+ * same commits/lanesBySha/rowsBySha it reads from.
+ *
+ * Endpoints are the commits' packed rows (see issue #305 / [LanePacker]), so each
+ * connector reaches the node where it sits after its lane is packed tight to the
+ * top - showing which node a commit forks off of when the parent lane runs longer.
  */
 object MapConnectors {
 
-    fun compute(commits: List<CommitGraphNode>, lanesBySha: Map<String, Int>): List<MapConnector> {
-        val indexBySha = commits.withIndex().associate { (index, commit) -> commit.sha to index }
-
-        return commits.flatMapIndexed { childIndex, commit ->
-            val childLane = lanesBySha[commit.sha] ?: return@flatMapIndexed emptyList()
+    fun compute(
+        commits: List<CommitGraphNode>,
+        lanesBySha: Map<String, Int>,
+        rowsBySha: Map<String, Int>,
+    ): List<MapConnector> {
+        return commits.flatMap { commit ->
+            val childLane = lanesBySha[commit.sha] ?: return@flatMap emptyList()
+            val childRow = rowsBySha[commit.sha] ?: return@flatMap emptyList()
 
             commit.parentShas.mapNotNull { parentSha ->
-                val parentIndex = indexBySha[parentSha] ?: return@mapNotNull null
+                val parentRow = rowsBySha[parentSha] ?: return@mapNotNull null
                 val parentLane = lanesBySha[parentSha] ?: return@mapNotNull null
-                MapConnector(childIndex, childLane, parentIndex, parentLane)
+                MapConnector(childRow, childLane, parentRow, parentLane)
             }
         }
     }

--- a/src/main/kotlin/com/codymikol/state/MapState.kt
+++ b/src/main/kotlin/com/codymikol/state/MapState.kt
@@ -8,6 +8,7 @@ import com.codymikol.data.map.CommitGraphNode
 import com.codymikol.data.map.CommitHistoryWalker
 import com.codymikol.extensions.listLocalBranches
 import com.codymikol.services.BranchTipOrderer
+import com.codymikol.services.LanePacker
 import com.codymikol.services.LaneAssigner
 import kotlin.math.abs
 
@@ -36,7 +37,25 @@ object MapState {
 
     val lanesBySha = mutableStateMapOf<String, Int>()
 
+    /**
+     * Each loaded commit's packed row within its lane (see issue #305): a lane's own
+     * commits stack down consecutive rows from the top rather than sitting at their
+     * global row in the merged walk, so every lane reads tight to the top of the map.
+     * Recomputed from lanesBySha by [LanePacker] each time a page loads.
+     */
+    val rowBySha = mutableStateMapOf<String, Int>()
+
     var hasMore = true
+
+    /**
+     * How many rows the packed map occupies (see issue #305): the length of the
+     * longest lane, since every lane packs tight to the top. This - not the raw
+     * loaded-commit count - is the map's vertical extent, so paging and scrolling
+     * measure against it. Falls back to the commit count before any lane has been
+     * packed (e.g. in tests that seed commits without rows).
+     */
+    val rowCount: Int
+        get() = rowBySha.values.maxOrNull()?.plus(1) ?: commits.size
 
     /**
      * Sha of the commit node whose detail card is currently shown, or null when no
@@ -161,17 +180,24 @@ object MapState {
 
         page.forEach { lanesBySha[it.sha] = laneAssigner.assign(it) }
         commits.addAll(page)
+
+        // Repack from the full loaded list so a page's commits stack onto the rows
+        // their lanes already reached, keeping each lane tight to the top (#305).
+        rowBySha.clear()
+        rowBySha.putAll(LanePacker.pack(commits, lanesBySha))
+
         hasMore = walker.hasMore
     }
 
     /**
      * lastVisibleIndex must be the last (bottom-most) visible row, not the first -
-     * the first visible index stays well short of commits.size whenever more than
+     * the first visible index stays well short of rowCount whenever more than
      * LOAD_MORE_THRESHOLD rows fit in the viewport, so it would never trigger paging.
+     * Both it and [rowCount] are in packed-row space (see issue #305).
      */
     fun shouldLoadMore(lastVisibleIndex: Int): Boolean {
         if (!hasMore) return false
-        return lastVisibleIndex >= commits.size - LOAD_MORE_THRESHOLD
+        return lastVisibleIndex >= rowCount - LOAD_MORE_THRESHOLD
     }
 
     fun reset() {
@@ -180,6 +206,7 @@ object MapState {
         laneAssigner = LaneAssigner()
         commits.clear()
         lanesBySha.clear()
+        rowBySha.clear()
         hasMore = true
         selectedNodeSha.value = null
         loadedDirectory = null

--- a/src/main/kotlin/com/codymikol/views/MapView.kt
+++ b/src/main/kotlin/com/codymikol/views/MapView.kt
@@ -97,16 +97,18 @@ private fun Map() {
     }
 
     // Keep the keyboard-driven selection (#295) on screen: when arrow keys move it out
-    // of the visible rows, scroll it into view (aligned to the top). Keyed on the
-    // selected sha alone - the effect only scrolls, never mutates the selection, so it
-    // can't relaunch itself the way keying on a mutated value once did (see #256).
+    // of the visible rows, scroll it into view (aligned to the top). Scrolls by the
+    // node's packed row (#305) - the LazyColumn's item index is a packed row, not a list
+    // index, so the row the node actually sits in is what must be brought into view.
+    // Keyed on the selected sha alone - the effect only scrolls, never mutates the
+    // selection, so it can't relaunch itself the way keying on a mutated value once did
+    // (see #256).
     val selectedSha = MapState.selectedNodeSha.value
     LaunchedEffect(selectedSha) {
         if (selectedSha == null) return@LaunchedEffect
-        val index = commits.indexOfFirst { it.sha == selectedSha }
-        if (index < 0) return@LaunchedEffect
-        val isVisible = lazyListState.layoutInfo.visibleItemsInfo.any { it.index == index }
-        if (!isVisible) lazyListState.animateScrollToItem(index)
+        val row = MapState.rowBySha[selectedSha] ?: return@LaunchedEffect
+        val isVisible = lazyListState.layoutInfo.visibleItemsInfo.any { it.index == row }
+        if (!isVisible) lazyListState.animateScrollToItem(row)
     }
 
     // shouldLoadMore() is true before anything has loaded, so this effect also covers
@@ -124,7 +126,9 @@ private fun Map() {
     // Recomputed only when commits/lanesBySha themselves change (i.e. on page load),
     // not on every scroll frame - the Canvas below reads lazyListState directly during
     // its own draw phase, so scrolling never triggers recomposition of this list.
-    val connectors by remember { derivedStateOf { MapConnectors.compute(commits, MapState.lanesBySha) } }
+    val connectors by remember {
+        derivedStateOf { MapConnectors.compute(commits, MapState.lanesBySha, MapState.rowBySha) }
+    }
 
     // The branch-tip nodes pinned to the top row of the grid (#291), each in the lane its
     // commit occupies below, so the lanes visibly start at the top and cascade into the
@@ -137,6 +141,20 @@ private fun Map() {
     // Canvas can look a tip's row up without rebuilding this map every draw.
     val indexBySha by remember {
         derivedStateOf { commits.withIndex().associate { (index, commit) -> commit.sha to index } }
+    }
+
+    // The commits sitting on each packed row (#305), indexed by row, so the LazyColumn
+    // can lay one item per row and draw every lane's node for that row inside it. Each
+    // lane packs tight to the top, so the longest lane fills rows 0..rowCount-1 with no
+    // gaps - the list has exactly MapState.rowCount items.
+    val commitsByRow by remember {
+        derivedStateOf {
+            val rows = List(MapState.rowCount) { mutableListOf<CommitGraphNode>() }
+            commits.forEach { commit ->
+                MapState.rowBySha[commit.sha]?.let { row -> rows[row].add(commit) }
+            }
+            rows
+        }
     }
 
     Column(modifier = Modifier.fillMaxSize().background(Colors.DarkGrayBackground)) {
@@ -155,24 +173,34 @@ private fun Map() {
             // commit row's own draw bounds are clipped to that row, so a diagonal line
             // reaching into a neighbouring row/lane can only be drawn here, not per-node.
             Canvas(modifier = Modifier.fillMaxSize()) {
-                drawConnectors(connectors, tipNodes, commits, indexBySha, lazyListState, dimensions)
+                drawConnectors(connectors, tipNodes, commits, indexBySha, MapState.rowBySha, lazyListState, dimensions)
             }
 
             LazyColumn(
                 state = lazyListState,
                 modifier = Modifier.fillMaxSize(),
             ) {
-                items(commits.size, key = { commits[it].sha }) { index ->
-                    val commit = commits[index]
-                    val lane = MapState.lanesBySha[commit.sha] ?: 0
+                // One item per packed row (#305): every lane that has a commit on this
+                // row draws its node here, offset into its own lane. The item index is
+                // the packed row, so the LazyColumn's scroll and the connector Canvas
+                // (which measures off firstVisibleItemIndex) share one row coordinate
+                // frame - a node never drifts away from the lines that reach it.
+                items(commitsByRow.size, key = { it }) { row ->
+                    Box(modifier = Modifier.fillMaxWidth().height(dimensions.rowHeight.dp)) {
+                        commitsByRow[row].forEach { commit ->
+                            val lane = MapState.lanesBySha[commit.sha] ?: 0
 
-                    CommitNode(
-                        commit = commit,
-                        isSelected = MapState.selectedNodeSha.value == commit.sha,
-                        onClick = { MapState.toggleSelectedNode(commit.sha) },
-                        dimensions = dimensions,
-                        modifier = Modifier.offset(x = dimensions.laneWidth.dp * lane).width(dimensions.laneWidth.dp),
-                    )
+                            CommitNode(
+                                commit = commit,
+                                isSelected = MapState.selectedNodeSha.value == commit.sha,
+                                onClick = { MapState.toggleSelectedNode(commit.sha) },
+                                dimensions = dimensions,
+                                modifier = Modifier
+                                    .offset(x = dimensions.laneWidth.dp * lane)
+                                    .width(dimensions.laneWidth.dp),
+                            )
+                        }
+                    }
                 }
             }
 
@@ -242,6 +270,7 @@ private fun DrawScope.drawConnectors(
     tipNodes: List<BranchTipNode>,
     commits: List<CommitGraphNode>,
     indexBySha: Map<String, Int>,
+    rowBySha: Map<String, Int>,
     lazyListState: LazyListState,
     dimensions: MapDimensions,
 ) {
@@ -254,7 +283,10 @@ private fun DrawScope.drawConnectors(
     val firstIndex = lazyListState.firstVisibleItemIndex
     val firstOffset = lazyListState.firstVisibleItemScrollOffset
 
-    fun rowCenterY(index: Int) = (index - firstIndex) * rowHeightPx - firstOffset + rowHeightPx / 2f
+    // Takes a packed row (#305). The LazyColumn lays one item per packed row, so
+    // firstIndex/firstOffset - the list's own scroll - are already in row space, and
+    // this lands a connector exactly on the node drawn in that row.
+    fun rowCenterY(row: Int) = (row - firstIndex) * rowHeightPx - firstOffset + rowHeightPx / 2f
     fun laneCenterX(lane: Int) = gutterXPx + lane * laneWidthPx
 
     val visibleTop = -rowHeightPx
@@ -275,8 +307,8 @@ private fun DrawScope.drawConnectors(
     }
 
     connectors.forEach { connector ->
-        val childY = rowCenterY(connector.childIndex)
-        val parentY = rowCenterY(connector.parentIndex)
+        val childY = rowCenterY(connector.childRow)
+        val parentY = rowCenterY(connector.parentRow)
         if (childY < visibleTop && parentY < visibleTop) return@forEach
         if (childY > visibleBottom && parentY > visibleBottom) return@forEach
 
@@ -299,12 +331,12 @@ private fun DrawScope.drawConnectors(
     val topY = rowHeightPx / 2f
     tipNodes.forEach { tip ->
         val laneX = laneCenterX(tip.lane)
-        val tipIndex = indexBySha[tip.sha]
-        val commit = tipIndex?.let { commits[it] }
+        val commit = indexBySha[tip.sha]?.let { commits[it] }
         val color = commit?.let(::nodeColor) ?: Colors.FileAdded
+        val tipRow = rowBySha[tip.sha]
 
-        if (tipIndex != null) {
-            val commitY = rowCenterY(tipIndex)
+        if (tipRow != null) {
+            val commitY = rowCenterY(tipRow)
             if (commitY > topY) {
                 drawConnector(laneX, topY, laneX, commitY, Colors.LightGrayText)
             }
@@ -492,6 +524,9 @@ private fun SelectedCommitCard(
 
     val commit = commits[index]
     val lane = MapState.lanesBySha[selectedSha] ?: 0
+    // The card tracks the node at its packed row (#305), the same row the node was
+    // lifted to, so it floats over the node rather than its vacated list slot.
+    val row = MapState.rowBySha[selectedSha] ?: index
 
     Box(
         modifier = Modifier
@@ -501,7 +536,7 @@ private fun SelectedCommitCard(
             // phase (see the derivedState note in Map()).
             .offset {
                 val placement = CommitCardPlacement.place(
-                    selectedIndex = index,
+                    selectedIndex = row,
                     lane = lane,
                     firstVisibleIndex = lazyListState.firstVisibleItemIndex,
                     firstVisibleOffset = lazyListState.firstVisibleItemScrollOffset.toDp().value,

--- a/src/test/kotlin/com/codymikol/services/LanePackerSpec.kt
+++ b/src/test/kotlin/com/codymikol/services/LanePackerSpec.kt
@@ -1,0 +1,60 @@
+package com.codymikol.services
+
+import com.codymikol.data.map.CommitGraphNode
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.util.Date
+
+private fun node(sha: String, vararg parents: String) = CommitGraphNode(
+    sha = sha,
+    shortSha = sha.take(7),
+    shortMessage = "message $sha",
+    authorName = "Author",
+    authorEmail = "author@example.com",
+    date = Date(0),
+    parentShas = parents.toList(),
+)
+
+class LanePackerSpec : DescribeSpec({
+
+    describe("LanePacker") {
+
+        describe("pack") {
+
+            it("should pack a linear single-lane history down consecutive rows") {
+                val commits = listOf(node("C", "B"), node("B", "A"), node("A"))
+                val lanesBySha = mapOf("C" to 0, "B" to 0, "A" to 0)
+
+                val rows = LanePacker.pack(commits, lanesBySha)
+
+                rows shouldBe mapOf("C" to 0, "B" to 1, "A" to 2)
+            }
+
+            it("should pack each lane tight to the top independently of list order") {
+                // side1 sits between two lane-0 commits in the list, yet it is the
+                // only commit in lane 1 so it packs to row 0 - its lane's top - not
+                // to its global position in the list.
+                val commits = listOf(
+                    node("M", "main1", "side1"),
+                    node("side1", "Base"),
+                    node("main1", "Base"),
+                    node("Base"),
+                )
+                val lanesBySha = mapOf("M" to 0, "side1" to 1, "main1" to 0, "Base" to 0)
+
+                val rows = LanePacker.pack(commits, lanesBySha)
+
+                rows shouldBe mapOf("M" to 0, "side1" to 0, "main1" to 1, "Base" to 2)
+            }
+
+            it("should skip a commit that has no lane assigned yet") {
+                val commits = listOf(node("C", "B"), node("B", "A"))
+                val lanesBySha = mapOf("C" to 0)
+
+                val rows = LanePacker.pack(commits, lanesBySha)
+
+                rows shouldBe mapOf("C" to 0)
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/codymikol/services/MapConnectorsSpec.kt
+++ b/src/test/kotlin/com/codymikol/services/MapConnectorsSpec.kt
@@ -25,44 +25,50 @@ class MapConnectorsSpec : DescribeSpec({
             it("should connect a linear stretch of commits with same-lane connectors") {
                 val commits = listOf(node("C", "B"), node("B", "A"), node("A"))
                 val lanesBySha = mapOf("C" to 0, "B" to 0, "A" to 0)
+                val rowsBySha = mapOf("C" to 0, "B" to 1, "A" to 2)
 
-                val connectors = MapConnectors.compute(commits, lanesBySha)
+                val connectors = MapConnectors.compute(commits, lanesBySha, rowsBySha)
 
                 connectors shouldBe listOf(
-                    MapConnector(childIndex = 0, childLane = 0, parentIndex = 1, parentLane = 0),
-                    MapConnector(childIndex = 1, childLane = 0, parentIndex = 2, parentLane = 0),
+                    MapConnector(childRow = 0, childLane = 0, parentRow = 1, parentLane = 0),
+                    MapConnector(childRow = 1, childLane = 0, parentRow = 2, parentLane = 0),
                 )
             }
 
             it("should connect a merge commit's extra parent to its own split-off lane") {
                 val commits = listOf(node("M", "main1", "side1"), node("main1"), node("side1"))
                 val lanesBySha = mapOf("M" to 0, "main1" to 0, "side1" to 1)
+                // side1 is alone in lane 1, so it packs to row 0 rather than its
+                // global list row of 2 - the connector reaches its packed position.
+                val rowsBySha = mapOf("M" to 0, "main1" to 1, "side1" to 0)
 
-                val connectors = MapConnectors.compute(commits, lanesBySha)
+                val connectors = MapConnectors.compute(commits, lanesBySha, rowsBySha)
 
                 connectors shouldBe listOf(
-                    MapConnector(childIndex = 0, childLane = 0, parentIndex = 1, parentLane = 0),
-                    MapConnector(childIndex = 0, childLane = 0, parentIndex = 2, parentLane = 1),
+                    MapConnector(childRow = 0, childLane = 0, parentRow = 1, parentLane = 0),
+                    MapConnector(childRow = 0, childLane = 0, parentRow = 0, parentLane = 1),
                 )
             }
 
             it("should converge two lanes onto the same ancestor rather than overlap silently") {
                 val commits = listOf(node("main1", "Base"), node("side1", "Base"), node("Base"))
                 val lanesBySha = mapOf("main1" to 0, "side1" to 1, "Base" to 0)
+                val rowsBySha = mapOf("main1" to 0, "side1" to 0, "Base" to 1)
 
-                val connectors = MapConnectors.compute(commits, lanesBySha)
+                val connectors = MapConnectors.compute(commits, lanesBySha, rowsBySha)
 
                 connectors shouldBe listOf(
-                    MapConnector(childIndex = 0, childLane = 0, parentIndex = 2, parentLane = 0),
-                    MapConnector(childIndex = 1, childLane = 1, parentIndex = 2, parentLane = 0),
+                    MapConnector(childRow = 0, childLane = 0, parentRow = 1, parentLane = 0),
+                    MapConnector(childRow = 0, childLane = 1, parentRow = 1, parentLane = 0),
                 )
             }
 
             it("should draw no connector for a parent pagination hasn't loaded yet") {
                 val commits = listOf(node("C", "NotLoaded"))
                 val lanesBySha = mapOf("C" to 0)
+                val rowsBySha = mapOf("C" to 0)
 
-                val connectors = MapConnectors.compute(commits, lanesBySha)
+                val connectors = MapConnectors.compute(commits, lanesBySha, rowsBySha)
 
                 connectors shouldBe emptyList()
             }

--- a/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
@@ -60,6 +60,12 @@ class MapStateSpec : DescribeSpec({
                 MapState.commits.map { MapState.lanesBySha[it.sha] } shouldBe listOf(0, 0, 0, 0)
             }
 
+            it("should pack every commit down consecutive rows of its lane (#305)") {
+                MapState.loadMore()
+
+                MapState.commits.map { MapState.rowBySha[it.sha] } shouldBe listOf(0, 1, 2, 3)
+            }
+
             it("should clear loaded state on reset") {
                 MapState.loadMore()
 
@@ -67,6 +73,7 @@ class MapStateSpec : DescribeSpec({
 
                 MapState.commits.isEmpty() shouldBe true
                 MapState.lanesBySha.isEmpty() shouldBe true
+                MapState.rowBySha.isEmpty() shouldBe true
                 MapState.hasMore shouldBe true
             }
         }
@@ -125,6 +132,14 @@ class MapStateSpec : DescribeSpec({
                 mainlineLanes.toSet() shouldBe setOf(0)
                 sideLane shouldBe 1
             }
+
+            it("should pack the lone side-branch commit to the top of its own lane (#305)") {
+                MapState.loadMore()
+
+                val featureSha = MapState.commits.single { it.shortMessage == "feature work" }.sha
+
+                MapState.rowBySha[featureSha] shouldBe 0
+            }
         }
 
         describe("shouldLoadMore") {
@@ -162,6 +177,22 @@ class MapStateSpec : DescribeSpec({
                 MapState.reset()
 
                 MapState.shouldLoadMore(0) shouldBe true
+            }
+
+            it("should page off packed rows, not raw commit count, when lanes diverge (#305)") {
+                // 30 commits packed two-abreast fill only 15 rows, so the map bottom
+                // is row 14 - a near-bottom row must trigger paging even though it is
+                // far from commits.size.
+                MapState.reset()
+                MapState.commits.addAll(dummyCommits(30))
+                MapState.commits.forEachIndexed { i, c ->
+                    MapState.lanesBySha[c.sha] = i % 2
+                    MapState.rowBySha[c.sha] = i / 2
+                }
+
+                MapState.rowCount shouldBe 15
+                MapState.shouldLoadMore(12) shouldBe true
+                MapState.shouldLoadMore(9) shouldBe false
             }
         }
 


### PR DESCRIPTION
Closes #305

## What changed

The map view no longer positions commit nodes at their global row in the
merged reverse-topological walk. Each **lane now packs its own commits tight
to the top of the vertical plane** (row = index within its lane), and
connectors reach across lanes to show which node a commit forks off of.

- `LanePacker` (new) computes each commit's packed row within its lane.
- `MapState` repacks `rowBySha` from `LanePacker` on every page load, clears it
  on reset, and exposes `rowCount` (the longest lane) so paging measures the
  packed height rather than the raw commit count.
- `MapConnector`'s endpoints become `childRow`/`parentRow`; `MapConnectors`
  reads `rowBySha`, so a connector lands on the packed position of the node it
  forks off of.
- `MapView` lays **one LazyColumn item per packed row** and draws every lane's
  node for that row inside it. The list's scroll index, the connector Canvas,
  the branch-tip drops, the selected card and keyboard scroll-into-view all
  share one packed-row coordinate frame, so nodes never drift away from the
  lines that reach them and there is no dead scroll space.

## Tests

- `LanePackerSpec` (new), updated `MapConnectorsSpec` (packed-row endpoints),
  and `MapStateSpec` (`rowBySha` packing, clear-on-reset, and row-space paging).
- Full suite green (428).

## Reviewer follow-up (out of scope for #305)

Keyboard `selectAdjacentNode` (#295) still steps through the commit **list**
order rather than the new packed-row layout, so arrow keys reach every node but
no longer always move to the visually adjacent one. Selection and
scroll-into-view remain correct; realigning keyboard navigation to packed-row
space is a follow-up on the #295 surface with its own test updates.

## Rendering note

Gradle/tests were run via a chroot nix store in the agent container (no JDK on
PATH); CI runs the canonical `nix flake check`.