### PR TITLE
fix(state): guard repo-derived state on project close

### DIFF
--- a/src/main/kotlin/com/codymikol/state/state.kt
+++ b/src/main/kotlin/com/codymikol/state/state.kt
@@ -81,11 +81,15 @@ object GitDownState {
     }
 
     val commitCount = derivedStateOf {
-        git.value.getCurrentRefCommitCount()
+        if (isValidGitDirectory.value) git.value.getCurrentRefCommitCount() else 0
     }
 
     val stashes = derivedStateOf {
-        git.value.getStashes().map { StashListItem.make(repo.value, it) }
+        if (isValidGitDirectory.value) {
+            git.value.getStashes().map { StashListItem.make(repo.value, it) }
+        } else {
+            emptyList()
+        }
     }
 
     val selectedStash = mutableStateOf<StashListItem?>(null)
@@ -149,8 +153,13 @@ object GitDownState {
         (git.value.repository?.refDatabase?.refs?.getOrNull(0)?.isSymbolic?.not()) ?: false
     }
 
+    // Null while no valid repository is open. Closing a project clears
+    // gitDirectory, which flips isValidGitDirectory to false; without this guard
+    // the still-mounted GitDown subtree recomputes status against the now-bare
+    // repository during the close recompose and JGit throws NoWorkTreeException
+    // (see issue #319). The two index derivedStates below tolerate the null.
     val status = derivedStateOf {
-        git.value.status().call()
+        if (isValidGitDirectory.value) git.value.status().call() else null
     }
 
     val removed = mutableStateOf(emptySet<String>())
@@ -196,13 +205,13 @@ object GitDownState {
     }
 
     val indexFilesAdded = derivedStateOf {
-        status.value.added
+        status.value?.added.orEmpty()
             .map { Index.FileAdded(Path.of(it)) }
             .toSet()
     }
 
     val indexFilesDeleted = derivedStateOf {
-        status.value.removed
+        status.value?.removed.orEmpty()
             .map { Index.FileDeleted(Path.of(it)) }
             .toSet()
     }

--- a/src/test/kotlin/com/codymikol/state/GitDownStateSpec.kt
+++ b/src/test/kotlin/com/codymikol/state/GitDownStateSpec.kt
@@ -8,6 +8,7 @@ import com.codymikol.extensions.stageSelectedLines
 import com.codymikol.extensions.stageLinesForAddedFile
 import com.codymikol.repository.TestRepository.Companion.createTestRepository
 import com.codymikol.tabs.Tab
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
@@ -1291,6 +1292,18 @@ class GitDownStateSpec : DescribeSpec({
                     GitDownState.returnToProjectSelection()
 
                     GitDownState.isStashDialogOpen.value shouldBe false
+                }
+
+                it("should not throw when repo-dependent state recomputes after close (#319)") {
+                    GitDownState.returnToProjectSelection()
+
+                    shouldNotThrowAny {
+                        GitDownState.status.value
+                        GitDownState.commitCount.value
+                        GitDownState.stashes.value
+                        GitDownState.indexFilesAdded.value
+                        GitDownState.indexFilesDeleted.value
+                    }
                 }
 
             }


### PR DESCRIPTION
## Summary

Closing a repository intermittently crashed with `NoWorkTreeException`. When
a project is closed, `returnToProjectSelection()` clears `gitDirectory`, which
flips `isValidGitDirectory` to false and swaps the app back to the splash
screen. During that recompose frame the still-mounted `GitDown` subtree
re-read the `status` derivedState, which rebuilt a bare repository against an
empty git dir and threw `NoWorkTreeException` from `StatusCommand.call`.

## Change

- Short-circuit `status`, `commitCount`, and `stashes` when no valid git
  directory is open, mirroring the existing guards on `isValidGitDirectory`
  and `branchName`.
- `status` now yields `null` while closed; the two index derivedStates that
  read it (`indexFilesAdded`/`indexFilesDeleted`) tolerate that via `orEmpty`.
- Regression test in `GitDownStateSpec` asserts the repo-derived state reads
  (including the per-frame index derivedStates) do not throw after
  `returnToProjectSelection()`.

## Note

Local JDK/Gradle toolchain was unavailable in the run environment (read-only
nix store, no daemon, no baked JDK), so tests were not executed locally; CI is
relied on as the gate.

Closes #319