### PR TITLE
fix(map): represent every branch as its own lane

### DIFF
--- a/src/main/kotlin/com/codymikol/services/BranchTipNodes.kt
+++ b/src/main/kotlin/com/codymikol/services/BranchTipNodes.kt
@@ -5,18 +5,15 @@ import com.codymikol.data.map.BranchTipNode
 /**
  * Places branch-tip nodes across the top row of the map (see issue #291). Each ordered
  * tip is pinned to the lane its commit already occupies in the graph, so the top nodes
- * line up with the lanes cascading down into the mainline. Tips whose commit pagination
- * hasn't loaded yet have no lane and are skipped; if two tips resolve to the same lane
- * only the first (mainline-priority) one is kept so a lane never gets two top nodes.
+ * line up with the lanes cascading down into the mainline. Every branch reserves its own
+ * lane (see issue #315), so distinct tips never collide - one node is placed per branch.
+ * Tips whose commit pagination hasn't loaded yet have no lane and are skipped.
  */
 object BranchTipNodes {
 
-    fun place(tips: List<OrderedBranchTip>, lanesBySha: Map<String, Int>): List<BranchTipNode> {
-        val seenLanes = mutableSetOf<Int>()
-        return tips.mapNotNull { tip ->
+    fun place(tips: List<OrderedBranchTip>, lanesBySha: Map<String, Int>): List<BranchTipNode> =
+        tips.mapNotNull { tip ->
             val lane = lanesBySha[tip.sha] ?: return@mapNotNull null
-            if (!seenLanes.add(lane)) return@mapNotNull null
             BranchTipNode(tip.sha, lane)
         }
-    }
 }

--- a/src/main/kotlin/com/codymikol/services/BranchTitles.kt
+++ b/src/main/kotlin/com/codymikol/services/BranchTitles.kt
@@ -5,18 +5,15 @@ import com.codymikol.data.map.BranchTitle
 /**
  * Places branch titles above the lanes of the map (see issue #307). Mirrors
  * [BranchTipNodes]: each ordered tip is pinned to the lane its commit already occupies,
- * so a title's first character sits directly above its node. A tip whose commit has not
- * paged in yet has no lane and is skipped; when two tips resolve to the same lane only
- * the first (mainline-priority) one keeps the lane so it never shows two titles.
+ * so a title's first character sits directly above its node. Every branch reserves its
+ * own lane (see issue #315), so distinct tips never collide - one title is placed per
+ * branch. A tip whose commit has not paged in yet has no lane and is skipped.
  */
 object BranchTitles {
 
-    fun place(tips: List<OrderedBranchTip>, lanesBySha: Map<String, Int>): List<BranchTitle> {
-        val seenLanes = mutableSetOf<Int>()
-        return tips.mapNotNull { tip ->
+    fun place(tips: List<OrderedBranchTip>, lanesBySha: Map<String, Int>): List<BranchTitle> =
+        tips.mapNotNull { tip ->
             val lane = lanesBySha[tip.sha] ?: return@mapNotNull null
-            if (!seenLanes.add(lane)) return@mapNotNull null
             BranchTitle(lane, tip.branchNames)
         }
-    }
 }

--- a/src/main/kotlin/com/codymikol/services/LaneAssigner.kt
+++ b/src/main/kotlin/com/codymikol/services/LaneAssigner.kt
@@ -4,16 +4,24 @@ import com.codymikol.data.map.CommitGraphNode
 
 /**
  * Assigns each commit in a newest-to-oldest (reverse topological) walk to a
- * lane/column number, GitUp-style: a lane tracks an ancestry lineage, not a
- * branch. Stateful and streaming so callers can feed it paginated batches -
- * see issue #269 - and get the same lane numbers as a single call over the
- * whole history.
+ * lane/column number, GitUp-style: a lane tracks an ancestry lineage. Stateful
+ * and streaming so callers can feed it paginated batches - see issue #269 - and
+ * get the same lane numbers as a single call over the whole history.
+ *
+ * [tipLanes] pins a branch tip's commit to a reserved lane so every branch is
+ * represented by its own lane even when one tip is an ancestor of another (see
+ * issue #315): a tip whose commit would otherwise inherit a descendant's lineage
+ * lane is forced onto its own reserved column instead, so no two branch tips
+ * ever collapse onto the same lane. [allocateLane] counts above the reserved range,
+ * so an unrelated lineage can't squat on a tip's column before the walk reaches that
+ * tip - a reserved lane only rejoins the free pool once its own tip has been placed.
+ * An empty map restores the plain lineage behaviour.
  */
-class LaneAssigner {
+class LaneAssigner(private val tipLanes: Map<String, Int> = emptyMap()) {
 
     private val laneAwaitingSha = mutableMapOf<String, MutableList<Int>>()
     private val freeLanes = sortedSetOf<Int>()
-    private var laneCount = 0
+    private var laneCount = tipLanes.values.maxOrNull()?.plus(1) ?: 0
 
     /**
      * Assigns lanes to [commits], which must already be in reverse
@@ -29,7 +37,10 @@ class LaneAssigner {
      */
     fun assign(commit: CommitGraphNode): Int {
         val waitingLanes = laneAwaitingSha.remove(commit.sha)
-        val lane = waitingLanes?.min() ?: allocateLane()
+        // A branch tip always claims its reserved lane, overriding any lineage
+        // lane a descendant was awaiting it on, so every branch keeps its own
+        // column (#315); those orphaned awaiting lanes fall back into the pool.
+        val lane = tipLanes[commit.sha] ?: waitingLanes?.min() ?: allocateLane()
         waitingLanes?.filter { it != lane }?.forEach { freeLanes.add(it) }
 
         val parents = commit.parentShas

--- a/src/main/kotlin/com/codymikol/state/MapState.kt
+++ b/src/main/kotlin/com/codymikol/state/MapState.kt
@@ -25,7 +25,7 @@ object MapState {
     const val LOAD_MORE_THRESHOLD = 5
 
     private var walker: CommitHistoryWalker? = null
-    private var laneAssigner = LaneAssigner()
+    private var laneAssigner: LaneAssigner? = null
 
     // The git directory whose history is currently loaded, or null before anything has
     // loaded. Lets resetForDirectory() tell a genuine project switch (which must clear
@@ -176,9 +176,13 @@ object MapState {
         if (!hasMore) return
 
         val walker = walker ?: CommitHistoryWalker(GitDownState.git.value, branches.value).also { walker = it }
+        // Reserve one lane per ordered branch tip (default first), so every branch
+        // keeps its own column even when one tip is an ancestor of another (#315).
+        // Built lazily alongside the walker so orderedBranchTips has resolved.
+        val assigner = laneAssigner ?: LaneAssigner(tipLanes()).also { laneAssigner = it }
         val page = walker.nextPage(PAGE_SIZE)
 
-        page.forEach { lanesBySha[it.sha] = laneAssigner.assign(it) }
+        page.forEach { lanesBySha[it.sha] = assigner.assign(it) }
         commits.addAll(page)
 
         // Repack from the full loaded list so a page's commits stack onto the rows
@@ -188,6 +192,15 @@ object MapState {
 
         hasMore = walker.hasMore
     }
+
+    /**
+     * Each ordered branch tip's reserved lane, keyed by its commit sha (#315): the
+     * tip's index in [orderedBranchTips] is its column, so lane 0 is the default
+     * branch and each side branch follows left-to-right. Feeds [LaneAssigner] so a
+     * tip never collapses onto a descendant tip's lane.
+     */
+    private fun tipLanes(): Map<String, Int> =
+        orderedBranchTips.value.withIndex().associate { (index, tip) -> tip.sha to index }
 
     /**
      * lastVisibleIndex must be the last (bottom-most) visible row, not the first -
@@ -203,7 +216,7 @@ object MapState {
     fun reset() {
         walker?.close()
         walker = null
-        laneAssigner = LaneAssigner()
+        laneAssigner = null
         commits.clear()
         lanesBySha.clear()
         rowBySha.clear()

--- a/src/test/kotlin/com/codymikol/services/BranchTipNodesSpec.kt
+++ b/src/test/kotlin/com/codymikol/services/BranchTipNodesSpec.kt
@@ -34,18 +34,6 @@ class BranchTipNodesSpec : DescribeSpec({
                     BranchTipNode("A", 0),
                 )
             }
-
-            it("keeps only the first tip when two share a lane, preserving mainline priority") {
-                val tips = listOf(
-                    OrderedBranchTip("A", listOf("main")),
-                    OrderedBranchTip("B", listOf("foo")),
-                )
-                val lanesBySha = mapOf("A" to 0, "B" to 0)
-
-                BranchTipNodes.place(tips, lanesBySha) shouldBe listOf(
-                    BranchTipNode("A", 0),
-                )
-            }
         }
     }
 })

--- a/src/test/kotlin/com/codymikol/services/BranchTitlesSpec.kt
+++ b/src/test/kotlin/com/codymikol/services/BranchTitlesSpec.kt
@@ -43,18 +43,6 @@ class BranchTitlesSpec : DescribeSpec({
                     BranchTitle(0, listOf("main")),
                 )
             }
-
-            it("keeps only the first tip when two share a lane, preserving mainline priority") {
-                val tips = listOf(
-                    OrderedBranchTip("A", listOf("main")),
-                    OrderedBranchTip("B", listOf("foo")),
-                )
-                val lanesBySha = mapOf("A" to 0, "B" to 0)
-
-                BranchTitles.place(tips, lanesBySha) shouldBe listOf(
-                    BranchTitle(0, listOf("main")),
-                )
-            }
         }
     }
 })

--- a/src/test/kotlin/com/codymikol/services/LaneAssignerSpec.kt
+++ b/src/test/kotlin/com/codymikol/services/LaneAssignerSpec.kt
@@ -110,6 +110,22 @@ class LaneAssignerSpec : DescribeSpec({
                 lanes shouldBe listOf(0, 1, 0, 1, 0)
             }
 
+            it("should give each branch tip its own lane even when one tip is an ancestor of another") {
+                // main -> C -> B (old's tip) -> A; old points at B, an ancestor
+                // of main's tip C. Without a per-tip reservation both tips
+                // collapse onto lane 0 and old vanishes from the map (#315).
+                val assigner = LaneAssigner(tipLanes = mapOf("C" to 0, "B" to 1))
+                val commits = listOf(
+                    node("C", "B"),
+                    node("B", "A"),
+                    node("A"),
+                )
+
+                val lanes = assigner.assign(commits)
+
+                lanes shouldBe listOf(0, 1, 1)
+            }
+
             it("should assign identical lanes whether a page is walked in one call or split across two") {
                 val commits = listOf(
                     node("M", "main1", "side1"),
@@ -126,6 +142,26 @@ class LaneAssignerSpec : DescribeSpec({
                     assigner.assign(commits.subList(0, 3)) + assigner.assign(commits.subList(3, commits.size))
                 }
 
+                paged shouldBe oneCall
+            }
+
+            it("should reserve a tip's lane across a page split so a later-paged ancestor tip still gets it") {
+                // old's tip B pages in on the second call, after main's tip C on
+                // the first; its reserved lane must survive the split unchanged.
+                val tipLanes = mapOf("C" to 0, "B" to 1)
+                val commits = listOf(
+                    node("C", "B"),
+                    node("B", "A"),
+                    node("A"),
+                )
+
+                val oneCall = LaneAssigner(tipLanes).assign(commits)
+
+                val paged = LaneAssigner(tipLanes).let { assigner ->
+                    assigner.assign(commits.subList(0, 1)) + assigner.assign(commits.subList(1, commits.size))
+                }
+
+                oneCall shouldBe listOf(0, 1, 1)
                 paged shouldBe oneCall
             }
         }

--- a/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/MapStateSpec.kt
@@ -2,10 +2,12 @@ package com.codymikol.state
 
 import com.codymikol.data.map.CommitGraphNode
 import com.codymikol.repository.TestRepository.Companion.createTestRepository
+import com.codymikol.services.BranchTipNodes
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import java.util.Date
 
 class MapStateSpec : DescribeSpec({
@@ -98,6 +100,51 @@ class MapStateSpec : DescribeSpec({
                 MapState.loadMore()
 
                 MapState.commits.map { it.shortMessage } shouldBe listOf("commit 2", "commit 1")
+            }
+        }
+
+        describe("two branches where one tip is an ancestor of the other") {
+
+            // main -> commit 3; "old" is created at commit 2 and never advances, so
+            // old's tip is a plain ancestor of main's tip. Every branch must still
+            // get its own lane rather than collapsing onto main's (#315).
+            autoClose(
+                createTestRepository()
+                    .addFile("a.txt", "a")
+                    .stageAll()
+                    .commitAll("commit 1")
+                    .appendToFile("a.txt", "b")
+                    .stageAll()
+                    .commitAll("commit 2")
+                    .createBranch("old")
+                    .appendToFile("a.txt", "c")
+                    .stageAll()
+                    .commitAll("commit 3")
+                    .transferIntoGitDownState()
+            )
+
+            it("gives each branch tip its own lane") {
+                MapState.branches.value shouldHaveSize 2
+
+                MapState.loadMore()
+
+                val tipLanes = MapState.branches.value
+                    .map { MapState.lanesBySha[it.objectId.name] }
+
+                tipLanes.forEach { it shouldNotBe null }
+                tipLanes.toSet() shouldHaveSize 2
+            }
+
+            it("places a top node for every branch, dropping none") {
+                MapState.loadMore()
+
+                val nodes = BranchTipNodes.place(
+                    MapState.orderedBranchTips.value,
+                    MapState.lanesBySha,
+                )
+
+                nodes shouldHaveSize 2
+                nodes.map { it.lane }.toSet() shouldHaveSize 2
             }
         }
 


### PR DESCRIPTION
## Problem

The map view stopped representing all branches as lanes: a branch whose
tip commit is an ancestor of another branch's tip (any stale/merged/behind
branch relative to the default) collapsed onto the descendant's lane and
was silently dropped, so only a subset of branches showed and some
overlapped.

Root cause: the lane model tracks one lane per *ancestry lineage*, not per
branch. When walking newest-first, an ancestor tip inherited its
descendant's lineage lane, and `BranchTipNodes`/`BranchTitles` then kept
only the first (mainline-priority) tip on any shared lane.

## Fix

- `LaneAssigner` now takes a `tipLanes` map and forces each branch-tip
  commit onto its own reserved lane, overriding any lineage lane a
  descendant awaited it on. Allocation counts above the reserved range so
  no unrelated lineage can squat on a tip's column before the walk reaches
  it. An empty map preserves the previous lineage behaviour.
- `MapState` builds `tipLanes` from `orderedBranchTips` (index = lane,
  default branch first) and constructs the assigner lazily beside the
  walker.
- `BranchTipNodes`/`BranchTitles` no longer dedupe by lane — with each tip
  on its own reserved lane the drop is unreachable dead code.

## Tests

- `LaneAssignerSpec`: tip-is-an-ancestor-of-another-tip gets distinct
  lanes, including across a page split.
- `MapStateSpec`: two branches where one tip is an ancestor of the other —
  each tip gets its own lane and every branch places a top node.
- Removed the specs that pinned the old collapse/drop behaviour.

Closes #315