### PR TITLE
feat(map): print-to-console button for debug menu values

### DIFF
--- a/src/main/kotlin/com/codymikol/data/map/MapDimensions.kt
+++ b/src/main/kotlin/com/codymikol/data/map/MapDimensions.kt
@@ -41,6 +41,22 @@ data class MapDimensions(
     )
 
     companion object {
+        /**
+         * Renders a slider value the way the debug menu shows it: at most two decimals,
+         * dropping a trailing ".0" so whole numbers read as plain integers.
+         */
+        fun format(value: Float): String {
+            val rounded = Math.round(value * 100f) / 100f
+            return if (rounded % 1f == 0f) rounded.toInt().toString() else rounded.toString()
+        }
+
+        /**
+         * A newline-separated dump of every debug key and its current value, in slider
+         * order, for the debug menu's "print to console" button (#309).
+         */
+        fun summarize(dimensions: MapDimensions): String =
+            sliders.joinToString("\n") { "${it.label}: ${format(it.get(dimensions))}" }
+
         val sliders: List<Slider> = listOf(
             Slider("laneWidth", 60f, 320f, { it.laneWidth }, { d, v -> d.copy(laneWidth = v) }),
             Slider("nodeRadius", 2f, 16f, { it.nodeRadius }, { d, v -> d.copy(nodeRadius = v) }),

--- a/src/main/kotlin/com/codymikol/state/MapDebugState.kt
+++ b/src/main/kotlin/com/codymikol/state/MapDebugState.kt
@@ -23,6 +23,11 @@ object MapDebugState {
         dimensions.value = slider.set(dimensions.value, value)
     }
 
+    /** Dumps every current debug key and value to the console (#309), one per line. */
+    fun printToConsole() {
+        println(MapDimensions.summarize(dimensions.value))
+    }
+
     fun reset() {
         dimensions.value = MapDimensions()
         isOpen.value = false

--- a/src/main/kotlin/com/codymikol/views/MapDebugMenu.kt
+++ b/src/main/kotlin/com/codymikol/views/MapDebugMenu.kt
@@ -7,9 +7,12 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Slider
 import androidx.compose.material.SliderDefaults
@@ -59,7 +62,7 @@ fun MapDebugMenu(modifier: Modifier = Modifier) {
                 val value = slider.get(dimensions)
 
                 Text(
-                    text = "${slider.label}: ${formatValue(value)}",
+                    text = "${slider.label}: ${MapDimensions.format(value)}",
                     color = Colors.LightGrayText,
                     fontSize = 10.sp,
                 )
@@ -75,10 +78,17 @@ fun MapDebugMenu(modifier: Modifier = Modifier) {
                 )
             }
         }
-    }
-}
 
-private fun formatValue(value: Float): String {
-    val rounded = Math.round(value * 100f) / 100f
-    return if (rounded % 1f == 0f) rounded.toInt().toString() else rounded.toString()
+        Button(
+            onClick = { MapDebugState.printToConsole() },
+            modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+            colors = ButtonDefaults.buttonColors(backgroundColor = Colors.FileAdded),
+        ) {
+            Text(
+                text = "Print to console",
+                color = Color.White,
+                fontSize = 11.sp,
+            )
+        }
+    }
 }

--- a/src/test/kotlin/com/codymikol/data/map/MapDimensionsSpec.kt
+++ b/src/test/kotlin/com/codymikol/data/map/MapDimensionsSpec.kt
@@ -1,0 +1,27 @@
+package com.codymikol.data.map
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+class MapDimensionsSpec : DescribeSpec({
+
+    describe("MapDimensions.summarize") {
+
+        it("lists every debug slider key with its current value") {
+            val summary = MapDimensions.summarize(MapDimensions())
+
+            val lines = summary.lines()
+            lines.size shouldBe MapDimensions.sliders.size
+            MapDimensions.sliders.forEachIndexed { index, slider ->
+                lines[index] shouldBe "${slider.label}: ${MapDimensions.format(slider.get(MapDimensions()))}"
+            }
+        }
+
+        it("reflects an adjusted value in the summary line") {
+            val tuned = MapDimensions().copy(mainlineGap = 40f)
+
+            MapDimensions.summarize(tuned) shouldContain "mainlineGap: 40"
+        }
+    }
+})

--- a/src/test/kotlin/com/codymikol/state/MapDebugStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/MapDebugStateSpec.kt
@@ -36,6 +36,23 @@ class MapDebugStateSpec : DescribeSpec({
                 MapDimensions()
         }
 
+        it("prints every current debug value to the console") {
+            val slider = MapDimensions.sliders.first { it.label == "forkCurveTension" }
+            MapDebugState.set(slider, 0.5f)
+
+            val original = System.out
+            val captured = java.io.ByteArrayOutputStream()
+            System.setOut(java.io.PrintStream(captured, true))
+            try {
+                MapDebugState.printToConsole()
+            } finally {
+                System.setOut(original)
+            }
+
+            captured.toString().trimEnd() shouldBe
+                MapDimensions.summarize(MapDebugState.dimensions.value)
+        }
+
         it("resets the dimensions back to their defaults") {
             val slider = MapDimensions.sliders.first { it.label == "laneWidth" }
             MapDebugState.set(slider, 300f)


### PR DESCRIPTION
Closes #309

## What

- Adds a **Print to console** button to the map debug menu (ctrl+shift+d)
  that dumps every debug key and its current value, one per line.
- Adds `MapDimensions.summarize()` (the dump) and `MapDimensions.format()`
  (the shared value formatter), and `MapDebugState.printToConsole()` which
  prints the summary.
- The map view's slider labels now reuse `MapDimensions.format` instead of
  the menu's private copy.

## Bezier constants

The issue also asks that all bezier-curve styling constants live in the
debug menu. These already exist as sliders from #291 —
`connectorStrokeWidth`, `mainlineGap`, and `forkCurveTension` — and cover
every tunable in the bezier drawing (`ConnectorGeometry`/`MapView`). No new
constants were needed; connector colors are chosen per connector type and
are not float-tunable via a slider.

## Tests

- `MapDimensionsSpec`: `summarize` lists every slider key with its formatted
  value, and reflects adjusted values.
- `MapDebugStateSpec`: `printToConsole` captured-stdout matches the summary.
- Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)