### PR TITLE
fix(index): show partially-staged files in Index panel

### DIFF
--- a/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
+++ b/src/main/kotlin/com/codymikol/extensions/GitExtensions.kt
@@ -734,6 +734,7 @@ fun Git.scanForChanges() = try {
 
     GitDownState.removed.assignWhenDifferent(newStatus.removed)
     GitDownState.added.assignWhenDifferent(newStatus.added)
+    GitDownState.changed.assignWhenDifferent(newStatus.changed)
     GitDownState.missing.assignWhenDifferent(newStatus.missing)
     GitDownState.conflicting.assignWhenDifferent(newStatus.conflicting)
     GitDownState.modified.assignWhenDifferent(newStatus.modified)

--- a/src/main/kotlin/com/codymikol/state/state.kt
+++ b/src/main/kotlin/com/codymikol/state/state.kt
@@ -190,9 +190,7 @@ object GitDownState {
     }
 
     val indexFilesModified = derivedStateOf {
-        uncommittedChanges.value.filter {
-            !modified.value.contains(it) && !added.value.contains(it) && !missing.value.contains(it) && !removed.value.contains(it)
-        }
+        changed.value
             .map { Index.FileModified(Path.of(it)) }
             .toSet()
     }

--- a/src/test/kotlin/com/codymikol/state/GitDownStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/GitDownStateSpec.kt
@@ -401,6 +401,94 @@ class GitDownStateSpec : DescribeSpec({
 
             }
 
+            describe("Partially staging a mixed hunk of an existing file") {
+
+                autoClose(
+                    createTestRepository()
+                        .addFile("init.txt", "init")
+                        .stageAll()
+                        .commitAll("init")
+                        .addFile("foo.txt", "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl\n")
+                        .stageAll()
+                        .commitAll("base")
+                        .addFile("foo.txt", "a\nb\nc\nx\ny\nz\ng\nh\ni\nj\nk\nl\n")
+                        .transferIntoGitDownState()
+                )
+
+                val workingFileDelta = GitDownState.workingDirectory.value
+                    .first { it.getPath() == "foo.txt" }
+
+                GitDownState.selectedFiles.clear()
+                GitDownState.selectedFiles.add(workingFileDelta)
+
+                val workingNode = GitDownState.diffTree.value.fileDeltaNodes.single()
+                val workingLines = workingNode.hunkNodes.flatMap { it.lineNodes }
+
+                val removedLines = workingLines
+                    .filter { it.line.type == LineType.Removed }
+
+                check(removedLines.isNotEmpty()) { "Expected removed lines in working hunk" }
+
+                // Stage only the deletions, leaving the additions unstaged so the
+                // file still differs from both HEAD (staged change) and the
+                // working tree (unstaged change).
+                GitDownState.git.value.stageSelectedLines(removedLines)
+
+                it("should show the file in the index panel") {
+                    GitDownState.index.value
+                        .any { it.getPath() == "foo.txt" } shouldBe true
+                }
+
+                it("should still show the file in the working directory panel") {
+                    GitDownState.workingDirectory.value
+                        .any { it.getPath() == "foo.txt" } shouldBe true
+                }
+
+            }
+
+            describe("Partially staging only the additions of a mixed hunk") {
+
+                autoClose(
+                    createTestRepository()
+                        .addFile("init.txt", "init")
+                        .stageAll()
+                        .commitAll("init")
+                        .addFile("foo.txt", "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl\n")
+                        .stageAll()
+                        .commitAll("base")
+                        .addFile("foo.txt", "a\nb\nc\nx\ny\nz\ng\nh\ni\nj\nk\nl\n")
+                        .transferIntoGitDownState()
+                )
+
+                val workingFileDelta = GitDownState.workingDirectory.value
+                    .first { it.getPath() == "foo.txt" }
+
+                GitDownState.selectedFiles.clear()
+                GitDownState.selectedFiles.add(workingFileDelta)
+
+                val workingNode = GitDownState.diffTree.value.fileDeltaNodes.single()
+                val workingLines = workingNode.hunkNodes.flatMap { it.lineNodes }
+
+                val addedLines = workingLines
+                    .filter { it.line.type == LineType.Added }
+
+                check(addedLines.isNotEmpty()) { "Expected added lines in working hunk" }
+
+                // Stage only the additions, leaving the deletions unstaged.
+                GitDownState.git.value.stageSelectedLines(addedLines)
+
+                it("should show the file in the index panel") {
+                    GitDownState.index.value
+                        .any { it.getPath() == "foo.txt" } shouldBe true
+                }
+
+                it("should still show the file in the working directory panel") {
+                    GitDownState.workingDirectory.value
+                        .any { it.getPath() == "foo.txt" } shouldBe true
+                }
+
+            }
+
             describe("Staging two added lines from ten added lines") {
 
                 autoClose(


### PR DESCRIPTION
## Summary

Staging one side of a mixed add/delete hunk removed the line from the
diff view but showed nothing staged in the Index panel. The file
vanished from both index lists.

Root cause: `indexFilesModified` was derived with an exclusion
heuristic (`uncommittedChanges` minus `modified`/`added`/`missing`/
`removed`) that dropped any file still having unstaged working-tree
changes. Partial staging always leaves such residual changes, so the
file appeared in neither `indexFilesModified` nor the added/deleted
lists.

## Changes

- Populate `GitDownState.changed` (JGit `Status.getChanged()`,
  HEAD→index staged modifications) in `scanForChanges` — it was
  declared but never assigned (dead state).
- Derive `indexFilesModified` from `changed` instead of the exclusion
  heuristic, matching how `indexFilesAdded`/`indexFilesDeleted` use
  git's own staged sets.
- Add state-level tests asserting a file appears in the Index panel
  (and stays in the Working Directory panel) after partially staging
  either the deletions or the additions of a mixed hunk. Existing
  tests only asserted index-vs-HEAD diff content, bypassing the buggy
  derivation.

Closes #317